### PR TITLE
fix migration with local disks

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -720,7 +720,7 @@ func (c *Client) SetLxcConfig(vmr *VmRef, vmParams map[string]interface{}) (exit
 
 // MigrateNode - Migrate a VM
 func (c *Client) MigrateNode(vmr *VmRef, newTargetNode string, online bool) (exitStatus interface{}, err error) {
-	reqbody := ParamsToBody(map[string]interface{}{"target": newTargetNode, "online": online})
+	reqbody := ParamsToBody(map[string]interface{}{"target": newTargetNode, "online": online, "with-local-disks": true})
 	url := fmt.Sprintf("/nodes/%s/%s/%d/migrate", vmr.node, vmr.vmType, vmr.vmId)
 	resp, err := c.session.Post(url, nil, nil, &reqbody)
 	if err == nil {


### PR DESCRIPTION
This is fixing the live migration errors effecting multiple users here:
https://github.com/Telmate/terraform-provider-proxmox/issues/303

The proxmox UI is using that option by default and migrating without problems, so I think we should also set it as default in the go-client, because otherwise it is impossible to live migrate VMs with local disks.