### PR TITLE
Change create method: use vmid by vmref

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -346,13 +346,12 @@ func (c *Client) ResizeQemuDisk(vmr *VmRef, disk string, moreSizeGB int) (exitSt
 	return
 }
 
-func (c *Client) CreateQemuDisk(vmr *VmRef, vmId int, diskName string, diskSize int, unit sizeunit.SizeUnit,
-	format string) error {
+func (c *Client) CreateQemuDisk(vmr *VmRef, diskName string, diskSize int, unit sizeunit.SizeUnit, format string) error {
 	reqBody := ParamsToBody(map[string]string{
 		"filename": diskName,
 		"size":     sizeunit.FormatToShortString(diskSize, unit),
 		"format":   format,
-		"vmid":     strconv.Itoa(vmId),
+		"vmid":     strconv.Itoa(vmr.vmId),
 	})
 	url := fmt.Sprintf("/nodes/%s/storage/local/content", vmr.node)
 	_, err := c.session.Post(url, nil, nil, &reqBody)


### PR DESCRIPTION
Sorry for this amount of pull request with little fixes
While pushing the create method, I didn't realize that vmref already contains a field called vmid