### PR TITLE
Fix: User Delete failed Silently

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -1530,8 +1530,15 @@ func (c *Client) CheckUserExistance(id string) (existance bool, err error) {
 }
 
 func (c *Client) DeleteUser(id string) (err error) {
-	_, err = c.session.Delete("/access/users/"+id, nil, nil)
-	return
+	existance, err := c.CheckUserExistance(id)
+	if err != nil {
+		return
+	}
+	if !existance {
+		return fmt.Errorf("user (%s) could not be deleted, the user does not exist", id)
+	}
+	// Proxmox silently fails a user delete if the users does not exist
+	return c.DeleteUrl("/access/users/" + id)
 }
 
 //ACME


### PR DESCRIPTION
While setting up integration testing for the new CLI. I found a bug where proxmox would silently fail the delete request if the specified user did not exist.