### PR TITLE
Support setting pool on VmRef to create VMs in resource pools

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -38,12 +38,17 @@ type Client struct {
 type VmRef struct {
 	vmId   int
 	node   string
+	pool   string
 	vmType string
 }
 
 func (vmr *VmRef) SetNode(node string) {
 	vmr.node = node
 	return
+}
+
+func (vmr *VmRef) SetPool(pool string) {
+	vmr.pool = pool
 }
 
 func (vmr *VmRef) SetVmType(vmType string) {

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -81,6 +81,9 @@ func (config ConfigQemu) CreateVm(vmr *VmRef, client *Client) (err error) {
 		"memory":      config.Memory,
 		"description": config.Description,
 	}
+	if vmr.pool != "" {
+		params["pool"] = vmr.pool
+	}
 
 	// Create disks config.
 	config.CreateQemuDisksParams(vmr.vmId, params, false)
@@ -138,6 +141,10 @@ func (config ConfigQemu) CloneVm(sourceVmr *VmRef, vmr *VmRef, client *Client) (
 		"storage": storage,
 		"full":    fullclone,
 	}
+	if vmr.pool != "" {
+		params["pool"] = vmr.pool
+	}
+
 	_, err = client.CloneQemuVm(sourceVmr, params)
 	if err != nil {
 		return


### PR DESCRIPTION
This PR adds some early support for creating VMs in resource pools. I'm not super happy with having to if-check it like this, but the func for Create and Clone don't have a similar signature (create takes the node name string, while clone takes the full vmref) to centralize it without breaking APIs.

Also, I'm not sure if there are more places we should add it to?