### PR TITLE
Handele Unhandled error

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -206,6 +206,9 @@ func (c *Client) GetVmRefByName(vmName string) (vmr *VmRef, err error) {
 
 func (c *Client) GetVmRefsByName(vmName string) (vmrs []*VmRef, err error) {
 	resp, err := c.GetVmList()
+	if err != nil {
+		return
+	}
 	vms := resp["data"].([]interface{})
 	for vmii := range vms {
 		vm := vms[vmii].(map[string]interface{})


### PR DESCRIPTION
 While looking into https://github.com/Telmate/terraform-provider-proxmox/issues/563 i came across an error that is not handled. Which i believe to be the cause of the this panic `panic: interface conversion: interface {} is nil, not []interface {}`