### PR TITLE
Fix type variable return for `link_down`

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -731,6 +731,11 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 		} else if nicConfMap["firewall"] == 0 {
 			nicConfMap["firewall"] = false
 		}
+		if nicConfMap["link_down"] == 1 {
+			nicConfMap["link_down"] = true
+		} else if nicConfMap["link_down"] == 0 {
+			nicConfMap["link_down"] = false
+		}
 
 		// And device config to networks.
 		if len(nicConfMap) > 0 {


### PR DESCRIPTION
Hi! This solves errors like Error: network.0.link_down: '' expected type 'bool', got unconvertible type 'int' when importing existing configuration (since Proxmox responds with integers for this configuration and terraform expects Boolean, see scheme). #103 