### PR TITLE
Fix when the vcpus parameter is committed

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -363,7 +363,7 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 	}
 	vcpus := 0.0
 	if _, isSet := vmConfig["vcpus"]; isSet {
-		cores = vmConfig["vcpus"].(float64)
+		vcpus = vmConfig["vcpus"].(float64)
 	}
 	sockets := 1.0
 	if _, isSet := vmConfig["sockets"]; isSet {


### PR DESCRIPTION
The documentation says the parameter can be set to 0 but Proxmox throws an error. Instead, the delete parameter has to be used to remove the property.