### PR TITLE
retrieve all VMs by name (not only first)

### DIFF
--- a/main.go
+++ b/main.go
@@ -180,17 +180,39 @@ func main() {
 
 	case "listQemuSnapshot":
 		sourceVmr, err := c.GetVmRefByName(flag.Args()[1])
-		jbody, _, err = c.ListQemuSnapshot(sourceVmr)
-		if rec, ok := jbody.(map[string]interface{}); ok {
-			temp := rec["data"].([]interface{})
-			for _, val := range temp {
-				snapshotName := val.(map[string]interface{})
-				if snapshotName["name"] != "current" {
-					fmt.Println(snapshotName["name"])
+		if err == nil {
+			jbody, _, err = c.ListQemuSnapshot(sourceVmr)
+			if rec, ok := jbody.(map[string]interface{}); ok {
+				temp := rec["data"].([]interface{})
+				for _, val := range temp {
+					snapshotName := val.(map[string]interface{})
+					if snapshotName["name"] != "current" {
+						fmt.Println(snapshotName["name"])
+					}
+				}
+			} else {
+				fmt.Printf("record not a map[string]interface{}: %v\n", jbody)
+			}
+		}
+		failError(err)
+
+	case "listQemuSnapshot2":
+		sourceVmrs, err := c.GetVmRefsByName(flag.Args()[1])
+		if err == nil {
+			for _, sourceVmr := range sourceVmrs {
+				jbody, _, err = c.ListQemuSnapshot(sourceVmr)
+				if rec, ok := jbody.(map[string]interface{}); ok {
+					temp := rec["data"].([]interface{})
+					for _, val := range temp {
+						snapshotName := val.(map[string]interface{})
+						if snapshotName["name"] != "current" {
+							fmt.Printf("%d@%s:%s\n", sourceVmr.VmId(), sourceVmr.Node(), snapshotName["name"])
+						}
+					}
+				} else {
+					fmt.Printf("record not a map[string]interface{}: %v\n", jbody)
 				}
 			}
-		} else {
-			fmt.Printf("record not a map[string]interface{}: %v\n", jbody)
 		}
 		failError(err)
 


### PR DESCRIPTION
This commit brings API to fetch all VMs matching specified name. It adds additional
method Client.GetVmRefsByName in addition to GetVmRefByName.

The background is that it's possible to create several templates in ProxMox
on different nodes with same name. Packer provider uses GetVmRefByName to
retrieve VM ID for cloning, but it may return unexpected VM ID. As result, cloning
will fail with error, for example:
   "500 can't clone VM to node '...' (VM uses local storage)"

Let's add way to fetch all VMs matching specified name for further filtering.

Also it brings extra command 'listQemuSnapshot2'