### PR TITLE
Allow token authentication

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -93,6 +93,18 @@ func NewClient(apiUrl string, hclient *http.Client, tls *tls.Config, taskTimeout
 	return client, err
 }
 
+// SetAPIToken specifies a pair of user identifier and token UUID to use
+// for authenticating API calls.
+// If this is set, a ticket from calling `Login` will not be used.
+//
+// - `userID` is expected to be in the form `USER@REALM!TOKENID`
+// - `token` is just the UUID you get when initially creating the token
+//
+// See https://pve.proxmox.com/wiki/User_Management#pveum_tokens
+func (c *Client) SetAPIToken(userID, token string) {
+	c.session.SetAPIToken(userID, token)
+}
+
 func (c *Client) Login(username string, password string, otp string) (err error) {
 	c.Username = username
 	c.Password = password


### PR DESCRIPTION
Proxmox allows people to create API tokens with limited privileges that can be rotated without deleting a user account. It is usually useful for giving automated systems specific access to parts of the Proxmox API, e.g. a single VM resource pool.

> API tokens allow stateless access to most parts of the REST API by another system, software or API client. Tokens can be generated for individual users and can be given separate permissions and expiration dates to limit the scope and duration of the access. Should the API token get compromised it can be revoked without disabling the user itself.
> _https://pve.proxmox.com/wiki/User_Management#pveum_tokens_

The current authentication flow used for the Proxmox client is not compatible though:
> `POST /api2/json/access/ticket`
> This API endpoint is not available for API tokens.
> _https://pve.proxmox.com/pve-docs/api-viewer/#/access/ticket (POST tab)_

Instead the required auth flow for API tokens is described here:
> To use an API token, set the HTTP header Authorization to the displayed value of the form `PVEAPIToken=USER@REALM!TOKENID=UUID` when making API requests
> _https://pve.proxmox.com/wiki/User_Management#pveum_tokens_

---

Adds a new method `SetAPIToken` on the `Client` and `Session` to use this method.

_Related to https://github.com/hashicorp/packer/pull/10797_