### PR TITLE
fix crash when cloud-init disk have missing size

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -628,6 +628,11 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 
 		diskConfMap["storage_type"] = storageType
 
+		// cloud-init disks not always have the size sent by the API, which results in a crash
+		if diskConfMap["size"] == nil && strings.Contains(fileName.(string), "cloudinit") {
+			diskConfMap["size"] = "4M" // default cloud-init disk size
+		}
+
 		// Convert to gigabytes if disk size was received in terabytes
 		sizeIsInTerabytes, err := regexp.MatchString("[0-9]+T", diskConfMap["size"].(string))
 		if err != nil {


### PR DESCRIPTION
There were some changes Proxmox side which resulted a missing `size` parameter in the API, and caused the application (and the provider using it) to crash.

My changes: the application now checks if the disk size is `nil` or not, and when it is then it sets the default cloud-init disk size if the disk is indeed a cloud-init one (by checking the filename).

PVE 6.3-6, cloud-init disk as `scsi2`