### PR TITLE
Fix an issue where next id already exists

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -497,6 +497,8 @@ func (c *Client) GetNextID(currentID int) (nextID int, err error) {
 			}
 		}
 		nextID, err = strconv.Atoi(data["data"].(string))
+	} else if strings.HasPrefix(err.Error(), "400 ") {
+		return c.GetNextID(currentID + 1)
 	}
 	return
 }


### PR DESCRIPTION
Hi,
i'm using your terraform-provider-proxmox and ran into a problem. When i wanted to create 6 qemu machines node1...node6, only two appeared in the Proxmox gui and terraform war running forever. The reason was:
The next free ID was 102
Only 102 and 103 were available, but proxmox-api-go requried that a whole range of 6 consecutive IDs were free.
I added a few debug logs to client.go and session.go and found out that in fact Proxmox returned a message {"errors":{"vmid":"VM 104 already exists"},"data":null}, which unfortunately got unhandled.
proxmox-api-go/proxmox/session.go Request->Do throws away the text so that it is not available in client.go::GetNextID. But at least the err object still contains the 400 http code. So i use this value to send another nextid request which then jumps beyond the 104 ID.

![proxmox-terraform](https://user-images.githubusercontent.com/198968/57184631-778bc100-6ebe-11e9-9d29-eee21ecc38f9.jpg)
