### PR TITLE
Fix file descriptor leak in session.Do

### DIFF
--- a/proxmox/session.go
+++ b/proxmox/session.go
@@ -167,10 +167,20 @@ func (s *Session) Do(req *http.Request) (*http.Response, error) {
 	}
 
 	resp, err := s.httpClient.Do(req)
-
 	if err != nil {
 		return nil, err
 	}
+
+	// The response body reader needs to be closed, but lots of places call
+	// session.Do, and they might not be able to reliably close it themselves.
+	// Therefore, read the body out, close the original, then replace it with
+	// a NopCloser over the bytes, which does not need to be closed downsteam.
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+	resp.Body.Close()
+	resp.Body = ioutil.NopCloser(bytes.NewReader(respBody))
 
 	if *Debug {
 		dr, _ := httputil.DumpResponse(resp, true)


### PR DESCRIPTION
Currently `session.Do` leaks a file descriptor with every request, since we don't close the body. Thir PR makes sure the body will always be closed.