### PR TITLE
Allow explicit empty parameters in request parameters

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -1404,7 +1404,7 @@ func (c *Client) UpdatePoolComment(poolid string, comment string) error {
 		"comment": comment,
 	}
 
-	reqbody := ParamsToBody(paramMap)
+	reqbody := ParamsToBodyWithEmpty(paramMap, []string{"comment"})
 	url := fmt.Sprintf("/pools/%s", poolid)
 	_, err := c.session.Put(url, nil, nil, &reqbody)
 	if err != nil {

--- a/proxmox/session.go
+++ b/proxmox/session.go
@@ -52,12 +52,23 @@ func NewSession(apiUrl string, hclient *http.Client, tls *tls.Config) (session *
 }
 
 func ParamsToBody(params map[string]interface{}) (body []byte) {
-	vals := ParamsToValues(params)
+	vals := ParamsToValuesWithEmpty(params, []string{})
 	body = bytes.NewBufferString(vals.Encode()).Bytes()
 	return
 }
 
 func ParamsToValues(params map[string]interface{}) (vals url.Values) {
+	vals = ParamsToValuesWithEmpty(params, []string{})
+	return
+}
+
+func ParamsToBodyWithEmpty(params map[string]interface{}, allowedEmpty []string) (body []byte) {
+	vals := ParamsToValuesWithEmpty(params, allowedEmpty)
+	body = bytes.NewBufferString(vals.Encode()).Bytes()
+	return
+}
+
+func ParamsToValuesWithEmpty(params map[string]interface{}, allowedEmpty []string) (vals url.Values) {
 	vals = url.Values{}
 	for k, intrV := range params {
 		var v string
@@ -72,7 +83,7 @@ func ParamsToValues(params map[string]interface{}) (vals url.Values) {
 		default:
 			v = fmt.Sprintf("%v", intrV)
 		}
-		if v != "" {
+		if v != "" || inArray(allowedEmpty, k) {
 			vals.Set(k, v)
 		}
 	}

--- a/proxmox/session_test.go
+++ b/proxmox/session_test.go
@@ -1,0 +1,90 @@
+package proxmox
+
+import (
+	"testing"
+)
+
+func TestParamsTo(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  map[string]interface{}
+		output []string
+	}{{
+		name: "basic_values",
+		input: map[string]interface{}{
+			"poolid": "test",
+		},
+		output: []string{"poolid=test"},
+	}, {
+		name: "multiple_values",
+		input: map[string]interface{}{
+			"poolid":  "test",
+			"comment": "comment",
+		},
+		output: []string{"poolid=test&comment=comment", "comment=comment&poolid=test"},
+	}, {
+		name: "empty_values_are_removed",
+		input: map[string]interface{}{
+			"poolid":  "test",
+			"comment": "",
+		},
+		output: []string{"poolid=test"},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(*testing.T) {
+			output := string(ParamsToBody(test.input))
+			if !inArray(test.output, output) {
+				t.Errorf("%s: expected `%+v`, got `%+v`",
+					test.name, test.output, output)
+			}
+		})
+	}
+}
+
+func TestParamsToWithEmpty(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        map[string]interface{}
+		allowedEmpty []string
+		output       []string
+	}{{
+		name: "basic_values",
+		input: map[string]interface{}{
+			"poolid": "test",
+		},
+		output: []string{"poolid=test"},
+	}, {
+		name: "multiple_values",
+		input: map[string]interface{}{
+			"poolid":  "test",
+			"comment": "comment",
+		},
+		output: []string{"poolid=test&comment=comment", "comment=comment&poolid=test"},
+	}, {
+		name: "empty_values_are_removed",
+		input: map[string]interface{}{
+			"poolid":  "test",
+			"comment": "",
+		},
+		output: []string{"poolid=test"},
+	}, {
+		name: "explicit_empty_values_are_not_removed",
+		input: map[string]interface{}{
+			"poolid":  "test",
+			"comment": "",
+		},
+		allowedEmpty: []string{"comment"},
+		output:       []string{"poolid=test&comment=", "comment=&poolid=test"},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(*testing.T) {
+			output := string(ParamsToBodyWithEmpty(test.input, test.allowedEmpty))
+			if !inArray(test.output, output) {
+				t.Errorf("%s: expected `%+v`, got `%+v`",
+					test.name, test.output, output)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Sometimes, it may be useful to allow for empty parameters in the requests.

The example that I'm finding is to allow removing the comment from a pool, but I'm sure it will be useful in other places.