### PR TITLE
Fixed issue when parsing mountpoints from received from Proxmox API

### DIFF
--- a/proxmox/config_lxc.go
+++ b/proxmox/config_lxc.go
@@ -173,20 +173,19 @@ func NewConfigLxcFromApi(vmr *VmRef, client *Client) (config *configLxc, err err
 
 		id := rxDeviceID.FindStringSubmatch(mpName)
 		mpID, _ := strconv.Atoi(id[0])
-		// add mp id
+		// add mp id, volume, and mp
+		_, mp := ParseSubConf(mpConfList[1], "=")
 		mpConfMap := QemuDevice{
-			"id": mpID,
+			"id":     mpID,
+			"volume": mpConfList[0],
+			"mp":     mp,
 		}
-		// add rest of device config
-		mpConfMap.readDeviceConfig(mpConfList)
-		// prepare empty mountpoint map
+
 		if config.Mountpoints == nil {
 			config.Mountpoints = QemuDevices{}
 		}
-		// and device config to mountpoints
-		if len(mpConfMap) > 0 {
-			config.Mountpoints[mpID] = mpConfMap
-		}
+
+		config.Mountpoints[mpID] = mpConfMap
 	}
 
 	nameserver := ""


### PR DESCRIPTION
This was causing problems when creating LXC containers with mountpoints in the Terraform Provider.

https://github.com/Telmate/terraform-provider-proxmox/issues/157

mpConfMap.readDeviceConfig expects a list of strings of the form ["key1=value","key2=value"]
But when parsing the mountpoints it was sent a list like ["/mnt/pve/storage-box","mp=/mnt/something"]
Note the missing '=' in the first entry, which cause an entry in the confMap with an empty string as a key and nil as a value. So I rejigged this a bit, and also included the 'volume' key.

This was previously causing an 'Error writing fields: Invalid address to set: []string{"mountpoint", "3317302270", ""}' in the Terraform Provider. when creating an LXC resource with mountpoints. The resource would be created but state wouldn't not be written.