### PR TITLE
Add method to retrieve resource pool

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -64,6 +64,10 @@ func (vmr *VmRef) Node() string {
 	return vmr.node
 }
 
+func (vmr *VmRef) Pool() string {
+	return vmr.pool
+}
+
 func NewVmRef(vmId int) (vmr *VmRef) {
 	vmr = &VmRef{vmId: vmId, node: "", vmType: ""}
 	return


### PR DESCRIPTION
This amends #36 with a way to retrieve the pool again from the VmRef