### PR TITLE
Added ability to parse IPv6 addresses with zone indices

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -232,7 +232,7 @@ func (c *Client) GetVmSpiceProxy(vmr *VmRef) (vmSpiceProxy map[string]interface{
 
 type AgentNetworkInterface struct {
 	MACAddress  string
-	IPAddresses []net.IP
+	IPAddresses []net.IPAddr
 	Name        string
 	Statistics  map[string]int64
 }
@@ -253,9 +253,9 @@ func (a *AgentNetworkInterface) UnmarshalJSON(b []byte) error {
 		return err
 	}
 
-	a.IPAddresses = make([]net.IP, len(intermediate.IPAddresses))
+	a.IPAddresses = make([]net.IPAddr, len(intermediate.IPAddresses))
 	for idx, ip := range intermediate.IPAddresses {
-		a.IPAddresses[idx] = net.ParseIP(ip.IPAddress)
+        a.IPAddresses[idx] = net.ParseIPZone(ip.IPAddress)
 		if a.IPAddresses[idx] == nil {
 			return fmt.Errorf("Could not parse %s as IP", ip.IPAddress)
 		}


### PR DESCRIPTION
If a VM has an interface that has an IPv6 address with a zone index, the API is not able to parse the address and fails when calling `AgentNetworkInterface`.

This is because `ParseIP` is used to parse the IP returned by Proxmox. By replacing that with `ParseIPZone`, scoped literal IPv6 addresses could be parsed correctly.

I changed the type to IPAddr, a struct of IP and a string for the zone.

I'm not sure if the changes that I made are correct. I'm really new to golang and creating PRs so any feedback is welcome.