### PR TITLE
fix disk recreating when Proxmox converts disk size from 1024G to 1T

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -598,8 +598,14 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 		diskConfMap["storage"] = storageName
 		diskConfMap["file"] = fileName
 
-		storageContent, err := client.GetStorageContent(vmr, storageName)
+		filePath := diskConfMap["volume"]
 
+		// Get disk format
+		storageContent, err := client.GetStorageContent(vmr, storageName)
+		if err != nil {
+			log.Fatal(err)
+			return nil, err
+		}
 		var storageFormat string
 		contents := storageContent["data"].([]interface{})
 		for content := range contents {
@@ -609,7 +615,9 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 				break
 			}
 		}
+		diskConfMap["format"] = storageFormat
 
+		// Get storage type for disk
 		var storageStatus map[string]interface{}
 		storageStatus, err = client.GetStorageStatus(vmr, storageName)
 		if err != nil {
@@ -619,7 +627,6 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 		storageType := storageStatus["type"]
 
 		diskConfMap["storage_type"] = storageType
-		diskConfMap["format"] = storageFormat
 
 		// Convert to gigabytes if disk size was received in terabytes
 		sizeIsInTerabytes, err := regexp.MatchString("[0-9]+T", diskConfMap["size"].(string))

--- a/proxmox/util.go
+++ b/proxmox/util.go
@@ -91,12 +91,14 @@ func DiskSizeGB(dcSize interface{}) float64 {
 
 		if len(diskArray) >= 3 {
 			switch diskArray[2] {
+			case "T", "TB":
+				diskSize *= 1024
 			case "G", "GB":
 				//Nothing to do
 			case "M", "MB":
-				diskSize /= 1000
+				diskSize /= 1024
 			case "K", "KB":
-				diskSize /= 1000000
+				diskSize /= 1048576
 			}
 		}
 	case float64:


### PR DESCRIPTION
When creating disk with 1024G size, Proxmox saves it as 1T and trying to apply the same resource leads to disk size update. See this issues: https://github.com/Telmate/terraform-provider-proxmox/issues/247

This PR should fix it, though was not tested properly.