### PR TITLE
Support for proxies servers, proper LXC HA management, go-staticcheck code fixes, miscs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 proxmox-api-go
 .vagrant/
+.vscode

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ export PM_OTP=otpcode (only if required)
 ./proxmox-api-go rollbackQemu vm-name
 ```
 
+## Proxy server support
+
+Just use the flag -proxy and specify your proxy url and port
+
+```sh
+./proxmox-api-go -proxy https://localhost:8080 start 123
+```
+
 ### Format
 
 createQemu JSON Sample:
@@ -76,7 +84,7 @@ createQemu JSON Sample:
   }
 }
 ```
- 
+
 cloneQemu JSON Sample:
 
 ```json
@@ -102,32 +110,32 @@ cloneQemu cloud-init JSON Sample:
   "cores": 2,
   "sockets": 1,
   "ipconfig0": "gw=10.0.2.2,ip=10.0.2.17/24",
-  "sshkeys" : "...",
+  "sshkeys": "...",
   "nameserver": "8.8.8.8"
 }
 ```
 
 ### Cloud-init options
 
-Cloud-init VMs must be cloned from a cloud-init ready template. 
+Cloud-init VMs must be cloned from a cloud-init ready template.
 See: https://pve.proxmox.com/wiki/Cloud-Init_Support
 
-* ciuser - User name to change ssh keys and password for instead of the image’s configured default user.
-* cipassword - Password to assign the user. 
-* cicustom - Specify custom files to replace the automatically generated ones at start.
-* searchdomain - Sets DNS search domains for a container.
-* nameserver - Sets DNS server IP address for a container.
-* sshkeys - public ssh keys, one per line
-* ipconfig0 - [gw=<GatewayIPv4>] [,gw6=<GatewayIPv6>] [,ip=<IPv4Format/CIDR>] [,ip6=<IPv6Format/CIDR>]
-* ipconfig1 - optional, same as ipconfig0 format
+- ciuser - User name to change ssh keys and password for instead of the image’s configured default user.
+- cipassword - Password to assign the user.
+- cicustom - Specify custom files to replace the automatically generated ones at start.
+- searchdomain - Sets DNS search domains for a container.
+- nameserver - Sets DNS server IP address for a container.
+- sshkeys - public ssh keys, one per line
+- ipconfig0 - [gw=<GatewayIPv4>] [,gw6=<GatewayIPv6>] [,ip=<IPv4Format/CIDR>] [,ip6=<IPv6Format/CIDR>]
+- ipconfig1 - optional, same as ipconfig0 format
 
 ### ISO requirements (non cloud-init)
 
 Kickstart auto install
 
-* partition /dev/vda
-* network eth1
-* sshd (with preshared key/password)
+- partition /dev/vda
+- network eth1
+- sshd (with preshared key/password)
 
 Network is temprorarily eth1 during the pre-provision phase.
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ export PM_API_URL="https://xxxx.com:8006/api2/json"
 export PM_USER=user@pam
 export PM_PASS=password
 export PM_OTP=otpcode (only if required)
+export PM_PROXY=http://proxyurl:port (only if required)
 
 ./proxmox-api-go installQemu proxmox-node-name < qemu1.json
 
@@ -76,7 +77,7 @@ createQemu JSON Sample:
   }
 }
 ```
- 
+
 cloneQemu JSON Sample:
 
 ```json
@@ -102,32 +103,32 @@ cloneQemu cloud-init JSON Sample:
   "cores": 2,
   "sockets": 1,
   "ipconfig0": "gw=10.0.2.2,ip=10.0.2.17/24",
-  "sshkeys" : "...",
+  "sshkeys": "...",
   "nameserver": "8.8.8.8"
 }
 ```
 
 ### Cloud-init options
 
-Cloud-init VMs must be cloned from a cloud-init ready template. 
+Cloud-init VMs must be cloned from a cloud-init ready template.
 See: https://pve.proxmox.com/wiki/Cloud-Init_Support
 
-* ciuser - User name to change ssh keys and password for instead of the image’s configured default user.
-* cipassword - Password to assign the user. 
-* cicustom - Specify custom files to replace the automatically generated ones at start.
-* searchdomain - Sets DNS search domains for a container.
-* nameserver - Sets DNS server IP address for a container.
-* sshkeys - public ssh keys, one per line
-* ipconfig0 - [gw=<GatewayIPv4>] [,gw6=<GatewayIPv6>] [,ip=<IPv4Format/CIDR>] [,ip6=<IPv6Format/CIDR>]
-* ipconfig1 - optional, same as ipconfig0 format
+- ciuser - User name to change ssh keys and password for instead of the image’s configured default user.
+- cipassword - Password to assign the user.
+- cicustom - Specify custom files to replace the automatically generated ones at start.
+- searchdomain - Sets DNS search domains for a container.
+- nameserver - Sets DNS server IP address for a container.
+- sshkeys - public ssh keys, one per line
+- ipconfig0 - [gw=<GatewayIPv4>] [,gw6=<GatewayIPv6>] [,ip=<IPv4Format/CIDR>] [,ip6=<IPv6Format/CIDR>]
+- ipconfig1 - optional, same as ipconfig0 format
 
 ### ISO requirements (non cloud-init)
 
 Kickstart auto install
 
-* partition /dev/vda
-* network eth1
-* sshd (with preshared key/password)
+- partition /dev/vda
+- network eth1
+- sshd (with preshared key/password)
 
 Network is temprorarily eth1 during the pre-provision phase.
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ export PM_API_URL="https://xxxx.com:8006/api2/json"
 export PM_USER=user@pam
 export PM_PASS=password
 export PM_OTP=otpcode (only if required)
-export PM_PROXY=http://proxyurl:port (only if required)
 
 ./proxmox-api-go installQemu proxmox-node-name < qemu1.json
 
@@ -77,7 +76,7 @@ createQemu JSON Sample:
   }
 }
 ```
