### PR TITLE
Create disks after VM clone

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -170,6 +170,14 @@ func (config ConfigQemu) CloneVm(sourceVmr *VmRef, vmr *VmRef, client *Client) (
 	if err != nil {
 		return
 	}
+	
+	configParams := map[string]interface{}{
+		"vmid": vmr.vmId,
+	}
+	// Create disks
+	config.CreateQemuDisksParams(vmr.vmId, configParams, true)
+	client.createVMDisks(vmr.node, configParams)
+	
 	return config.UpdateConfig(vmr, client)
 }
 


### PR DESCRIPTION
When a VM is created based on a Cloud-init template, the extra disk defined in the tf file are not created.