### PR TITLE
LXC Container HA state support

### DIFF
--- a/proxmox/config_lxc.go
+++ b/proxmox/config_lxc.go
@@ -317,6 +317,9 @@ func (config ConfigLxc) CreateLxc(vmr *VmRef, client *Client) (err error) {
 	// amend vmid
 	paramMap["vmid"] = vmr.vmId
 
+	// hastate is special
+	delete(paramMap, "hastate")
+
 	exitStatus, err := client.CreateLxcContainer(vmr.node, paramMap)
 	if err != nil {
 		params, _ := json.Marshal(&paramMap)

--- a/proxmox/config_lxc.go
+++ b/proxmox/config_lxc.go
@@ -317,9 +317,6 @@ func (config ConfigLxc) CreateLxc(vmr *VmRef, client *Client) (err error) {
 	// amend vmid
 	paramMap["vmid"] = vmr.vmId
 
-	// hastate is special
-	delete(paramMap, "hastate")
-
 	exitStatus, err := client.CreateLxcContainer(vmr.node, paramMap)
 	if err != nil {
 		params, _ := json.Marshal(&paramMap)
@@ -428,6 +425,9 @@ func (config ConfigLxc) mapToAPIParams() map[string]interface{} {
 	delete(paramMap, "networks")
 	delete(paramMap, "mountpoints")
 	delete(paramMap, "unused")
+
+	// also delete the hastate key which is used elsewhere
+	delete(paramMap, "hastate")
 
 	return paramMap
 }

--- a/proxmox/config_lxc.go
+++ b/proxmox/config_lxc.go
@@ -325,7 +325,7 @@ func (config ConfigLxc) CreateLxc(vmr *VmRef, client *Client) (err error) {
 
 	_, err = client.UpdateVMHA(vmr, config.HaState)
 	if err != nil {
-		log.Printf("[ERROR] %q", err)
+		return fmt.Errorf("[ERROR] %q", err)
 	}
 
 	return
@@ -346,13 +346,13 @@ func (config ConfigLxc) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 	// also, error "500 unable to modify read-only option: 'unprivileged'"
 	delete(paramMap, "unprivileged")
 
-	_, err = client.SetLxcConfig(vmr, paramMap)
-	return err
-
 	_, err = client.UpdateVMHA(vmr, config.HaState)
 	if err != nil {
-		log.Printf("[ERROR] %q", err)
+		return err
 	}
+
+	_, err = client.SetLxcConfig(vmr, paramMap)
+	return err
 }
 
 func ParseLxcDisk(diskStr string) QemuDevice {


### PR DESCRIPTION
This closes #125 by extending the existing support for setting HA state on VMs to LXC containers.

This change reuses the existing UpdateVMHA function and adds the necessary parameters to the LXC side of the code.