### PR TITLE
Fixing typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ cloneQemu cloud-init JSON Sample:
   "cores": 2,
   "sockets": 1,
   "ipconfig0": "gw=10.0.2.2,ip=10.0.2.17/24",
-  "sshkey" : "...",
+  "sshkeys" : "...",
   "nameserver": "8.8.8.8"
 }
 ```


### PR DESCRIPTION
There is a typo inside the given cloud-init example. You're still using the singular key "sshkey" (which is not working) instead of the working plural key called "sshkeys".