### PR TITLE
CI and Proxmox Vagrant Box

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 proxmox-api-go
+.vagrant/

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ env:
     - GO111MODULE=on
 
 install:
-  # install libvirt and KVM
-  - sudo apt-get update && sudo apt-get install -y bridge-utils dnsmasq-base ebtables libvirt-bin libvirt-dev qemu-kvm qemu-utils
+  # install build dependencies for vagrant-libvirt
+  - sudo apt-get update && sudo apt-get build-dep vagrant ruby-libvirt && sudo apt-get install -y qemu libvirt-daemon-system libvirt-clients ebtables dnsmasq-base libxslt-dev libxml2-dev libvirt-dev zlib1g-dev ruby-dev
 
   # install vagrant
   - sudo wget -nv https://releases.hashicorp.com/vagrant/2.2.9/vagrant_2.2.9_x86_64.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+language: go
+
+install:
+  # install libvirt and KVM
+  - sudo apt-get update && sudo apt-get install -y bridge-utils dnsmasq-base ebtables libvirt-bin libvirt-dev qemu-kvm qemu-utils
+
+  # install vagrant
+  - sudo wget -nv https://releases.hashicorp.com/vagrant/2.2.9/vagrant_2.2.9_x86_64.deb
+  - sudo dpkg -i vagrant_2.2.9_x86_64.deb
+
+  # install vagrant-libvirt plugin
+  - sudo vagrant plugin install vagrant-libvirt
+
+script:
+  - sudo vagrant up --provider=libvirt
+  - make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,18 @@
 language: go
 
+go:
+  - 1.14.x
+
+dist: bionic
+
+cache:
+  directories:
+    - /home/travis/.vagrant.d/boxes
+
+env:
+  global:
+    - GO111MODULE=on
+
 install:
   # install libvirt and KVM
   - sudo apt-get update && sudo apt-get install -y bridge-utils dnsmasq-base ebtables libvirt-bin libvirt-dev qemu-kvm qemu-utils

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+TEST?=$(shell go list ./...)
+
+test:
+	@go test $(TEST)

--- a/README.md
+++ b/README.md
@@ -122,3 +122,11 @@ Kickstart auto install
 * sshd (with preshared key/password)
 
 Network is temprorarily eth1 during the pre-provision phase.
+
+## Test
+
+You're going to need [vagrant](https://www.vagrantup.com/downloads) and [virtualbox](https://www.virtualbox.org/wiki/Downloads) to run the tests:
+
+```sh
+make test
+```

--- a/README.md
+++ b/README.md
@@ -1,21 +1,18 @@
 # Proxmox API Go
 
-
 Proxmox API in golang. For /api2/json. Work in progress.
 
-Starting with Proxmox 5.2 you can use clout-init options.
+Starting with Proxmox 5.2 you can use cloud-init options.
 
 ## Build
 
-```
+```sh
 go build -o proxmox-api-go
 ```
 
-
 ## Run
 
-
-```
+```sh
 export PM_API_URL="https://xxxx.com:8006/api2/json"
 export PM_USER=user@pam
 export PM_PASS=password
@@ -34,11 +31,11 @@ export PM_OTP=otpcode (only if required)
 ./proxmox-api-go migrate pve1 123
 ```
 
-
 ### Format
 
 createQemu JSON Sample:
-```
+
+```json
 {
   "name": "golang1.test.com",
   "desc": "Test proxmox-api-go",
@@ -71,10 +68,10 @@ createQemu JSON Sample:
   }
 }
 ```
-
  
 cloneQemu JSON Sample:
-```
+
+```json
 {
   "name": "golang2.test.com",
   "desc": "Test proxmox-api-go clone",
@@ -87,7 +84,8 @@ cloneQemu JSON Sample:
 ```
 
 cloneQemu cloud-init JSON Sample:
