### PR TITLE
Handle error from MonitorCmd POST

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -275,6 +275,9 @@ func (c *Client) MonitorCmd(vmr *VmRef, command string) (monitorRes map[string]i
 	reqbody := ParamsToBody(map[string]interface{}{"command": command})
 	url := fmt.Sprintf("/nodes/%s/%s/%d/monitor", vmr.node, vmr.vmType, vmr.vmId)
 	resp, err := c.session.Post(url, nil, nil, &reqbody)
+	if err != nil {
+		return nil, err
+	}
 	monitorRes, err = ResponseJSON(resp)
 	return
 }


### PR DESCRIPTION
Errors returned from the `MonitorCmd` POST request aren't checked. This PR checks them and returns the error if one occurred. 