### PR TITLE
fix proxmox API errors on empty params

### DIFF
--- a/proxmox/session.go
+++ b/proxmox/session.go
@@ -65,7 +65,9 @@ func ParamsToBody(params map[string]interface{}) (body []byte) {
 		default:
 			v = fmt.Sprintf("%v", intrV)
 		}
-		vals.Set(k, v)
+		if v != "" {
+			vals.Set(k, v)
+		}
 	}
 	body = bytes.NewBufferString(vals.Encode()).Bytes()
 	return


### PR DESCRIPTION
When attempting to clone a VM that already has disks (so none need to be sent), the clone operation errors out because of empty params in call to proxmox API.

Before:
```
2020-04-24T20:33:09.737-0700 [DEBUG] plugin.terraform-provider-proxmox: full=1&name=terraform-test-vm&newid=102&pool=managed&storage=&target=tachikoma
[snip]
2020-04-24T20:33:09.745-0700 [DEBUG] plugin.terraform-provider-proxmox: Pragma: no-cache
2020-04-24T20:33:09.745-0700 [DEBUG] plugin.terraform-provider-proxmox: Server: pve-api-daemon/3.0
2020-04-24T20:33:09.745-0700 [DEBUG] plugin.terraform-provider-proxmox: 
2020-04-24T20:33:09.745-0700 [DEBUG] plugin.terraform-provider-proxmox: {"data":null,"errors":{"storage":"invalid format - storage ID '' contains illegal characters\n"}}
2020/04/24 20:33:09 [DEBUG] proxmox_vm_qemu.cloudinit--test: apply errored, but we're indicating that via the Error pointer rather than returning it: 400 Parameter verification failed.
```

After, empty param is omitted and operation succedes:
```
2020-04-24T20:47:47.206-0700 [DEBUG] plugin.terraform-provider-proxmox: full=1&name=terraform-test-vm&newid=102&pool=managed&target=tachikoma

```