### PR TITLE
Fixes #111 by splitting IPv6 at the zone delimiter

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -301,7 +301,7 @@ func (a *AgentNetworkInterface) UnmarshalJSON(b []byte) error {
 
 	a.IPAddresses = make([]net.IP, len(intermediate.IPAddresses))
 	for idx, ip := range intermediate.IPAddresses {
-		a.IPAddresses[idx] = net.ParseIP(ip.IPAddress)
+		a.IPAddresses[idx] = net.ParseIP((strings.Split(ip.IPAddress, "%"))[0])
 		if a.IPAddresses[idx] == nil {
 			return fmt.Errorf("Could not parse %s as IP", ip.IPAddress)
 		}


### PR DESCRIPTION
When the Qemu guest agent returns IPv6 link local address for Windows guest the IP cannot be parsed.
Quickest fix is to split all ip addresses at the zone delimiter "%" so a proper IPv6 address is returned.