-
+ 
 cloneQemu JSON Sample:
 
 ```json
@@ -103,32 +102,32 @@ cloneQemu cloud-init JSON Sample:
   "cores": 2,
   "sockets": 1,
   "ipconfig0": "gw=10.0.2.2,ip=10.0.2.17/24",
-  "sshkeys": "...",
+  "sshkeys" : "...",
   "nameserver": "8.8.8.8"
 }
 ```
 
 ### Cloud-init options
 
-Cloud-init VMs must be cloned from a cloud-init ready template.
+Cloud-init VMs must be cloned from a cloud-init ready template. 
 See: https://pve.proxmox.com/wiki/Cloud-Init_Support
 
-- ciuser - User name to change ssh keys and password for instead of the image’s configured default user.
-- cipassword - Password to assign the user.
-- cicustom - Specify custom files to replace the automatically generated ones at start.
-- searchdomain - Sets DNS search domains for a container.
-- nameserver - Sets DNS server IP address for a container.
-- sshkeys - public ssh keys, one per line
-- ipconfig0 - [gw=<GatewayIPv4>] [,gw6=<GatewayIPv6>] [,ip=<IPv4Format/CIDR>] [,ip6=<IPv6Format/CIDR>]
-- ipconfig1 - optional, same as ipconfig0 format
+* ciuser - User name to change ssh keys and password for instead of the image’s configured default user.
+* cipassword - Password to assign the user. 
+* cicustom - Specify custom files to replace the automatically generated ones at start.
+* searchdomain - Sets DNS search domains for a container.
+* nameserver - Sets DNS server IP address for a container.
+* sshkeys - public ssh keys, one per line
+* ipconfig0 - [gw=<GatewayIPv4>] [,gw6=<GatewayIPv6>] [,ip=<IPv4Format/CIDR>] [,ip6=<IPv6Format/CIDR>]
+* ipconfig1 - optional, same as ipconfig0 format
 
 ### ISO requirements (non cloud-init)
 
 Kickstart auto install
 
-- partition /dev/vda
-- network eth1
-- sshd (with preshared key/password)
+* partition /dev/vda
+* network eth1
+* sshd (with preshared key/password)
 
 Network is temprorarily eth1 during the pre-provision phase.
 

