### PR TITLE
Support CephRBD storage types

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -654,9 +654,9 @@ func (c ConfigQemu) CreateQemuDisksParams(
 
 		// Disk name.
 		var diskFile string
-		// Currently ZFS local, LVM, and Directory are considered.
+		// Currently ZFS local, LVM, Ceph RBD, and Directory are considered.
 		// Other formats are not verified, but could be added if they're needed.
-		rxStorageTypes := `(zfspool|lvm)`
+		rxStorageTypes := `(zfspool|lvm|rbd)`
 		storageType := diskConfMap["storage_type"].(string)
 		if matched, _ := regexp.MatchString(rxStorageTypes, storageType); matched {
 			diskFile = fmt.Sprintf("file=%v:vm-%v-disk-%v", diskConfMap["storage"], vmID, diskID)


### PR DESCRIPTION
### Intent
Support CephRBD storage type (trickle-down from failed Packer builds)

This resolves the following error, when defining `storage_type = rbd`

```
Build 'proxmox' errored: Error creating VM: 500 error with cfs lock 'storage-cephrbd': rbd create vm-1003-disk-0.<nil>' error: rbd: create error: (17) File exists, error status:  (params: map[agent:1 cores:2 cpu:host description:Packer ephemeral build VM ide2:cephfs:iso/CentOS-7-x86_64-Minimal-1810.iso,media=cdrom memory:2048 name:packer-5d0df07c-5681-bd69-2d4f-4d628f9cb264 net0:e1000=8E:E1:EF:F8:C9:05,bridge=vmbr0 onboot:false ostype:other sockets:1 virtio0:media=disk,size=30G,file=cephrbd:1003/vm-1003-disk-0.<nil> vmid:1003])
```