### PR TITLE
[fixed] CreateQemuDisksParams fails with cloneQemu if no disk config …

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -636,7 +636,9 @@ func (c ConfigQemu) CreateQemuDisksParams(
 			"storage_type": "lvm",  // default old style
 			"cache":        "none", // default old value
 		}
-
+		if c.QemuDisks == nil {
+			c.QemuDisks = make(QemuDevices)
+		}
 		c.QemuDisks[0] = deprecatedStyleMap
 	}
 


### PR DESCRIPTION
…is defined for cloud-init and fails like:

```
2019/07/30 00:56:10 Looking for template: debian-buster-64g
2019/07/30 00:56:10 Creating node: 
2019/07/30 00:56:10 &{104 vmhost02  }
panic: assignment to entry in nil map

goroutine 1 [running]:
github.com/Telmate/proxmox-api-go/proxmox.ConfigQemu.CreateQemuDisksParams(0xc0000ba940, 0x16, 0xc0000ba960, 0x19, 0x0, 0x0, 0x5e8, 0x0, 0x0, 0x2, ...)
        /Users/lanzm/Documents/git/proxmox-api-go/proxmox/config_qemu.go:642 +0x391
github.com/Telmate/proxmox-api-go/proxmox.ConfigQemu.UpdateConfig(0xc0000ba940, 0x16, 0xc0000ba960, 0x19, 0x0, 0x0, 0x5e8, 0x0, 0x0, 0x2, ...)
        /Users/lanzm/Documents/git/proxmox-api-go/proxmox/config_qemu.go:167 +0x437
github.com/Telmate/proxmox-api-go/proxmox.ConfigQemu.CloneVm(0xc0000ba940, 0x16, 0xc0000ba960, 0x19, 0x0, 0x0, 0x5e8, 0x0, 0x0, 0x2, ...)
        /Users/lanzm/Documents/git/proxmox-api-go/proxmox/config_qemu.go:152 +0x4dd
main.main()
        /Users/lanzm/Documents/git/proxmox-api-go/main.go:153 +0xd7e
```