### PR TITLE
Added "args" parameter for passing arbitrary arguments to kvm.

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -56,6 +56,7 @@ type ConfigQemu struct {
 	QemuSerials     QemuDevices `json:"serial,omitempty"`
 	HaState         string      `json:"hastate,omitempty"`
 	Tags            string      `json:"tags"`
+	Args            string      `json:"args"`
 
 	// Deprecated single disk.
 	DiskSize    float64 `json:"diskGB"`
@@ -107,6 +108,7 @@ func (config ConfigQemu) CreateVm(vmr *VmRef, client *Client) (err error) {
 		"boot":        config.Boot,
 		"description": config.Description,
 		"tags":        config.Tags,
+		"args":        config.Args,
 	}
 
 	if config.Bios != "" {
@@ -230,6 +232,7 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 		"name":        config.Name,
 		"description": config.Description,
 		"tags":        config.Tags,
+		"args":        config.Args,
 		"onboot":      config.Onboot,
 		"agent":       config.Agent,
 		"sockets":     config.QemuSockets,
@@ -429,6 +432,11 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 	if _, isSet := vmConfig["tags"]; isSet {
 		tags = vmConfig["tags"].(string)
 	}
+        args := ""
+        if _, isSet := vmConfig["args"]; isSet {
+                tags = vmConfig["args"].(string)
+        }
+
 	bios := "seabios"
 	if _, isSet := vmConfig["bios"]; isSet {
 		bios = vmConfig["bios"].(string)
@@ -511,6 +519,7 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 		Name:            name,
 		Description:     strings.TrimSpace(description),
 		Tags:            strings.TrimSpace(tags),
+		Args:            strings.TrimSpace(args),
 		Bios:            bios,
 		Onboot:          onboot,
 		Agent:           agent,


### PR DESCRIPTION
Hi all,

Would like to add the args parameter. This would enable passing arbitrary arguments to KVM..
My personal use case is enabling ignition for a flatcar linux template. An example value for the args parameter to enable ignition would be the following:  "-fw_cfg name=opt/org.flatcar-linux/config,file=/var/lib/vz/snippets/flatcar.ign".
This is my first bit of go code. Hope I got it right. Cheers!

Theo