### PR TITLE
Expose GetVmAgentNetworkInterfaces

### DIFF
--- a/main.go
+++ b/main.go
@@ -64,6 +64,15 @@ func main() {
 		cj, err := json.MarshalIndent(config, "", "  ")
 		log.Println(string(cj))
 
+	case "getNetworkInterfaces":
+		vmr = proxmox.NewVmRef(vmid)
+		c.CheckVmRef(vmr)
+		networkInterfaces, err := c.GetVmAgentNetworkInterfaces(vmr)
+		failError(err)
+
+		networkInterfaceJson, err := json.Marshal(networkInterfaces)
+		fmt.Println(string(networkInterfaceJson))
+
 	case "createQemu":
 		config, err := proxmox.NewConfigQemuFromJson(os.Stdin)
 		failError(err)


### PR DESCRIPTION
Can we expose the already existing getVmAgentNetworkInterfaces for usage?

The already existing functinality in GetVmAgentNetworkInterfaces returns the network interfaces of the VM by help of the Qemu agent (if enabled).

This change only exposes the method for usage. Example output:
```
$ ./proxmox-api-go getInterfaces 116 | jq -r
{
  "data": {
    "result": [
      {
        "hardware-address": "00:00:00:00:00:00",
        "ip-addresses": [
          {
            "ip-address": "127.0.0.1",
            "ip-address-type": "ipv4",
            "prefix": 8
          },
          {
            "ip-address": "::1",
            "ip-address-type": "ipv6",
            "prefix": 128
          }
        ],
        "name": "lo"
      },
      {
        "hardware-address": "02:0c:21:fc:c7:9b",
        "ip-addresses": [
          {
            "ip-address": "192.168.0.123",
            "ip-address-type": "ipv4",
            "prefix": 24
          },
          {
            "ip-address": "fe80::c:21ff:fefc:c79b",
            "ip-address-type": "ipv6",
            "prefix": 64
          }
        ],
        "name": "eth0"
      }
    ]
  }
}
```
