### PR TITLE
Set nameserver when getting config from api

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -306,6 +306,9 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 	if _, isSet := vmConfig["searchdomain"]; isSet {
 		config.Searchdomain = vmConfig["searchdomain"].(string)
 	}
+	if _, isSet := vmConfig["nameserver"]; isSet {
+		config.Nameserver = vmConfig["nameserver"].(string)
+	}
 	if _, isSet := vmConfig["sshkeys"]; isSet {
 		config.Sshkeys, _ = url.PathUnescape(vmConfig["sshkeys"].(string))
 	}


### PR DESCRIPTION
Fixes the issue for me with terraform-provider-proxmox wanting to update the VMs on every pass.

https://github.com/Telmate/terraform-provider-proxmox/issues/58