### PR TITLE
Implement hookscripts for Qemu virtual machines

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -302,6 +302,7 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 		"hotplug":     config.Hotplug,
 		"memory":      config.Memory,
 		"boot":        config.Boot,
+		"hookscript":  config.Hookscript,
 	}
 
 	//Array to list deleted parameters
@@ -325,6 +326,10 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 
 	if config.BootDisk != "" {
 		configParams["bootdisk"] = config.BootDisk
+	}
+
+	if config.Hookscript != "" {
+		configParams["hookscript"] = config.Hookscript
 	}
 
 	if config.Scsihw != "" {

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -59,6 +59,7 @@ type ConfigQemu struct {
 	QemuNetworks    QemuDevices `json:"network"`
 	QemuSerials     QemuDevices `json:"serial,omitempty"`
 	QemuUsbs        QemuDevices `json:"usb,omitempty"`
+	Hookscript      string      `json:"hookscript,omitempty"`
 	HaState         string      `json:"hastate,omitempty"`
 	HaGroup         string      `json:"hagroup,omitempty"`
 	Tags            string      `json:"tags"`
@@ -618,6 +619,10 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 	if _, isSet := vmConfig["scsihw"]; isSet {
 		scsihw = vmConfig["scsihw"].(string)
 	}
+	hookscript := ""
+	if _, isSet := vmConfig["hookscript"]; isSet {
+		hookscript = vmConfig["hookscript"].(string)
+	}
 
 	config = &ConfigQemu{
 		Name:            name,
@@ -642,6 +647,7 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 		Boot:            boot,
 		BootDisk:        bootdisk,
 		Scsihw:          scsihw,
+		Hookscript:      hookscript,
 		QemuDisks:       QemuDevices{},
 		QemuUnusedDisks: QemuDevices{},
 		QemuVga:         QemuDevice{},


### PR DESCRIPTION
Right now, this API client only implements hookscripts for LXC containers. This PR tries to add this support to Qemu virtual machines too.