### PR TITLE
Add KVM hardware virtualization support

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ export PM_OTP=otpcode (only if required)
 
 ./proxmox-api-go cloneQemu template-name proxmox-node-name < clone1.json
 
+./proxmox-api-go migrate pve1 123
 ```
 
 

--- a/main.go
+++ b/main.go
@@ -178,6 +178,18 @@ func main() {
 		failError(err)
 		log.Println("Keys sent")
 
+	case "nextid":
+		id, err := c.NextId()
+		failError(err)
+		log.Printf("Getting Next Free ID: %d\n", id)
+
+	case "checkid":
+		i, err := strconv.Atoi(flag.Args()[1])
+		failError(err)
+		id, err := c.VMIdExists(i)
+		failError(err)
+		log.Printf("Selected ID is free: %d\n", id)
+
 	default:
 		fmt.Printf("unknown action, try start|stop vmid")
 	}

--- a/main.go
+++ b/main.go
@@ -159,6 +159,7 @@ func main() {
 		log.Print("Creating node: ")
 		log.Println(vmr)
 		failError(config.CloneVm(sourceVmr, vmr, c))
+		failError(config.UpdateConfig(vmr, c))
 		log.Println("Complete")
 
 	case "rollbackQemu":

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -3,12 +3,14 @@ package proxmox
 // inspired by https://github.com/Telmate/vagrant-proxmox/blob/master/lib/vagrant-proxmox/proxmox/connection.rb
 
 import (
+	"bytes"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
+	"mime/multipart"
 	"net"
 	"net/http"
 	"regexp"
@@ -57,7 +59,7 @@ func (vmr *VmRef) SetVmType(vmType string) {
 	return
 }
 
-func (vmr *VmRef) GetVmType() (string) {
+func (vmr *VmRef) GetVmType() string {
 	return vmr.vmType
 }
 
@@ -90,7 +92,7 @@ func NewClient(apiUrl string, hclient *http.Client, tls *tls.Config) (client *Cl
 func (c *Client) Login(username string, password string, otp string) (err error) {
 	c.Username = username
 	c.Password = password
-	c.Otp      = otp
+	c.Otp = otp
 	return c.session.Login(username, password, otp)
 }
 
@@ -675,6 +677,50 @@ func (c *Client) DeleteVMDisks(
 	return nil
 }
 
+func (c *Client) Upload(node string, storage string, contentType string, filename string, file io.Reader) error {
+	body, mimetype, err := createUploadBody(contentType, filename, file)
+	if err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("%s/nodes/%s/storage/%s/upload", c.session.ApiUrl, node, storage)
+	req, err := c.session.NewRequest(http.MethodPost, url, nil, body)
+	if err != nil {
+		return err
+	}
+	req.Header.Add("Content-Type", mimetype)
+	req.Header.Add("Accept", "application/json")
+
+	_, err = c.session.Do(req)
+	return err
+}
+
+func createUploadBody(contentType string, filename string, r io.Reader) (io.Reader, string, error) {
+	var buf bytes.Buffer
+	w := multipart.NewWriter(&buf)
+
+	err := w.WriteField("content", contentType)
+	if err != nil {
+		return nil, "", err
+	}
+
+	fw, err := w.CreateFormFile("filename", filename)
+	if err != nil {
+		return nil, "", err
+	}
+	_, err = io.Copy(fw, r)
+	if err != nil {
+		return nil, "", err
+	}
+
+	err = w.Close()
+	if err != nil {
+		return nil, "", err
+	}
+
+	return &buf, w.FormDataContentType(), nil
+}
+
 // getStorageAndVolumeName - Extract disk storage and disk volume, since disk name is saved
 // in Proxmox with its storage.
 func getStorageAndVolumeName(
@@ -696,14 +742,14 @@ func getStorageAndVolumeName(
 
 func (c *Client) UpdateVMPool(vmr *VmRef, pool string) (exitStatus interface{}, err error) {
 	// Same pool
-	if(vmr.pool == pool) {
+	if vmr.pool == pool {
 		return
 	}
 
 	// Remove from old pool
-	if(vmr.pool != "") {
+	if vmr.pool != "" {
 		paramMap := map[string]interface{}{
-			"vms": vmr.vmId,
+			"vms":    vmr.vmId,
 			"delete": 1,
 		}
 		reqbody := ParamsToBody(paramMap)
@@ -722,7 +768,7 @@ func (c *Client) UpdateVMPool(vmr *VmRef, pool string) (exitStatus interface{}, 
 		}
 	}
 	// Add to the new pool
-	if(pool != "") {
+	if pool != "" {
 		paramMap := map[string]interface{}{
 			"vms": vmr.vmId,
 		}

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -135,6 +135,10 @@ func (c *Client) GetVmInfo(vmr *VmRef) (vmInfo map[string]interface{}, err error
 			vmInfo = vm
 			vmr.node = vmInfo["node"].(string)
 			vmr.vmType = vmInfo["type"].(string)
+			vmr.pool = ""
+			if vmInfo["pool"] != nil {
+				vmr.pool = vmInfo["pool"].(string)
+			}
 			return
 		}
 	}
@@ -150,6 +154,10 @@ func (c *Client) GetVmRefByName(vmName string) (vmr *VmRef, err error) {
 			vmr = NewVmRef(int(vm["vmid"].(float64)))
 			vmr.node = vm["node"].(string)
 			vmr.vmType = vm["type"].(string)
+			vmr.pool = ""
+			if vm["pool"] != nil {
+				vmr.pool = vm["pool"].(string)
+			}
 			return
 		}
 	}
@@ -684,4 +692,52 @@ func getStorageAndVolumeName(
 	}
 
 	return storageName, volumeName
+}
+
+func (c *Client) UpdateVMPool(vmr *VmRef, pool string) (exitStatus interface{}, err error) {
+	// Same pool
+	if(vmr.pool == pool) {
+		return
+	}
+
+	// Remove from old pool
+	if(vmr.pool != "") {
+		paramMap := map[string]interface{}{
+			"vms": vmr.vmId,
+			"delete": 1,
+		}
+		reqbody := ParamsToBody(paramMap)
+		url := fmt.Sprintf("/pools/%s", vmr.pool)
+		resp, err := c.session.Put(url, nil, nil, &reqbody)
+		if err == nil {
+			taskResponse, err := ResponseJSON(resp)
+			if err != nil {
+				return nil, err
+			}
+			exitStatus, err = c.WaitForCompletion(taskResponse)
+
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+	// Add to the new pool
+	if(pool != "") {
+		paramMap := map[string]interface{}{
+			"vms": vmr.vmId,
+		}
+		reqbody := ParamsToBody(paramMap)
+		url := fmt.Sprintf("/pools/%s", pool)
+		resp, err := c.session.Put(url, nil, nil, &reqbody)
+		if err == nil {
+			taskResponse, err := ResponseJSON(resp)
+			if err != nil {
+				return nil, err
+			}
+			exitStatus, err = c.WaitForCompletion(taskResponse)
+		} else {
+			return nil, err
+		}
+	}
+	return
 }

--- a/proxmox/config_lxc.go
+++ b/proxmox/config_lxc.go
@@ -5,66 +5,66 @@ import (
 	"fmt"
 	"io"
 	"log"
-	"strings"
 	"strconv"
+	"strings"
 )
 
 // LXC options for the Proxmox API
 type configLxc struct {
-	Ostemplate         string         `json:"ostemplate"`
-		Arch               string         `json:"arch"`
-		BWLimit            int            `json:"bwlimit,omitempty"`
-		CMode              string         `json:"cmode"`
-		Console            bool           `json:"console"`
-		Cores              int            `json:"cores,omitempty"`
-		CPULimit           int            `json:"cpulimit"`
-		CPUUnits           int            `json:"cpuunits"`
-		Description        string         `json:"description,omitempty"`
-		Features           QemuDevice     `json:"features,omitempty"`
-		Force              bool           `json:"force,omitempty"`
-		Hookscript         string         `json:"hookscript,omitempty"`
-		Hostname           string         `json:"hostname,omitempty"`
-		IgnoreUnpackErrors bool           `json:"ignore-unpack-errors,omitempty"`
-		Lock               string         `json:"lock,omitempty"`
-		Memory             int            `json:"memory"`
-		Mountpoints        QemuDevices    `json:"mountpoints,omitempty"`
-		Nameserver         string         `json:"nameserver,omitempty"`
-		Networks           QemuDevices    `json:"networks,omitempty"`
-		OnBoot             bool           `json:"onboot"`
-		OsType             string         `json:"ostype,omitempty"`
-		Password           string         `json:"password,omitempty"`
-		Pool               string         `json:"pool,omitempty"`
-		Protection         bool           `json:"protection"`
-		Restore            bool           `json:"restore,omitempty"`
-		RootFs             string         `json:"rootfs,omitempty"`
-		SearchDomain       string         `json:"searchdomain,omitempty"`
-		SSHPublicKeys      string         `json:"ssh-public-keys,omitempty"`
-		Start              bool           `json:"start"`
-		Startup            string         `json:"startup,omitempty"`
-		Storage            string         `json:"storage"`
-		Swap               int            `json:"swap"`
-		Template           bool           `json:"template,omitempty"`
-		Tty                int            `json:"tty"`
-		Unique             bool           `json:"unique,omitempty"`
-		Unprivileged       bool           `json:"unprivileged"`
-		Unused             []string       `json:"unused,omitempty"`
+	Ostemplate         string      `json:"ostemplate"`
+	Arch               string      `json:"arch"`
+	BWLimit            int         `json:"bwlimit,omitempty"`
+	CMode              string      `json:"cmode"`
+	Console            bool        `json:"console"`
+	Cores              int         `json:"cores,omitempty"`
+	CPULimit           int         `json:"cpulimit"`
+	CPUUnits           int         `json:"cpuunits"`
+	Description        string      `json:"description,omitempty"`
+	Features           QemuDevice  `json:"features,omitempty"`
+	Force              bool        `json:"force,omitempty"`
+	Hookscript         string      `json:"hookscript,omitempty"`
+	Hostname           string      `json:"hostname,omitempty"`
+	IgnoreUnpackErrors bool        `json:"ignore-unpack-errors,omitempty"`
+	Lock               string      `json:"lock,omitempty"`
+	Memory             int         `json:"memory"`
+	Mountpoints        QemuDevices `json:"mountpoints,omitempty"`
+	Nameserver         string      `json:"nameserver,omitempty"`
+	Networks           QemuDevices `json:"networks,omitempty"`
+	OnBoot             bool        `json:"onboot"`
+	OsType             string      `json:"ostype,omitempty"`
+	Password           string      `json:"password,omitempty"`
+	Pool               string      `json:"pool,omitempty"`
+	Protection         bool        `json:"protection"`
+	Restore            bool        `json:"restore,omitempty"`
+	RootFs             string      `json:"rootfs,omitempty"`
+	SearchDomain       string      `json:"searchdomain,omitempty"`
+	SSHPublicKeys      string      `json:"ssh-public-keys,omitempty"`
+	Start              bool        `json:"start"`
+	Startup            string      `json:"startup,omitempty"`
+	Storage            string      `json:"storage"`
+	Swap               int         `json:"swap"`
+	Template           bool        `json:"template,omitempty"`
+	Tty                int         `json:"tty"`
+	Unique             bool        `json:"unique,omitempty"`
+	Unprivileged       bool        `json:"unprivileged"`
+	Unused             []string    `json:"unused,omitempty"`
 }
 
-func NewConfigLxc() (configLxc) {
+func NewConfigLxc() configLxc {
 	return configLxc{
-		Arch: "amd64",
-		CMode: "tty",
-		Console: true,
-		CPULimit: 0,
-		CPUUnits: 1024,
-		Memory: 512,
-		OnBoot: false,
-		Protection: false,
-		Start: false,
-		Storage: "local",
-		Swap: 512,
-		Template: false,
-		Tty: 2,
+		Arch:         "amd64",
+		CMode:        "tty",
+		Console:      true,
+		CPULimit:     0,
+		CPUUnits:     1024,
+		Memory:       512,
+		OnBoot:       false,
+		Protection:   false,
+		Start:        false,
+		Storage:      "local",
+		Swap:         512,
+		Template:     false,
+		Tty:          2,
 		Unprivileged: false,
 	}
 }
@@ -162,7 +162,7 @@ func NewConfigLxcFromApi(vmr *VmRef, client *Client) (config *configLxc, err err
 	mpNames := []string{}
 
 	for k, _ := range lxcConfig {
-		if mpName:= rxMpName.FindStringSubmatch(k); len(mpName) > 0 {
+		if mpName := rxMpName.FindStringSubmatch(k); len(mpName) > 0 {
 			mpNames = append(mpNames, mpName[0])
 		}
 	}
@@ -175,7 +175,7 @@ func NewConfigLxcFromApi(vmr *VmRef, client *Client) (config *configLxc, err err
 		mpID, _ := strconv.Atoi(id[0])
 		// add mp id
 		mpConfMap := QemuDevice{
-			"id":      mpID,
+			"id": mpID,
 		}
 		// add rest of device config
 		mpConfMap.readDeviceConfig(mpConfList)
@@ -211,7 +211,7 @@ func NewConfigLxcFromApi(vmr *VmRef, client *Client) (config *configLxc, err err
 		nicID, _ := strconv.Atoi(id[0])
 		// add nic id
 		nicConfMap := QemuDevice{
-			"id":      nicID,
+			"id": nicID,
 		}
 		// add rest of device config
 		nicConfMap.readDeviceConfig(nicConfList)

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -201,11 +201,7 @@ func (config ConfigQemu) CloneVm(sourceVmr *VmRef, vmr *VmRef, client *Client) (
 	}
 
 	_, err = client.CloneQemuVm(sourceVmr, params)
-	if err != nil {
-		return
-	}
-
-	return config.UpdateConfig(vmr, client)
+	return err
 }
 
 func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
@@ -251,7 +247,7 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 	}
 
 	// Create disks config.
-	configParamsDisk := map[string]interface{} {
+	configParamsDisk := map[string]interface{}{
 		"vmid": vmr.vmId,
 	}
 	config.CreateQemuDisksParams(vmr.vmId, configParamsDisk, false)

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -254,7 +254,7 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 	configParamsDisk := map[string]interface{} {
 		"vmid": vmr.vmId,
 	}
-	config.CreateQemuDisksParams(vmr.vmId, configParamsDisk, true)
+	config.CreateQemuDisksParams(vmr.vmId, configParamsDisk, false)
 	client.createVMDisks(vmr.node, configParamsDisk)
 	//Copy the disks to the global configParams
 	for key, value := range configParamsDisk {

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -33,6 +33,7 @@ type ConfigQemu struct {
 	QemuOs       string      `json:"os"`
 	QemuCores    int         `json:"cores"`
 	QemuSockets  int         `json:"sockets"`
+	QemuVcpus    int         `json:"vcpus"`
 	QemuCpu      string      `json:"cpu"`
 	QemuNuma     bool        `json:"numa"`
 	Hotplug      string      `json:"hotplug"`
@@ -87,6 +88,7 @@ func (config ConfigQemu) CreateVm(vmr *VmRef, client *Client) (err error) {
 		"ide2":        config.QemuIso + ",media=cdrom",
 		"ostype":      config.QemuOs,
 		"sockets":     config.QemuSockets,
+		"vcpus":       config.QemuVcpus,
 		"cores":       config.QemuCores,
 		"cpu":         config.QemuCpu,
 		"numa":        config.QemuNuma,
@@ -191,6 +193,7 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 		"onboot":      config.Onboot,
 		"agent":       config.Agent,
 		"sockets":     config.QemuSockets,
+		"vcpus":       config.QemuVcpus,
 		"cores":       config.QemuCores,
 		"cpu":         config.QemuCpu,
 		"numa":        config.QemuNuma,
@@ -358,6 +361,10 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 	if _, isSet := vmConfig["cores"]; isSet {
 		cores = vmConfig["cores"].(float64)
 	}
+	vcpus := 0.0
+	if _, isSet := vmConfig["vcpus"]; isSet {
+		cores = vmConfig["vcpus"].(float64)
+	}
 	sockets := 1.0
 	if _, isSet := vmConfig["sockets"]; isSet {
 		sockets = vmConfig["sockets"].(float64)
@@ -402,6 +409,7 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 		Memory:       int(memory),
 		QemuCores:    int(cores),
 		QemuSockets:  int(sockets),
+		QemuVcpus:    int(vcpus),
 		QemuCpu:      cpu,
 		QemuNuma:     numa,
 		Hotplug:      hotplug,

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -120,9 +120,9 @@ func (config ConfigQemu) CreateVm(vmr *VmRef, client *Client) (err error) {
 	if err != nil {
 		return fmt.Errorf("Error creating VM: %v, error status: %s (params: %v)", err, exitStatus, params)
 	}
-	
-	client.UpdateVMHA(vmr, config.HaState);
-	
+
+	client.UpdateVMHA(vmr, config.HaState)
+
 	return
 }
 
@@ -180,7 +180,7 @@ func (config ConfigQemu) CloneVm(sourceVmr *VmRef, vmr *VmRef, client *Client) (
 	if err != nil {
 		return
 	}
-	
+
 	return config.UpdateConfig(vmr, client)
 }
 
@@ -264,11 +264,11 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 		log.Print(err)
 		return err
 	}
-	
-	client.UpdateVMHA(vmr, config.HaState);
-	
+
+	client.UpdateVMHA(vmr, config.HaState)
+
 	_, err = client.UpdateVMPool(vmr, config.Pool)
-	
+
 	return err
 }
 
@@ -392,7 +392,7 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 	if _, isSet := vmConfig["hastate"]; isSet {
 		hastate = vmConfig["hastate"].(string)
 	}
-	
+
 	config = &ConfigQemu{
 		Name:         name,
 		Description:  strings.TrimSpace(description),

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -25,6 +25,7 @@ type (
 type ConfigQemu struct {
 	Name         string      `json:"name"`
 	Description  string      `json:"desc"`
+	Pool         string      `json:"pool,omitempty"`
 	Onboot       bool        `json:"onboot"`
 	Agent        int         `json:"agent"`
 	Memory       int         `json:"memory"`
@@ -242,6 +243,13 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 		configParams["ipconfig2"] = config.Ipconfig2
 	}
 	_, err = client.SetVmConfig(vmr, configParams)
+	if err != nil {
+		log.Fatal(err)
+		return err
+	}
+	
+	_, err = client.UpdateVMPool(vmr, config.Pool);
+	
 	return err
 }
 

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -27,6 +27,7 @@ type ConfigQemu struct {
 	Name         string      `json:"name"`
 	Description  string      `json:"desc"`
 	Pool         string      `json:"pool,omitempty"`
+	Bios         string      `json:"bios"`
 	Onboot       bool        `json:"onboot"`
 	Agent        int         `json:"agent"`
 	Memory       int         `json:"memory"`
@@ -97,7 +98,11 @@ func (config ConfigQemu) CreateVm(vmr *VmRef, client *Client) (err error) {
 		"boot":        config.Boot,
 		"description": config.Description,
 	}
-	
+
+	if config.Bios != "" {
+		params["bios"] = config.Bios
+	}
+
 	if config.Balloon >= 1 {
 		params["balloon"] = config.Balloon
 	}
@@ -212,6 +217,10 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 
 	//Array to list deleted parameters
 	deleteParams := []string{}
+
+	if config.Bios != "" {
+		configParams["bios"] = config.Bios
+	}
 
 	if config.Balloon >= 1 {
 		configParams["balloon"] = config.Balloon
@@ -362,6 +371,10 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 	if _, isSet := vmConfig["description"]; isSet {
 		description = vmConfig["description"].(string)
 	}
+	bios := "seabios"
+	if _, isSet := vmConfig["bios"]; isSet {
+		bios = vmConfig["bios"].(string)
+	}
 	onboot := true
 	if _, isSet := vmConfig["onboot"]; isSet {
 		onboot = Itob(int(vmConfig["onboot"].(float64)))
@@ -435,6 +448,7 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 	config = &ConfigQemu{
 		Name:         name,
 		Description:  strings.TrimSpace(description),
+		Bios:         bios,
 		Onboot:       onboot,
 		Agent:        agent,
 		QemuOs:       ostype,

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -247,9 +247,9 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 		log.Fatal(err)
 		return err
 	}
-	
-	_, err = client.UpdateVMPool(vmr, config.Pool);
-	
+
+	_, err = client.UpdateVMPool(vmr, config.Pool)
+
 	return err
 }
 

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -250,7 +250,7 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 	}
 	_, err = client.SetVmConfig(vmr, configParams)
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
 		return err
 	}
 	

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -38,6 +38,7 @@ type ConfigQemu struct {
 	QemuVcpus    int         `json:"vcpus"`
 	QemuCpu      string      `json:"cpu"`
 	QemuNuma     bool        `json:"numa"`
+	QemuKVM      bool        `json:"kvm,omitempty"`
 	Hotplug      string      `json:"hotplug"`
 	QemuIso      string      `json:"iso"`
 	FullClone    *int        `json:"fullclone"`
@@ -94,6 +95,7 @@ func (config ConfigQemu) CreateVm(vmr *VmRef, client *Client) (err error) {
 		"cores":       config.QemuCores,
 		"cpu":         config.QemuCpu,
 		"numa":        config.QemuNuma,
+		"kvm":         config.QemuKVM,
 		"hotplug":     config.Hotplug,
 		"memory":      config.Memory,
 		"boot":        config.Boot,
@@ -214,6 +216,7 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 		"cores":       config.QemuCores,
 		"cpu":         config.QemuCpu,
 		"numa":        config.QemuNuma,
+		"kvm":         config.QemuKVM,
 		"hotplug":     config.Hotplug,
 		"memory":      config.Memory,
 		"boot":        config.Boot,
@@ -435,6 +438,10 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 	if _, isSet := vmConfig["numa"]; isSet {
 		numa = Itob(int(vmConfig["numa"].(float64)))
 	}
+	kvm := true
+	if _, isSet := vmConfig["kvm"]; isSet {
+		kvm = Itob(int(vmConfig["kvm"].(float64)))
+	}
 	//Can be network,disk,cpu,memory,usb
 	hotplug := "network,disk,usb"
 	if _, isSet := vmConfig["hotplug"]; isSet {
@@ -470,6 +477,7 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 		QemuSockets:  int(sockets),
 		QemuCpu:      cpu,
 		QemuNuma:     numa,
+		QemuKVM:      kvm,
 		Hotplug:      hotplug,
 		QemuVlanTag:  -1,
 		Boot:         boot,

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -208,7 +208,18 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 	}
 
 	// Create disks config.
-	config.CreateQemuDisksParams(vmr.vmId, configParams, true)
+	configParamsDisk := map[string]interface{} {
+		"vmid": vmr.vmId,
+	}
+	config.CreateQemuDisksParams(vmr.vmId, configParamsDisk, true)
+	client.createVMDisks(vmr.node, configParamsDisk)
+	//Copy the disks to the global configParams
+	for key, value := range configParamsDisk {
+		//vmid is only required in createVMDisks
+		if key != "vmid" {
+			configParams[key] = value
+		}
+	}
 
 	// Create networks config.
 	config.CreateQemuNetworksParams(vmr.vmId, configParams)

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -829,9 +829,9 @@ func (c ConfigQemu) CreateQemuDisksParams(
 
 		// Disk name.
 		var diskFile string
-		// Currently ZFS local, LVM, Ceph RBD, and Directory are considered.
+		// Currently ZFS local, LVM, Ceph RBD, CephFS and Directory are considered.
 		// Other formats are not verified, but could be added if they're needed.
-		rxStorageTypes := `(zfspool|lvm|rbd)`
+		rxStorageTypes := `(zfspool|lvm|rbd|cephfs)`
 		storageType := diskConfMap["storage_type"].(string)
 		if matched, _ := regexp.MatchString(rxStorageTypes, storageType); matched {
 			diskFile = fmt.Sprintf("file=%v:vm-%v-disk-%v", diskConfMap["storage"], vmID, diskID)

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -272,8 +272,7 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 	vgaParam = vgaParam.createDeviceParam(config.QemuVga, nil)
 	if len(vgaParam) > 0 {
 		configParams["vga"] = strings.Join(vgaParam, ",")
-	}
-	else {
+	} else {
 		deleteParams = append(deleteParams, "vga")
 	}
 

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -30,6 +30,7 @@ type ConfigQemu struct {
 	Onboot       bool        `json:"onboot"`
 	Agent        int         `json:"agent"`
 	Memory       int         `json:"memory"`
+	Balloon      int         `json:"balloon"`
 	QemuOs       string      `json:"os"`
 	QemuCores    int         `json:"cores"`
 	QemuSockets  int         `json:"sockets"`
@@ -95,6 +96,10 @@ func (config ConfigQemu) CreateVm(vmr *VmRef, client *Client) (err error) {
 		"memory":      config.Memory,
 		"boot":        config.Boot,
 		"description": config.Description,
+	}
+	
+	if config.Balloon >= 1 {
+		params["balloon"] = config.Balloon
 	}
 	
 	if config.QemuVcpus >= 1 {
@@ -208,6 +213,12 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 	//Array to list deleted parameters
 	deleteParams := []string{}
 
+	if config.Balloon >= 1 {
+		configParams["balloon"] = config.Balloon
+	} else {
+		deleteParams = append(deleteParams, "balloon")
+	}
+	
 	if config.QemuVcpus >= 1 {
 		configParams["vcpus"] = config.QemuVcpus
 	} else {
@@ -374,6 +385,10 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 	if _, isSet := vmConfig["memory"]; isSet {
 		memory = vmConfig["memory"].(float64)
 	}
+	balloon := 0.0
+	if _, isSet := vmConfig["balloon"]; isSet {
+		balloon = vmConfig["balloon"].(float64)
+	}
 	cores := 1.0
 	if _, isSet := vmConfig["cores"]; isSet {
 		cores = vmConfig["cores"].(float64)
@@ -439,6 +454,9 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 		QemuSerials:  QemuDevices{},
 	}
 	
+	if balloon >= 1 {
+		config.Balloon = int(balloon);
+	}
 	if vcpus >= 1 {
 		config.QemuVcpus = int(vcpus);
 	}

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -88,7 +88,6 @@ func (config ConfigQemu) CreateVm(vmr *VmRef, client *Client) (err error) {
 		"ide2":        config.QemuIso + ",media=cdrom",
 		"ostype":      config.QemuOs,
 		"sockets":     config.QemuSockets,
-		"vcpus":       config.QemuVcpus,
 		"cores":       config.QemuCores,
 		"cpu":         config.QemuCpu,
 		"numa":        config.QemuNuma,
@@ -97,6 +96,11 @@ func (config ConfigQemu) CreateVm(vmr *VmRef, client *Client) (err error) {
 		"boot":        config.Boot,
 		"description": config.Description,
 	}
+	
+	if config.QemuVcpus >= 1 {
+		params["vcpus"] = config.QemuVcpus
+	}
+	
 	if vmr.pool != "" {
 		params["pool"] = vmr.pool
 	}
@@ -193,7 +197,6 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 		"onboot":      config.Onboot,
 		"agent":       config.Agent,
 		"sockets":     config.QemuSockets,
-		"vcpus":       config.QemuVcpus,
 		"cores":       config.QemuCores,
 		"cpu":         config.QemuCpu,
 		"numa":        config.QemuNuma,
@@ -202,6 +205,15 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 		"boot":        config.Boot,
 	}
 
+	//Array to list deleted parameters
+	deleteParams := []string{}
+
+	if config.QemuVcpus >= 1 {
+		configParams["vcpus"] = config.QemuVcpus
+	} else {
+		deleteParams = append(deleteParams, "vcpus")
+	}
+	
 	if config.BootDisk != "" {
 		configParams["bootdisk"] = config.BootDisk
 	}
@@ -262,6 +274,11 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 	if config.Ipconfig2 != "" {
 		configParams["ipconfig2"] = config.Ipconfig2
 	}
+	
+	if len(deleteParams) > 0 {
+		configParams["delete"] = strings.Join(deleteParams, ", ")
+	}
+	
 	_, err = client.SetVmConfig(vmr, configParams)
 	if err != nil {
 		log.Print(err)
@@ -363,7 +380,7 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 	}
 	vcpus := 0.0
 	if _, isSet := vmConfig["vcpus"]; isSet {
-		cores = vmConfig["vcpus"].(float64)
+		vcpus = vmConfig["vcpus"].(float64)
 	}
 	sockets := 1.0
 	if _, isSet := vmConfig["sockets"]; isSet {
@@ -409,7 +426,6 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 		Memory:       int(memory),
 		QemuCores:    int(cores),
 		QemuSockets:  int(sockets),
-		QemuVcpus:    int(vcpus),
 		QemuCpu:      cpu,
 		QemuNuma:     numa,
 		Hotplug:      hotplug,
@@ -421,6 +437,10 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 		QemuDisks:    QemuDevices{},
 		QemuNetworks: QemuDevices{},
 		QemuSerials:  QemuDevices{},
+	}
+	
+	if vcpus >= 1 {
+		config.QemuVcpus = int(vcpus);
 	}
 
 	if vmConfig["ide2"] != nil {

--- a/proxmox/session.go
+++ b/proxmox/session.go
@@ -163,7 +163,7 @@ func (s *Session) Do(req *http.Request) (*http.Response, error) {
 
 	if *Debug {
 		d, _ := httputil.DumpRequestOut(req, true)
-		log.Printf(">>>>>>>>>> REQUEST:\n", string(d))
+		log.Printf(">>>>>>>>>> REQUEST:\n%v", string(d))
 	}
 
 	resp, err := s.httpClient.Do(req)
@@ -174,7 +174,7 @@ func (s *Session) Do(req *http.Request) (*http.Response, error) {
 
 	if *Debug {
 		dr, _ := httputil.DumpResponse(resp, true)
-		log.Printf("<<<<<<<<<< RESULT:\n", string(dr))
+		log.Printf("<<<<<<<<<< RESULT:\n%v", string(dr))
 	}
 
 	if resp.StatusCode < 200 || resp.StatusCode > 299 {

--- a/proxmox/session.go
+++ b/proxmox/session.go
@@ -167,10 +167,20 @@ func (s *Session) Do(req *http.Request) (*http.Response, error) {
 	}
 
 	resp, err := s.httpClient.Do(req)
-
 	if err != nil {
 		return nil, err
 	}
+
+	// The response body reader needs to be closed, but lots of places call
+	// session.Do, and they might not be able to reliably close it themselves.
+	// Therefore, read the body out, close the original, then replace it with
+	// a NopCloser over the bytes, which does not need to be closed downsteam.
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+	resp.Body = ioutil.NopCloser(bytes.NewReader(respBody))
 
 	if *Debug {
 		dr, _ := httputil.DumpResponse(resp, true)


### PR DESCRIPTION
This PR adds the ability to toggle KVM hardware virtualization on or off via the `kvm` boolean. Open to criticism/feedback as I haven't had much experience with golang so I am looking to improve. 

Successfully tested with the following:
```
$ ./proxmox-api-go -insecure createQemu 123 proxmox < qemu1.json
2019/10/07 14:30:15 {"name":"golang1.test.com","desc":"Test proxmox-api-go","onboot":false,"agent":0,"memory":2048,"os":"l26","cores":2,"sockets":1,"cpu":"kvm64","numa":false,"kvm":false,"hotplug":"","iso":"zfs-nfs:iso/CentOS-7-x86_64-DVD-1908.iso","fullclone":null,"boot":"cdn","disk":{"0":{"backup":true,"cache":"none","size":"30G","storage":"lvm-thin","storage_type":"lvm","type":"scsi"}},"network":{"0":{"bridge":"nat","model":"virtio"},"1":{"bridge":"vmbr0","model":"virtio","tag":-1}},"diskGB":0,"storage":"","storageType":"","nic":"","bridge":"","vlan":-1,"mac":"","ciuser":"","cipassword":"","cicustom":"","searchdomain":"","nameserver":"","sshkeys":"","ipconfig0":"","ipconfig1":"","ipconfig2":""}                                
2019/10/07 14:30:16 Complete
$ 
$ cat qemu1.json
{
  "name": "golang1.test.com",
  "desc": "Test proxmox-api-go",
  "memory": 2048,
  "os": "l26",
  "cores": 2,
  "sockets": 1,
  "kvm": false,
  "boot": "cdn",
  "cpu": "kvm64",
  "iso": "zfs-nfs:iso/CentOS-7-x86_64-DVD-1908.iso",
  "disk": {
    "0": {
      "type": "scsi",
      "storage": "lvm-thin",
      "storage_type": "lvm",
      "size": "30G",
      "backup": true,
      "cache": "none"
    }
  },
  "network": {
    "0": {
      "model": "virtio",
      "bridge": "nat"
    },
    "1": {
      "model": "virtio",
      "bridge": "vmbr0",
      "tag": -1
    }
  }
}
```