### PR TITLE
Changed agent type to mirror the type from the proxmox api.

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -26,7 +26,7 @@ type ConfigQemu struct {
 	Name         string      `json:"name"`
 	Description  string      `json:"desc"`
 	Onboot       bool        `json:"onboot"`
-	Agent        string      `json:"agent"`
+	Agent        int         `json:"agent"`
 	Memory       int         `json:"memory"`
 	QemuOs       string      `json:"os"`
 	QemuCores    int         `json:"cores"`
@@ -251,9 +251,10 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 	if _, isSet := vmConfig["onboot"]; isSet {
 		onboot = Itob(int(vmConfig["onboot"].(float64)))
 	}
-	agent := "1"
+
+	agent := 1.0
 	if _, isSet := vmConfig["agent"]; isSet {
-		agent = vmConfig["agent"].(string)
+		agent = vmConfig["agent"].(float64)
 	}
 	ostype := "other"
 	if _, isSet := vmConfig["ostype"]; isSet {
@@ -275,7 +276,7 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 		Name:         name,
 		Description:  strings.TrimSpace(description),
 		Onboot:       onboot,
-		Agent:        agent,
+		Agent:        int(agent),
 		QemuOs:       ostype,
 		Memory:       int(memory),
 		QemuCores:    int(cores),


### PR DESCRIPTION
The agent value from the api is received as an integer instead of an string. Therefore applying terraform changes fails when the agent was active within the base image.

Fixes https://github.com/Telmate/terraform-provider-proxmox/issues/46