### PR TITLE
Remove a fatal log to return an error

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -245,7 +245,7 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 	}
 	_, err = client.SetVmConfig(vmr, configParams)
 	if err != nil {
-		log.Fatal(err)
+		log.Print(err)
 		return err
 	}
 


### PR DESCRIPTION
I replace the method ``Fatal`` by ``Print`` because the ``Fatal`` method do an ``os.Exit(1)`` and the lib stop and doesn't return the err. 

Stopping the api client with an ``os.exit`` doesn't stop the promox provider properly.

The ``log.Fatal`` is use more than once in this library. If i have time (or someone else) i will do an other PR to clean it. 