### PR TITLE
implement disk "format" and "storage_type" fetch from API

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -226,6 +226,18 @@ func (c *Client) GetStorageStatus(vmr *VmRef, storageName string) (storageStatus
 	return
 }
 
+func (c *Client) GetStorageContent(vmr *VmRef, storageName string) (data map[string]interface{}, err error) {
+	url := fmt.Sprintf("/nodes/%s/storage/%s/content", vmr.node, storageName)
+	err = c.GetJsonRetryable(url, &data, 3)
+	if err != nil {
+		return nil, err
+	}
+	if data["data"] == nil {
+		return nil, errors.New("Storage Content not readable")
+	}
+	return
+}
+
 func (c *Client) GetVmSpiceProxy(vmr *VmRef) (vmSpiceProxy map[string]interface{}, err error) {
 	err = c.CheckVmRef(vmr)
 	if err != nil {

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -212,6 +212,20 @@ func (c *Client) GetVmConfig(vmr *VmRef) (vmConfig map[string]interface{}, err e
 	return
 }
 
+func (c *Client) GetStorageStatus(vmr *VmRef, storageName string) (storageStatus map[string]interface{}, err error) {
+	var data map[string]interface{}
+	url := fmt.Sprintf("/nodes/%s/storage/%s/status", vmr.node, storageName)
+	err = c.GetJsonRetryable(url, &data, 3)
+	if err != nil {
+		return nil, err
+	}
+	if data["data"] == nil {
+		return nil, errors.New("Storage STATUS not readable")
+	}
+	storageStatus = data["data"].(map[string]interface{})
+	return
+}
+
 func (c *Client) GetVmSpiceProxy(vmr *VmRef) (vmSpiceProxy map[string]interface{}, err error) {
 	err = c.CheckVmRef(vmr)
 	if err != nil {

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -213,6 +213,10 @@ func (c *Client) GetVmConfig(vmr *VmRef) (vmConfig map[string]interface{}, err e
 }
 
 func (c *Client) GetStorageStatus(vmr *VmRef, storageName string) (storageStatus map[string]interface{}, err error) {
+	err = c.CheckVmRef(vmr)
+	if err != nil {
+		return nil, err
+	}
 	var data map[string]interface{}
 	url := fmt.Sprintf("/nodes/%s/storage/%s/status", vmr.node, storageName)
 	err = c.GetJsonRetryable(url, &data, 3)
@@ -227,6 +231,10 @@ func (c *Client) GetStorageStatus(vmr *VmRef, storageName string) (storageStatus
 }
 
 func (c *Client) GetStorageContent(vmr *VmRef, storageName string) (data map[string]interface{}, err error) {
+	err = c.CheckVmRef(vmr)
+	if err != nil {
+		return nil, err
+	}
 	url := fmt.Sprintf("/nodes/%s/storage/%s/content", vmr.node, storageName)
 	err = c.GetJsonRetryable(url, &data, 3)
 	if err != nil {

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -392,7 +392,7 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 	}
 	tags := ""
 	if _, isSet := vmConfig["tags"]; isSet {
-	    tags = vmConfig["tags"].(string)
+		tags = vmConfig["tags"].(string)
 	}
 	bios := "seabios"
 	if _, isSet := vmConfig["bios"]; isSet {
@@ -555,10 +555,30 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 		id := rxDeviceID.FindStringSubmatch(diskName)
 		diskID, _ := strconv.Atoi(id[0])
 		diskType := rxDiskType.FindStringSubmatch(diskName)[0]
-		storageName, fileName := ParseSubConf(diskConfList[0], ":")
+		filePath := diskConfList[0]
+		storageName, fileName := ParseSubConf(filePath, ":")
+
+		storageContent, err := client.GetStorageContent(vmr, storageName)
+		if err != nil {
+			log.Fatal(err)
+			return nil, err
+		}
+		var storageFormat string
+		contents := storageContent["data"].([]interface{})
+		for content := range contents {
+			storageContentMap := contents[content].(map[string]interface{})
+			if storageContentMap["volid"] == filePath {
+				storageFormat = storageContentMap["format"].(string)
+				break
+			}
+		}
 
 		var storageStatus map[string]interface{}
 		storageStatus, err = client.GetStorageStatus(vmr, storageName)
+		if err != nil {
+			log.Fatal(err)
+			return nil, err
+		}
 		storageType := storageStatus["type"]
 		//
 		diskConfMap := QemuDevice{
@@ -567,6 +587,7 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 			"storage":      storageName,
 			"file":         fileName,
 			"storage_type": storageType,
+			"format":       storageFormat,
 		}
 
 		// Add rest of device config.

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -557,12 +557,16 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 		diskType := rxDiskType.FindStringSubmatch(diskName)[0]
 		storageName, fileName := ParseSubConf(diskConfList[0], ":")
 
+		var storageStatus map[string]interface{}
+		storageStatus, err = client.GetStorageStatus(vmr, storageName)
+		storageType := storageStatus["type"]
 		//
 		diskConfMap := QemuDevice{
-			"id":      diskID,
-			"type":    diskType,
-			"storage": storageName,
-			"file":    fileName,
+			"id":           diskID,
+			"type":         diskType,
+			"storage":      storageName,
+			"file":         fileName,
+			"storage_type": storageType,
 		}
 
 		// Add rest of device config.


### PR DESCRIPTION
This is to support `terraform import` to populate with actual disk parameters, right now both "format" and "storage_type" are only assigned on Create and Update.
PS: Yes, there are 2 additional API calls :) but not sure if it can be simplified.