### PR TITLE
Fix float64/bool conversion and default value for KVM flag

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -329,7 +329,7 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 }
 
 func NewConfigQemuFromJson(io io.Reader) (config *ConfigQemu, err error) {
-	config = &ConfigQemu{QemuVlanTag: -1}
+	config = &ConfigQemu{QemuVlanTag: -1, QemuKVM: true}
 	err = json.NewDecoder(io).Decode(config)
 	if err != nil {
 		log.Fatal(err)
@@ -454,7 +454,7 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 	}
 	kvm := true
 	if _, isSet := vmConfig["kvm"]; isSet {
-		kvm = vmConfig["kvm"].(bool)
+		kvm = Itob(int(vmConfig["kvm"].(float64)))
 	}
 	scsihw := "lsi"
 	if _, isSet := vmConfig["scsihw"]; isSet {


### PR DESCRIPTION
Fixes for #82 .

The Terraform Proxmox Provider will also need some updates to default the kvm flag to true on that side, I'll have an issue/PR sent up shortly.