### PR TITLE
Added file flag

### DIFF
--- a/proxmox/config_acme_account.go
+++ b/proxmox/config_acme_account.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 	"errors"
 	"fmt"
-	"io"
 	"log"
 )
 
@@ -73,12 +72,9 @@ func NewConfigAcmeAccountFromApi(id string, client *Client) (config *ConfigAcmeA
 	return
 }
 
-func NewConfigAcmeAccountFromJson(io io.Reader) (config *ConfigAcmeAccount, err error) {
+func NewConfigAcmeAccountFromJson(input []byte) (config *ConfigAcmeAccount, err error) {
 	config = &ConfigAcmeAccount{}
-	err = json.NewDecoder(io).Decode(config)
-	if err != nil {
-		log.Fatal(err)
-		return nil, err
-	}
+	err = json.Unmarshal([]byte(input), config)
+	if err != nil {log.Fatal(err)}
 	return
 }

--- a/proxmox/config_acme_plugin.go
+++ b/proxmox/config_acme_plugin.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 )
 
@@ -86,12 +85,9 @@ func NewConfigAcmePluginFromApi(id string, client *Client) (config *ConfigAcmePl
 	return
 }
 
-func NewConfigAcmePluginFromJson(io io.Reader) (config *ConfigAcmePlugin, err error) {
+func NewConfigAcmePluginFromJson(input []byte) (config *ConfigAcmePlugin, err error) {
 	config = &ConfigAcmePlugin{}
-	err = json.NewDecoder(io).Decode(config)
-	if err != nil {
-		log.Fatal(err)
-		return nil, err
-	}
+	err = json.Unmarshal([]byte(input), config)
+	if err != nil {log.Fatal(err)}
 	return
 }

--- a/proxmox/config_lxc.go
+++ b/proxmox/config_lxc.go
@@ -3,7 +3,6 @@ package proxmox
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"strconv"
 	"strings"
@@ -76,10 +75,11 @@ func NewConfigLxc() ConfigLxc {
 	}
 }
 
-func NewConfigLxcFromJson(io io.Reader) (config ConfigLxc, err error) {
+func NewConfigLxcFromJson(input []byte) (config ConfigLxc, err error) {
 	config = NewConfigLxc()
-	err = json.NewDecoder(io).Decode(&config)
-	return config, err
+	err = json.Unmarshal([]byte(input), &config)
+	if err != nil {log.Fatal(err)}
+	return
 }
 
 func NewConfigLxcFromApi(vmr *VmRef, client *Client) (config *ConfigLxc, err error) {

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -3,7 +3,6 @@ package proxmox
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 	"math/rand"
 	"net"
@@ -468,13 +467,10 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 	return err
 }
 
-func NewConfigQemuFromJson(io io.Reader) (config *ConfigQemu, err error) {
+func NewConfigQemuFromJson(input []byte) (config *ConfigQemu, err error) {
 	config = &ConfigQemu{QemuVlanTag: -1, QemuKVM: true}
-	err = json.NewDecoder(io).Decode(config)
-	if err != nil {
-		log.Fatal(err)
-		return nil, err
-	}
+	err = json.Unmarshal([]byte(input), config)
+	if err != nil {log.Fatal(err)}
 	return
 }
 

--- a/proxmox/config_user.go
+++ b/proxmox/config_user.go
@@ -5,7 +5,6 @@ import (
 	"unicode/utf8"
 	"errors"
 	"fmt"
-	"io"
 	"log"
 )
 
@@ -105,13 +104,10 @@ func NewConfigUserFromApi(userid string, client *Client) (config *ConfigUser, er
 	return
 }
 
-func NewConfigUserFromJson(io io.Reader) (config *ConfigUser, err error) {
+func NewConfigUserFromJson(input []byte) (config *ConfigUser, err error) {
 	config = &ConfigUser{}
-	err = json.NewDecoder(io).Decode(config)
-	if err != nil {
-		log.Fatal(err)
-		return nil, err
-	}
+	err = json.Unmarshal([]byte(input), config)
+	if err != nil {log.Fatal(err)}
 	return
 }
 


### PR DESCRIPTION
Added a file flag to specify a config file.

This feature will help with development since it is quite awkward to input the config from stdin while debugging.

The old behavior of using [os.Stdin](https://github.com/Tinyblargon/proxmox-api-go/blame/Feature-File-Flag/main.go#L567) is still there and will be used when the file flag is either empty or unspecified.
All user file input is now handled by the [GetConfig](https://github.com/Tinyblargon/proxmox-api-go/blame/Feature-File-Flag/main.go#L560) function.