### PR TITLE
LXC mountpoint boolean flag conversion

### DIFF
--- a/proxmox/config_lxc.go
+++ b/proxmox/config_lxc.go
@@ -181,6 +181,8 @@ func NewConfigLxcFromApi(vmr *VmRef, client *Client) (config *ConfigLxc, err err
 		mpID, _ := strconv.Atoi(id[0])
 		mpConfMap["slot"] = mpID
 
+		mpConfMap["backup"] = mpConfMap["backup"] != 0
+
 		// prepare empty mountpoint map
 		if config.Mountpoints == nil {
 			config.Mountpoints = QemuDevices{}
@@ -218,11 +220,7 @@ func NewConfigLxcFromApi(vmr *VmRef, client *Client) (config *ConfigLxc, err err
 		// add rest of device config
 		nicConfMap.readDeviceConfig(nicConfList)
 
-		if nicConfMap["firewall"] == 1 {
-			nicConfMap["firewall"] = true
-		} else if nicConfMap["firewall"] == 0 {
-			nicConfMap["firewall"] = false
-		}
+		nicConfMap["firewall"] = nicConfMap["firewall"] != 0
 
 		// prepare empty network map
 		if config.Networks == nil {

--- a/proxmox/config_lxc.go
+++ b/proxmox/config_lxc.go
@@ -181,7 +181,13 @@ func NewConfigLxcFromApi(vmr *VmRef, client *Client) (config *ConfigLxc, err err
 		mpID, _ := strconv.Atoi(id[0])
 		mpConfMap["slot"] = mpID
 
-		mpConfMap["backup"] = mpConfMap["backup"] != 0
+		// 5 potential boolean flags need to be converted
+		for _, key := range []string{"acl", "backup", "quota", "replicate", "shared"} {
+			// if flag is set, need to convert int to bool
+			if _, isSet := mpConfMap[key]; isSet {
+				mpConfMap[key] = Itob(mpConfMap[key].(int))
+			}
+		}
 
 		// prepare empty mountpoint map
 		if config.Mountpoints == nil {
@@ -220,7 +226,10 @@ func NewConfigLxcFromApi(vmr *VmRef, client *Client) (config *ConfigLxc, err err
 		// add rest of device config
 		nicConfMap.readDeviceConfig(nicConfList)
 
-		nicConfMap["firewall"] = nicConfMap["firewall"] != 0
+		// if firewall flag is set, need to convert int to bool
+		if _, isSet := nicConfMap["firewall"]; isSet {
+			nicConfMap["firewall"] = Itob(nicConfMap["firewall"].(int))
+		}
 
 		// prepare empty network map
 		if config.Networks == nil {


### PR DESCRIPTION
There is an issue with fetching LXC configs with certain boolean flags set because the Proxmox API represents boolean flags as an integer.  This has manifested in several places, including network configs as illustrated in #97, #113 and other PRs.

I encountered this issue when attempting to create an LXC with the Proxmox Terraform provider.  When a mountpoint's backup flag is set to true, the creation succeeds but Terraform fails to read in the new resource state due to a type conversion error.

```
│ Error: mountpoint.0.backup: '' expected type 'bool', got unconvertible type 'int'
│
│   with proxmox_lxc.testlxc,
│   on main.tf line 30, in resource "proxmox_lxc" "testlxc":
│   30: resource "proxmox_lxc" "testlxc" {
```

This patch adds a loop to perform Itob conversion for 5 possible boolean flags encountered in the mountpoint config.  For the sake of consistency, I also updated the NIC config firewall flag to use the same Itob conversion.

After recompiling this module and the Terraform Proxmox provider with the fix, I was able to successfully create an LXC with the 5 affected flags set.