### PR TITLE
Fixes #104 - Fix delete issue caused by []byte marshall

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -493,7 +493,14 @@ func (c *Client) DeleteVmParams(vmr *VmRef, params map[string]interface{}) (exit
 	reqbody := ParamsToBody(params)
 	url := fmt.Sprintf("/nodes/%s/%s/%d", vmr.node, vmr.vmType, vmr.vmId)
 	var taskResponse map[string]interface{}
-	_, err = c.session.RequestJSON("DELETE", url, nil, nil, &reqbody, &taskResponse)
+	if len(reqbody) != 0 {
+		_, err = c.session.RequestJSON("DELETE", url, nil, nil, &reqbody, &taskResponse)
+	} else {
+		_, err = c.session.RequestJSON("DELETE", url, nil, nil, nil, &taskResponse)
+	}
+	if err != nil {
+		return
+	}
 	exitStatus, err = c.WaitForCompletion(taskResponse)
 	return
 }


### PR DESCRIPTION
Based on suggested fix in #104

Delete's would not work properly because of the way the params were
passed through. If an empty list of params was passed, it would actually
Marshall that to a byte string like [34 34]

This is representative of '""' in the body of a curl http call. The
delete function requires no params so this may really be oboslete, but
this is a good workaround for now.