### PR TITLE
change input order of migrate feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ export PM_OTP=otpcode (only if required)
 
 ./proxmox-api-go cloneQemu template-name proxmox-node-name < clone1.json
 
-./proxmox-api-go migrate pve1 123
+./proxmox-api-go migrate 123 migrate-to-proxmox-node-name
 
 ./proxmox-api-go createQemuSnapshot vm-name snapshot_name
 

--- a/main.go
+++ b/main.go
@@ -43,7 +43,7 @@ func main() {
 	vmid := *fvmid
 	if vmid < 0 {
 		if len(flag.Args()) > 1 {
-			vmid, err = strconv.Atoi(flag.Args()[len(flag.Args())-1])
+			vmid, err = strconv.Atoi(flag.Args()[1])
 			if err != nil {
 				vmid = 0
 			}
@@ -294,7 +294,7 @@ func main() {
 			fmt.Printf("Missing target node\n")
 			os.Exit(1)
 		}
-		_, err := c.MigrateNode(vmr, args[1], true)
+		_, err := c.MigrateNode(vmr, args[2], true)
 
 		if err != nil {
 			log.Printf("Error to move %+v\n", err)


### PR DESCRIPTION
Changed the input syntax of the migrate feature to be in the same style as the other vm related operations.

Resolves #158