### PR TITLE
get generic /cluster/resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ export PM_OTP=otpcode (only if required)
 
 ./proxmox-api-go rollbackQemu vm-name
 
+./proxmox-api-go getResourceList
+
+./proxmox-api-go getVmList
+
 ./proxmox-api-go getUserList
 
 ./proxmox-api-go getUser userid

--- a/main.go
+++ b/main.go
@@ -320,7 +320,7 @@ func main() {
 		fmt.Println(string(nodeList))
 
 	case "getResourceList":
-		resource, err := c.GetResourceList()
+		resource, err := c.GetResourceList("")
 		if err != nil {
 			log.Printf("Error listing resources %+v\n", err)
 			os.Exit(1)

--- a/main.go
+++ b/main.go
@@ -326,6 +326,7 @@ func main() {
 			os.Exit(1)
 		}
 		rsList, err := json.Marshal(resource)
+		failError(err)
 		fmt.Println(string(rsList))
 
 	case "getVmList":

--- a/main.go
+++ b/main.go
@@ -319,6 +319,15 @@ func main() {
 		failError(err)
 		fmt.Println(string(nodeList))
 
+	case "getResourceList":
+		resource, err := c.GetResourceList()
+		if err != nil {
+			log.Printf("Error listing resources %+v\n", err)
+			os.Exit(1)
+		}
+		rsList, err := json.Marshal(resource)
+		fmt.Println(string(rsList))
+
 	case "getVmList":
 		vms, err := c.GetVmList()
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -319,6 +319,7 @@ func main() {
 		failError(err)
 		fmt.Println(string(nodeList))
 
+	// only returns enabled resources
 	case "getResourceList":
 		resource, err := c.GetResourceList("")
 		if err != nil {

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -142,6 +142,11 @@ func (c *Client) GetNodeList() (list map[string]interface{}, err error) {
 	return
 }
 
+func (c *Client) GetResourceList() (list map[string]interface{}, err error) {
+	err = c.GetJsonRetryable("/cluster/resources", &list, 3)
+	return
+}
+
 func (c *Client) GetVmList() (list map[string]interface{}, err error) {
 	err = c.GetJsonRetryable("/cluster/resources?type=vm", &list, 3)
 	return

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -142,13 +142,17 @@ func (c *Client) GetNodeList() (list map[string]interface{}, err error) {
 	return
 }
 
-func (c *Client) GetResourceList() (list map[string]interface{}, err error) {
-	err = c.GetJsonRetryable("/cluster/resources", &list, 3)
+func (c *Client) GetResourceList(resourceType string) (list map[string]interface{}, err error) {
+	var endpoint = "/cluster/resources"
+	if resourceType != "" {
+		endpoint = fmt.Sprintf("%s?type=%s", endpoint, resourceType)
+	}
+	err = c.GetJsonRetryable(endpoint, &list, 3)
 	return
 }
 
 func (c *Client) GetVmList() (list map[string]interface{}, err error) {
-	err = c.GetJsonRetryable("/cluster/resources?type=vm", &list, 3)
+	list, err = c.GetResourceList("vm")
 	return
 }
 

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -142,6 +142,9 @@ func (c *Client) GetNodeList() (list map[string]interface{}, err error) {
 	return
 }
 
+// GetResourceList returns a list of all enabled proxmox resources.
+// For resource types that can be in a disabled state, disabled resources
+// will not be returned
 func (c *Client) GetResourceList(resourceType string) (list map[string]interface{}, err error) {
 	var endpoint = "/cluster/resources"
 	if resourceType != "" {


### PR DESCRIPTION
This adds the ability to fetch  `/cluster/resources`  without `?type=vm` being appended to it. This way, we have flexibility in what types we retrieve, such as storage. 