-```
+
+```json
 {
   "name": "cloudinit.test.com",
   "desc": "Test proxmox-api-go clone",
@@ -100,7 +98,6 @@ cloneQemu cloud-init JSON Sample:
   "nameserver": "8.8.8.8"
 }
 ```
-
 
 ### Cloud-init options
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,30 @@
+Vagrant.configure("2") do |config|
+    config.vm.box = "debian/buster64"
+
+    config.vm.boot_timeout = 1800
+    config.vm.synced_folder ".", "/vagrant", disabled: true
+
+    # forward proxmox API port
+    config.vm.network "forwarded_port",
+            guest: 8006,
+            host_ip: "127.0.0.1",
+            host: 8006
+
+    # install and configure proxmox
+    config.vm.provision "shell",
+            privileged: true,
+			path: './scripts/vagrant-bootstrap.sh'
+    
+    config.vm.provider :virtualbox do |vb|
+        vb.memory = 2048
+        vb.cpus = 2
+    end
+
+    config.vm.provider :libvirt do |v, override|
+        v.disk_bus = "virtio"
+        v.driver = "kvm"
+        v.video_vram = 8
+        v.memory = 2048
+        v.cpus = 2
+    end
+end

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/Telmate/proxmox-api-go
+
+go 1.14
+
+require github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,10 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
+github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/proxmox/client_test.go
+++ b/proxmox/client_test.go
@@ -1,0 +1,16 @@
+package proxmox
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClient_Login(t *testing.T) {
+	client, err := NewClient("https://localhost:8006/api2/json", nil, &tls.Config{InsecureSkipVerify: true})
+	assert.Nil(t, err)
+
+	err = client.Login("root@pam", "root", "")
+	assert.Nil(t, err)
+}

--- a/scripts/vagrant-bootstrap.sh
+++ b/scripts/vagrant-bootstrap.sh
@@ -4,11 +4,14 @@ export DEBIAN_FRONTEND=noninteractive
 
 # ensure required utilities are installed
 apt-get update
-apt-get install -y software-properties-common git make gnupg2
+apt-get install -y software-properties-common gnupg2
 
-# make sure the hostname can be resolved via /etc/hosts
+# make sure hostname can be resolved via /etc/hosts
+sed -i "/127.0.1.1/d" /etc/hosts
 PVE_IP=$(hostname -I | awk '{print $1}')
-sed -i "s/127.0.1.1/$PVE_IP/" /etc/hosts
+if [ -z "$(grep $PVE_IP /etc/hosts)" ]; then
+    echo "$PVE_IP $(hostname)" > /etc/hosts
+fi
 
 # add proxmox repository and its key
 apt-add-repository 'deb http://download.proxmox.com/debian/pve buster pve-no-subscription'

--- a/scripts/vagrant-bootstrap.sh
+++ b/scripts/vagrant-bootstrap.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+export DEBIAN_FRONTEND=noninteractive
+
+# ensure required utilities are installed
+apt-get update
+apt-get install -y software-properties-common git make gnupg2
+
+# make sure the hostname can be resolved via /etc/hosts
+PVE_IP=$(hostname -I | awk '{print $1}')
+sed -i "s/127.0.1.1/$PVE_IP/" /etc/hosts
+
+# add proxmox repository and its key
+apt-add-repository 'deb http://download.proxmox.com/debian/pve buster pve-no-subscription'
+wget -qO- http://download.proxmox.com/debian/proxmox-ve-release-6.x.gpg | apt-key add -
+
+# update repositories and system
+apt-get update
+apt-get full-upgrade
+
+# install proxmox packages
+apt-get install -y proxmox-ve postfix open-iscsi
+
+# don't scan for other operating systems
+apt-get remove -y os-prober
+
+# set root password so that we can use it to login to Proxmox API
+sudo -i passwd <<EOF
+root
+root
+EOF


### PR DESCRIPTION
Continuing from the ongoing discussion in #79 this is a first dig at running tests against a **real** Proxmox VE API.

It takes around 8 minutes to provision a vagrant box on Travis CI, but I think that's OK.

Vanilla proxmox environment can now be built just by typing:

```sh
vagrant up
```

Wait until the box is provisioned and then visit https://localhost:8006 (use root:root for logging in)

Would love some feedback on this! 🕵️‍♂️

/cc @carlpett 