### PR TITLE
Fixed DeleteVmParams

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -503,11 +503,11 @@ func (c *Client) DeleteVmParams(vmr *VmRef, params map[string]interface{}) (exit
 		}
 	}
 
-	reqbody := ParamsToBody(params)
+	values := ParamsToValues(params)
 	url := fmt.Sprintf("/nodes/%s/%s/%d", vmr.node, vmr.vmType, vmr.vmId)
 	var taskResponse map[string]interface{}
-	if len(reqbody) != 0 {
-		_, err = c.session.RequestJSON("DELETE", url, nil, nil, &reqbody, &taskResponse)
+	if len(values) != 0 {
+		_, err = c.session.RequestJSON("DELETE", url, &values, nil, nil, &taskResponse)
 	} else {
 		_, err = c.session.RequestJSON("DELETE", url, nil, nil, nil, &taskResponse)
 	}

--- a/proxmox/session.go
+++ b/proxmox/session.go
@@ -74,6 +74,28 @@ func ParamsToBody(params map[string]interface{}) (body []byte) {
 	return
 }
 
+func ParamsToValues(params map[string]interface{}) (vals url.Values) {
+	vals = url.Values{}
+	for k, intrV := range params {
+		var v string
+		switch intrV.(type) {
+		// Convert true/false bool to 1/0 string where Proxmox API can understand it.
+		case bool:
+			if intrV.(bool) {
+				v = "1"
+			} else {
+				v = "0"
+			}
+		default:
+			v = fmt.Sprintf("%v", intrV)
+		}
+		if v != "" {
+			vals.Set(k, v)
+		}
+	}
+	return
+}
+
 func decodeResponse(resp *http.Response, v interface{}) error {
 	if resp.Body == nil {
 		return nil

--- a/proxmox/session.go
+++ b/proxmox/session.go
@@ -52,24 +52,7 @@ func NewSession(apiUrl string, hclient *http.Client, tls *tls.Config) (session *
 }
 
 func ParamsToBody(params map[string]interface{}) (body []byte) {
-	vals := url.Values{}
-	for k, intrV := range params {
-		var v string
-		switch intrV.(type) {
-		// Convert true/false bool to 1/0 string where Proxmox API can understand it.
-		case bool:
-			if intrV.(bool) {
-				v = "1"
-			} else {
-				v = "0"
-			}
-		default:
-			v = fmt.Sprintf("%v", intrV)
-		}
-		if v != "" {
-			vals.Set(k, v)
-		}
-	}
+	vals := ParamsToValues(params)
 	body = bytes.NewBufferString(vals.Encode()).Bytes()
 	return
 }


### PR DESCRIPTION
The delete path expects parameters to be URL values, not contained within the body. Passing any body values to the DELETE path returns "501 Unexpected content for method 'DELETE'"

Updated DeleteVmParams to use a new function ParamsToValues which is the exact same as ParamsToBody with no conversion to []byte.
ParamsToBody now calls ParamsToValues and converts to []byte
