### PR TITLE
converting nic's firewall integers to bool

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -645,6 +645,11 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 		if err != nil {
 			log.Printf("[ERROR] %q", err)
 		}
+		if nicConfMap["firewall"] == 1 {
+			nicConfMap["firewall"] = true
+		} else if nicConfMap["firewall"] == 0 {
+			nicConfMap["firewall"] = false
+		}
 
 		// And device config to networks.
 		if len(nicConfMap) > 0 {


### PR DESCRIPTION
This solves errors like `Error: network.0.firewall: '' expected type 'bool', got unconvertible type 'int'` when importing existing configuration (since Proxmox responds with integers for this configuration and terraform expects Boolean, see scheme).