### PR TITLE
added task timeout flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -16,13 +16,14 @@ func main() {
 	var insecure *bool
 	insecure = flag.Bool("insecure", false, "TLS insecure mode")
 	proxmox.Debug = flag.Bool("debug", false, "debug mode")
+	taskTimeout := flag.Int("timeout", 300, "api task timeout in seconds")
 	fvmid := flag.Int("vmid", -1, "custom vmid (instead of auto)")
 	flag.Parse()
 	tlsconf := &tls.Config{InsecureSkipVerify: true}
 	if !*insecure {
 		tlsconf = nil
 	}
-	c, _ := proxmox.NewClient(os.Getenv("PM_API_URL"), nil, tlsconf)
+	c, _ := proxmox.NewClient(os.Getenv("PM_API_URL"), nil, tlsconf, *taskTimeout)
 	err := c.Login(os.Getenv("PM_USER"), os.Getenv("PM_PASS"), os.Getenv("PM_OTP"))
 	if err != nil {
 		log.Fatal(err)

--- a/proxmox/client_test.go
+++ b/proxmox/client_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestClient_Login(t *testing.T) {
-	client, err := NewClient("https://localhost:8006/api2/json", nil, &tls.Config{InsecureSkipVerify: true})
+	client, err := NewClient("https://localhost:8006/api2/json", nil, &tls.Config{InsecureSkipVerify: true}, 300)
 	assert.Nil(t, err)
 
 	err = client.Login("root@pam", "root", "")


### PR DESCRIPTION
Adding a flag to set the task timeout for proxmox API calls. I noticed an issue with API calls timing out when cloning templates that where located on slow disks so increasing the timeout for some tasks would be very helpful.

This is my first time writing any go so if I messed anything up just let me know 😄 