### PR TITLE
Implement HA Group setting

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -43,6 +43,7 @@ type VmRef struct {
 	pool    string
 	vmType  string
 	haState string
+	haGroup string
 }
 
 func (vmr *VmRef) SetNode(node string) {
@@ -77,6 +78,10 @@ func (vmr *VmRef) Pool() string {
 
 func (vmr *VmRef) HaState() string {
 	return vmr.haState
+}
+
+func (vmr *VmRef) HaGroup() string {
+	return vmr.haGroup
 }
 
 func NewVmRef(vmId int) (vmr *VmRef) {
@@ -1357,9 +1362,9 @@ func (c *Client) UpdateVMPool(vmr *VmRef, pool string) (exitStatus interface{}, 
 	return
 }
 
-func (c *Client) UpdateVMHA(vmr *VmRef, haState string) (exitStatus interface{}, err error) {
-	// Same hastate
-	if vmr.haState == haState {
+func (c *Client) UpdateVMHA(vmr *VmRef, haState string, haGroup string) (exitStatus interface{}, err error) {
+	// Same hastate & hagroup
+	if vmr.haState == haState && vmr.haGroup == haGroup {
 		return
 	}
 
@@ -1382,6 +1387,9 @@ func (c *Client) UpdateVMHA(vmr *VmRef, haState string) (exitStatus interface{},
 		paramMap := map[string]interface{}{
 			"sid": vmr.vmId,
 		}
+		if haGroup != "" {
+			paramMap["group"] = haGroup
+		}
 		reqbody := ParamsToBody(paramMap)
 		resp, err := c.session.Post("/cluster/ha/resources", nil, nil, &reqbody)
 		if err == nil {
@@ -1400,6 +1408,7 @@ func (c *Client) UpdateVMHA(vmr *VmRef, haState string) (exitStatus interface{},
 	//Set wanted state
 	paramMap := map[string]interface{}{
 		"state": haState,
+		"group": haGroup,
 	}
 	reqbody := ParamsToBody(paramMap)
 	url := fmt.Sprintf("/cluster/ha/resources/%d", vmr.vmId)

--- a/proxmox/config_lxc.go
+++ b/proxmox/config_lxc.go
@@ -25,6 +25,7 @@ type ConfigLxc struct {
 	Force              bool        `json:"force,omitempty"`
 	Full               bool        `json:"full,omitempty"`
 	HaState            string      `json:"hastate,omitempty"`
+	HaGroup            string      `json:"hagroup,omitempty"`
 	Hookscript         string      `json:"hookscript,omitempty"`
 	Hostname           string      `json:"hostname,omitempty"`
 	IgnoreUnpackErrors bool        `json:"ignore-unpack-errors,omitempty"`
@@ -334,7 +335,7 @@ func (config ConfigLxc) CreateLxc(vmr *VmRef, client *Client) (err error) {
 		return fmt.Errorf("Error creating LXC container: %v, error status: %s (params: %v)", err, exitStatus, string(params))
 	}
 
-	_, err = client.UpdateVMHA(vmr, config.HaState)
+	_, err = client.UpdateVMHA(vmr, config.HaState, config.HaGroup)
 	if err != nil {
 		return fmt.Errorf("[ERROR] %q", err)
 	}
@@ -383,7 +384,7 @@ func (config ConfigLxc) CloneLxc(vmr *VmRef, client *Client) (err error) {
 		return fmt.Errorf("Error cloning LXC container: %v, error status: %s (params: %v)", err, exitStatus, string(params))
 	}
 
-	_, err = client.UpdateVMHA(vmr, config.HaState)
+	_, err = client.UpdateVMHA(vmr, config.HaState, config.HaGroup)
 	if err != nil {
 		return fmt.Errorf("[ERROR] %q", err)
 	}
@@ -406,7 +407,7 @@ func (config ConfigLxc) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 	// also, error "500 unable to modify read-only option: 'unprivileged'"
 	delete(paramMap, "unprivileged")
 
-	_, err = client.UpdateVMHA(vmr, config.HaState)
+	_, err = client.UpdateVMHA(vmr, config.HaState, config.HaGroup)
 	if err != nil {
 		return err
 	}

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -59,6 +59,7 @@ type ConfigQemu struct {
 	QemuNetworks    QemuDevices `json:"network"`
 	QemuSerials     QemuDevices `json:"serial,omitempty"`
 	HaState         string      `json:"hastate,omitempty"`
+	HaGroup         string      `json:"hagroup,omitempty"`
 	Tags            string      `json:"tags"`
 	Args            string      `json:"args"`
 
@@ -194,7 +195,7 @@ func (config ConfigQemu) CreateVm(vmr *VmRef, client *Client) (err error) {
 		return fmt.Errorf("Error creating VM: %v, error status: %s (params: %v)", err, exitStatus, params)
 	}
 
-	_, err = client.UpdateVMHA(vmr, config.HaState)
+	_, err = client.UpdateVMHA(vmr, config.HaState, config.HaGroup)
 	if err != nil {
 		log.Printf("[ERROR] %q", err)
 	}
@@ -441,7 +442,7 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 		return err
 	}
 
-	_, err = client.UpdateVMHA(vmr, config.HaState)
+	_, err = client.UpdateVMHA(vmr, config.HaState, config.HaGroup)
 	if err != nil {
 		log.Printf("[ERROR] %q", err)
 	}


### PR DESCRIPTION
This change will implement the HA Group setting. We could already define the HA State (running, stopped, etc.) but with this change it'll be possible to also set what HA Group a resource should belong to.

I successfully tested this on my own proxmox instance by forking the [proxmox provider](https://github.com/Telmate/terraform-provider-proxmox) and changing the scheme to accept the HA Group parameter. I wanted to merge it back here first before I open a pull request on the `terraform-provider-proxmox` repo to ensure nothing breaks.