### PR TITLE
fix(config): VM id cannot be lower than 100

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -451,7 +451,7 @@ func RemoveSshForwardUsernet(vmr *VmRef, client *Client) (err error) {
 func MaxVmId(client *Client) (max int, err error) {
 	resp, err := client.GetVmList()
 	vms := resp["data"].([]interface{})
-	max = 0
+	max = 100
 	for vmii := range vms {
 		vm := vms[vmii].(map[string]interface{})
 		vmid := int(vm["vmid"].(float64))


### PR DESCRIPTION
The first VM you can create in an empty cluster has the ID 100. This cause an issue for https://github.com/hashicorp/packer/issues/7692