### PR TITLE
fix(CreateVm): Make 'ide2' not hardcoded assumption

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -114,7 +114,6 @@ func (config ConfigQemu) CreateVm(vmr *VmRef, client *Client) (err error) {
 		"onboot":      config.Onboot,
 		"tablet":      config.Tablet,
 		"agent":       config.Agent,
-		"ide2":        config.QemuIso + ",media=cdrom",
 		"ostype":      config.QemuOs,
 		"sockets":     config.QemuSockets,
 		"cores":       config.QemuCores,
@@ -128,6 +127,10 @@ func (config ConfigQemu) CreateVm(vmr *VmRef, client *Client) (err error) {
 		"tags":        config.Tags,
 		"machine":     config.Machine,
 		"args":        config.Args,
+	}
+
+	if config.QemuIso != "" {
+		params["ide2"] = config.QemuIso + ",media=cdrom"
 	}
 
 	if config.Bios != "" {


### PR DESCRIPTION
In the `proxmox/config_qemu.go` code path, the `QemuIso` is specified as a hard coded assumption (see #151 ) for the `CreateVm` call.  This does not allow for other VM creation scenarios that do not need or require the ISO be used or specified.

This pull request moves the `ide2` Param definition out of the params map, and in to a separate optional `if` check structure.  This allows for the create of a VM resource without the ISO definition in the config.  Existing use cases will continue to function without modification, with the ISO definition in the config.