--- a/main.go
+++ b/main.go
@@ -18,13 +18,14 @@ func main() {
 	insecure = flag.Bool("insecure", false, "TLS insecure mode")
 	proxmox.Debug = flag.Bool("debug", false, "debug mode")
 	taskTimeout := flag.Int("timeout", 300, "api task timeout in seconds")
+	proxyUrl := flag.String("proxy", "", "proxy url to connect to")
 	fvmid := flag.Int("vmid", -1, "custom vmid (instead of auto)")
 	flag.Parse()
 	tlsconf := &tls.Config{InsecureSkipVerify: true}
 	if !*insecure {
 		tlsconf = nil
 	}
-	c, err := proxmox.NewClient(os.Getenv("PM_API_URL"), nil, tlsconf, *taskTimeout)
+	c, err := proxmox.NewClient(os.Getenv("PM_API_URL"), nil, tlsconf, *proxyUrl, *taskTimeout)
 	if userRequiresAPIToken(os.Getenv("PM_USER")) {
 		c.SetAPIToken(os.Getenv("PM_USER"), os.Getenv("PM_PASS"))
 		// As test, get the version of the server

--- a/proxmox/client_test.go
+++ b/proxmox/client_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestClient_Login(t *testing.T) {
-	client, err := NewClient("https://localhost:8006/api2/json", nil, &tls.Config{InsecureSkipVerify: true}, 300)
+	client, err := NewClient("https://localhost:8006/api2/json", nil, &tls.Config{InsecureSkipVerify: true}, "", 300)
 	assert.Nil(t, err)
 
 	err = client.Login("root@pam", "root", "")

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -796,7 +796,7 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 			unusedDiskNames = append(unusedDiskNames, unusedDiskName[0])
 		}
 	}
-	if unusedDiskNames == nil {
+	if unusedDiskNames != nil {
 		log.Printf("unusedDiskNames: %v", unusedDiskNames)
 	}
 

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -2,7 +2,6 @@ package proxmox
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -105,7 +104,7 @@ type ConfigQemu struct {
 // CreateVm - Tell Proxmox API to make the VM
 func (config ConfigQemu) CreateVm(vmr *VmRef, client *Client) (err error) {
 	if config.HasCloudInit() {
-		return errors.New("Cloud-init parameters only supported on clones or updates")
+		return fmt.Errorf("cloud-init parameters only supported on clones or updates")
 	}
 	vmr.SetVmType("qemu")
 
@@ -192,7 +191,7 @@ func (config ConfigQemu) CreateVm(vmr *VmRef, client *Client) (err error) {
 
 	exitStatus, err := client.CreateQemuVm(vmr.node, params)
 	if err != nil {
-		return fmt.Errorf("Error creating VM: %v, error status: %s (params: %v)", err, exitStatus, params)
+		return fmt.Errorf("error creating VM: %v, error status: %s (params: %v)", err, exitStatus, params)
 	}
 
 	_, err = client.UpdateVMHA(vmr, config.HaState, config.HaGroup)
@@ -492,7 +491,7 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 	}
 
 	if vmConfig["lock"] != nil {
-		return nil, errors.New("vm locked, could not obtain config")
+		return nil, fmt.Errorf("vm locked, could not obtain config")
 	}
 
 	// vmConfig Sample: map[ cpu:host
@@ -775,13 +774,10 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 			diskConfMap["size"] = "4M" // default cloud-init disk size
 		}
 
+		var sizeInTerabytes = regexp.MustCompile(`[0-9]+T`)
 		// Convert to gigabytes if disk size was received in terabytes
-		sizeIsInTerabytes, err := regexp.MatchString("[0-9]+T", diskConfMap["size"].(string))
-		if err != nil {
-			log.Fatal(err)
-			return nil, err
-		}
-		if sizeIsInTerabytes {
+		matched := sizeInTerabytes.MatchString(diskConfMap["size"].(string))
+		if matched {
 			diskConfMap["size"] = fmt.Sprintf("%.0fG", DiskSizeGB(diskConfMap["size"]))
 		}
 
@@ -800,8 +796,10 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 			unusedDiskNames = append(unusedDiskNames, unusedDiskName[0])
 		}
 	}
+	if unusedDiskNames == nil {
+		log.Printf("unusedDiskNames: %v", unusedDiskNames)
+	}
 
-	fmt.Println(fmt.Sprintf("unusedDiskNames: %v", unusedDiskNames))
 	for _, unusedDiskName := range unusedDiskNames {
 		unusedDiskConfStr := vmConfig[unusedDiskName].(string)
 		finalDiskConfMap := QemuDevice{}
@@ -810,7 +808,7 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 		id := rxDeviceID.FindStringSubmatch(unusedDiskName)
 		diskID, err := strconv.Atoi(id[0])
 		if err != nil {
-			return nil, errors.New(fmt.Sprintf("Unable to parse unused disk id from input string '%v' tried to convert '%v' to integer.", unusedDiskName, diskID))
+			return nil, fmt.Errorf(fmt.Sprintf("Unable to parse unused disk id from input string '%v' tried to convert '%v' to integer.", unusedDiskName, diskID))
 		}
 		finalDiskConfMap["slot"] = diskID
 
@@ -924,7 +922,7 @@ func WaitForShutdown(vmr *VmRef, client *Client) (err error) {
 		}
 		time.Sleep(5 * time.Second)
 	}
-	return errors.New("Not shutdown within wait time")
+	return fmt.Errorf("not shutdown within wait time")
 }
 
 // This is because proxmox create/config API won't let us make usernet devices
@@ -934,7 +932,7 @@ func SshForwardUsernet(vmr *VmRef, client *Client) (sshPort string, err error) {
 		return "", err
 	}
 	if vmState["status"] == "stopped" {
-		return "", errors.New("VM must be running first")
+		return "", fmt.Errorf("VM must be running first")
 	}
 	sshPort = strconv.Itoa(vmr.VmId() + 22000)
 	_, err = client.MonitorCmd(vmr, "netdev_add user,id=net1,hostfwd=tcp::"+sshPort+"-:22")
@@ -956,7 +954,7 @@ func RemoveSshForwardUsernet(vmr *VmRef, client *Client) (err error) {
 		return err
 	}
 	if vmState["status"] == "stopped" {
-		return errors.New("VM must be running first")
+		return fmt.Errorf("VM must be running first")
 	}
 	_, err = client.MonitorCmd(vmr, "device_del net1")
 	if err != nil {
@@ -989,7 +987,7 @@ func SendKeysString(vmr *VmRef, client *Client, keys string) (err error) {
 		return err
 	}
 	if vmState["status"] == "stopped" {
-		return errors.New("VM must be running first")
+		return fmt.Errorf("VM must be running first")
 	}
 	for _, r := range keys {
 		c := string(r)
@@ -1044,7 +1042,7 @@ func SendKeysString(vmr *VmRef, client *Client, keys string) (err error) {
 		if err != nil {
 			return err
 		}
-		time.Sleep(100)
+		time.Sleep(1 * time.Millisecond)
 	}
 	return nil
 }
@@ -1241,7 +1239,7 @@ func (c ConfigQemu) CreateQemuMachineParam(
 		params["machine"] = c.Machine
 		return nil
 	}
-	return errors.New("unsupported machine type, fall back to default")
+	return fmt.Errorf("unsupported machine type, fall back to default")
 }
 
 func (p QemuDeviceParam) createDeviceParam(

--- a/proxmox/session.go
+++ b/proxmox/session.go
@@ -34,29 +34,29 @@ type Session struct {
 
 func NewSession(apiUrl string, hclient *http.Client, proxyString string, tls *tls.Config) (session *Session, err error) {
 	if hclient == nil {
-		proxyURL, err := url.ParseRequestURI(proxyString)
-		if err != nil {
-			return nil, err
-		}
-		if _, _, err := net.SplitHostPort(proxyURL.Host); err != nil {
-			return nil, err
-		} else {
-			// Only build a transport if we're also building the client
+		if proxyString == "" {
 			tr := &http.Transport{
 				TLSClientConfig:    tls,
 				DisableCompression: true,
-				Proxy:              http.ProxyURL(proxyURL),
+				Proxy:              nil,
 			}
-			if proxyURL.String() == "" {
-				tr = &http.Transport{
+			hclient = &http.Client{Transport: tr}
+		} else {
+			proxyURL, err := url.ParseRequestURI(proxyString)
+			if err != nil {
+				return nil, err
+			}
+			if _, _, err := net.SplitHostPort(proxyURL.Host); err != nil {
+				return nil, err
+			} else {
+				// Only build a transport if we're also building the client
+				tr := &http.Transport{
 					TLSClientConfig:    tls,
 					DisableCompression: true,
-					Proxy:              nil,
+					Proxy:              http.ProxyURL(proxyURL),
 				}
-
+				hclient = &http.Client{Transport: tr}
 			}
-
-			hclient = &http.Client{Transport: tr}
 		}
 	}
 	session = &Session{

--- a/proxmox/util.go
+++ b/proxmox/util.go
@@ -17,10 +17,7 @@ func inArray(arr []string, str string) bool {
 }
 
 func Itob(i int) bool {
-	if i == 1 {
-		return true
-	}
-	return false
+	return i == 1
 }
 
 // ParseSubConf - Parse standard sub-conf strings `key=value`.
@@ -81,9 +78,9 @@ func ParsePMConf(
 // Convert a disk-size string to a GB float
 func DiskSizeGB(dcSize interface{}) float64 {
 	var diskSize float64
-	switch dcSize.(type) {
+	switch dcSize := dcSize.(type) {
 	case string:
-		diskString := strings.ToUpper(dcSize.(string))
+		diskString := strings.ToUpper(dcSize)
 		re := regexp.MustCompile("([0-9]+)([A-Z]*)")
 		diskArray := re.FindStringSubmatch(diskString)
 
@@ -102,7 +99,7 @@ func DiskSizeGB(dcSize interface{}) float64 {
 			}
 		}
 	case float64:
-		diskSize = dcSize.(float64)
+		diskSize = dcSize
 	}
 	return diskSize
 }


### PR DESCRIPTION
Hi,

here we go with some upgrades on the proxmox api

- I've added the support for proxies for easy debugging, just use your preferred proxy (i use mitmproxy) and se what actually happens in term of api calls to/from your lovely proxmox instance cluster
- I think I've managed to solve the HA management on LXC side
- I changed how unused disks are handled(since we can only read them)
- I've cleaned a bit the code following go-staticcheck(not 100%)
- Some other small fixes that you can see reading through the diff

**Since this is a breaking change for the proxmox provider because the NewClient() function changes it's signature, as soon the PR get merged I'll open a new PR to the provider to support the new api version**

thanks