### PR TITLE
fix(CreateVm): Add PXE boolean option to config

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -48,6 +48,7 @@ type ConfigQemu struct {
 	QemuKVM         bool        `json:"kvm"`
 	Hotplug         string      `json:"hotplug"`
 	QemuIso         string      `json:"iso"`
+	QemuPxe         bool        `json:"pxe"`
 	FullClone       *int        `json:"fullclone"`
 	Boot            string      `json:"boot"`
 	BootDisk        string      `json:"bootdisk,omitempty"`
@@ -131,6 +132,10 @@ func (config ConfigQemu) CreateVm(vmr *VmRef, client *Client) (err error) {
 
 	if config.QemuIso != "" {
 		params["ide2"] = config.QemuIso + ",media=cdrom"
+	}
+
+	if config.QemuPxe {
+		params["pxe"] = config.QemuPxe
 	}
 
 	if config.Bios != "" {

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -134,10 +134,6 @@ func (config ConfigQemu) CreateVm(vmr *VmRef, client *Client) (err error) {
 		params["ide2"] = config.QemuIso + ",media=cdrom"
 	}
 
-	if config.QemuPxe {
-		params["pxe"] = config.QemuPxe
-	}
-
 	if config.Bios != "" {
 		params["bios"] = config.Bios
 	}


### PR DESCRIPTION
This pull requests adds a new Config directive of `pxe` type which can be used to indicate that a PXE boot is being requested of the Virtual Machine.

On its own, this will not actually implement the PXE boot capability.  That is ultimately implemented by use of a correct set of `boot` directives defining the Network Boot option first (eg `ncd`, or `order=net0;scsi0`).

This addresses Issue #153 .