### PR TITLE
Fix HA Group setup for LXC containers

### DIFF
--- a/proxmox/config_lxc.go
+++ b/proxmox/config_lxc.go
@@ -145,6 +145,10 @@ func NewConfigLxcFromApi(vmr *VmRef, client *Client) (config *ConfigLxc, err err
 	if _, isSet := lxcConfig["hastate"]; isSet {
 		hastate = lxcConfig["hastate"].(string)
 	}
+	hagroup := ""
+	if _, isSet := lxcConfig["hagroup"]; isSet {
+		hagroup = lxcConfig["hagroup"].(string)
+	}
 	hookscript := ""
 	if _, isSet := lxcConfig["hookscript"]; isSet {
 		hookscript = lxcConfig["hookscript"].(string)
@@ -300,6 +304,7 @@ func NewConfigLxcFromApi(vmr *VmRef, client *Client) (config *ConfigLxc, err err
 	config.Description = description
 	config.OnBoot = onboot
 	config.HaState = hastate
+	config.HaGroup = hagroup
 	config.Hookscript = hookscript
 	config.Hostname = hostname
 	config.Lock = lock
@@ -487,8 +492,9 @@ func (config ConfigLxc) mapToAPIParams() map[string]interface{} {
 	delete(paramMap, "mountpoints")
 	delete(paramMap, "unused")
 
-	// also delete the hastate key which is used elsewhere
+	// also delete the hastate & hagroup key which is used elsewhere
 	delete(paramMap, "hastate")
+	delete(paramMap, "hagroup")
 
 	return paramMap
 }


### PR DESCRIPTION
In #142 I wrote the code to support the HA Group parameter only for QEMU resources. However in my pull request upstream [here](https://github.com/Telmate/terraform-provider-proxmox/pull/423) I implemented it both for QEMU and LXC. However as there was no support for this in this library yet, it [broke things](https://github.com/Telmate/terraform-provider-proxmox/issues/424).

Sorry for being careless. I have not tested this yet as I don't work with LXC containers myself but looking through the Proxmox API and source code these changes should work. Would appreciate if someone could test it to double check though.