### PR TITLE
Cli overhaul: user password change

### DIFF
--- a/proxmox/config_user.go
+++ b/proxmox/config_user.go
@@ -2,10 +2,10 @@ package proxmox
 
 import (
 	"encoding/json"
-	"unicode/utf8"
 	"errors"
 	"fmt"
 	"log"
+	"unicode/utf8"
 )
 
 // User options for the Proxmox API
@@ -21,7 +21,7 @@ type ConfigUser struct {
 	Lastname  string   `json:"lastname,omitempty"`
 }
 
-func (config ConfigUser) MapUserValues()(params map[string]interface{}) {
+func (config ConfigUser) MapUserValues() (params map[string]interface{}) {
 	params = map[string]interface{}{
 		"comment":   config.Comment,
 		"email":     config.Email,
@@ -35,18 +35,28 @@ func (config ConfigUser) MapUserValues()(params map[string]interface{}) {
 	return
 }
 
-func (config ConfigUser) SetUser(userid string, password string, client *Client) (err error) {
+func (config *ConfigUser) SetUser(userid string, password string, client *Client) (err error) {
 	err = ValidateUserPassword(password)
-	if err != nil {return err}
+	if err != nil {
+		return err
+	}
 
-	config.UserID = userid
+	if config != nil {
+		config.UserID = userid
+	}
 
 	userExists, err := client.CheckUserExistance(userid)
-	if err != nil {return err}
+	if err != nil {
+		return err
+	}
 
 	if userExists {
-		err = config.UpdateUser(client)
-		if err != nil {return err}
+		if config != nil {
+			err = config.UpdateUser(client)
+			if err != nil {
+				return err
+			}
+		}
 		if password != "" {
 			err = client.UpdateUserPassword(userid, password)
 		}
@@ -68,7 +78,7 @@ func (config ConfigUser) CreateUser(password string, client *Client) (err error)
 	return
 }
 
-func (config ConfigUser) UpdateUser(client *Client) (err error) {
+func (config *ConfigUser) UpdateUser(client *Client) (err error) {
 	params := config.MapUserValues()
 	err = client.UpdateUser(config.UserID, params)
 	if err != nil {
@@ -82,31 +92,55 @@ func NewConfigUserFromApi(userid string, client *Client) (config *ConfigUser, er
 	// prepare json map to receive the information from the api
 	var userConfig map[string]interface{}
 	userConfig, err = client.GetUserConfig(userid)
-	if err != nil {return nil, err}
+	if err != nil {
+		return nil, err
+	}
 	config = new(ConfigUser)
 
 	config.UserID = userid
 
-	if _, isSet := userConfig["comment"]; isSet {config.Comment = userConfig["comment"].(string)}
-	if _, isSet := userConfig["email"]; isSet {config.Email = userConfig["email"].(string)}
-	if _, isSet := userConfig["enable"]; isSet {config.Enable = Itob(int(userConfig["enable"].(float64)))}
-	if _, isSet := userConfig["expire"]; isSet {config.Expire = int(userConfig["expire"].(float64))}
-	if _, isSet := userConfig["firstname"]; isSet {config.Firstname = userConfig["firstname"].(string)}
-	if _, isSet := userConfig["keys"]; isSet {config.Keys = userConfig["keys"].(string)}
-	if _, isSet := userConfig["lastname"]; isSet {config.Lastname = userConfig["lastname"].(string)}
-	if _, isSet := userConfig["groups"]; isSet {config.Groups = ArrayToStringType(userConfig["groups"].(interface{}).([]interface{}))}
+	if _, isSet := userConfig["comment"]; isSet {
+		config.Comment = userConfig["comment"].(string)
+	}
+	if _, isSet := userConfig["email"]; isSet {
+		config.Email = userConfig["email"].(string)
+	}
+	if _, isSet := userConfig["enable"]; isSet {
+		config.Enable = Itob(int(userConfig["enable"].(float64)))
+	}
+	if _, isSet := userConfig["expire"]; isSet {
+		config.Expire = int(userConfig["expire"].(float64))
+	}
+	if _, isSet := userConfig["firstname"]; isSet {
+		config.Firstname = userConfig["firstname"].(string)
+	}
+	if _, isSet := userConfig["keys"]; isSet {
+		config.Keys = userConfig["keys"].(string)
+	}
+	if _, isSet := userConfig["lastname"]; isSet {
+		config.Lastname = userConfig["lastname"].(string)
+	}
+	if _, isSet := userConfig["groups"]; isSet {
+		config.Groups = ArrayToStringType(userConfig["groups"].(interface{}).([]interface{}))
+	}
 
 	return
 }
 
 func NewConfigUserFromJson(input []byte) (config *ConfigUser, err error) {
-	config = &ConfigUser{}
-	err = json.Unmarshal([]byte(input), config)
-	if err != nil {log.Fatal(err)}
+	if len(input) != 0 {
+		config = &ConfigUser{}
+		err = json.Unmarshal([]byte(input), config)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
 	return
 }
 
-func ValidateUserPassword(password string) error{
-	if utf8.RuneCountInString(password) >= 5 || password == ""{return nil}
+func ValidateUserPassword(password string) error {
+	if utf8.RuneCountInString(password) >= 5 || password == "" {
+		return nil
+	}
 	return errors.New("error updating User: the minimum password length is 5")
 }

--- a/test/cli/Users/User_0_test.go
+++ b/test/cli/Users/User_0_test.go
@@ -2,29 +2,30 @@ package cli_user_test
 
 import (
 	"testing"
+
 	_ "github.com/Telmate/proxmox-api-go/cli/command/commands"
 	cliTest "github.com/Telmate/proxmox-api-go/test/cli"
 )
 
-func Test_User_0_Cleanup(t *testing.T){
+func Test_User_0_Cleanup(t *testing.T) {
 	Test := cliTest.Test{
-		ReqErr: true,
+		ReqErr:      true,
 		ErrContains: "test-user0@pve",
-		Args: []string{"-i","delete","user","test-user0@pve"},
+		Args:        []string{"-i", "delete", "user", "test-user0@pve"},
 	}
 	Test.StandardTest(t)
 }
 
 // Set groups
 
-func Test_User_0_Set_Full_With_Password_Set(t *testing.T){
+func Test_User_0_Set_Full_With_Password_Set(t *testing.T) {
 	Test := cliTest.Test{
 		InputJson: `
 {
 	"comment": "this is a comment",
 	"email": "b.wayne@proxmox.com",
 	"enable": true,
-	"expire": 99999999,
+	"expire": 253370811600,
 	"firstname": "Bruce",
 	"lastname": "Wayne",
 	"groups": [
@@ -33,7 +34,7 @@ func Test_User_0_Set_Full_With_Password_Set(t *testing.T){
 }`,
 		Expected: "(test-user0@pve)",
 		Contains: true,
-		Args: []string{"-i","set","user","test-user0@pve","Enter123!"},
+		Args:     []string{"-i", "set", "user", "test-user0@pve", "Enter123!"},
 	}
 	Test.StandardTest(t)
 }
@@ -41,9 +42,28 @@ func Test_User_0_Set_Full_With_Password_Set(t *testing.T){
 func Test_User_0_Login_Password_Set(t *testing.T) {
 	cliTest.SetEnvironmentVariables()
 	Test := cliTest.LoginTest{
-		UserID: "test-user0@pve",
+		UserID:   "test-user0@pve",
 		Password: "Enter123!",
-		ReqErr: false,
+		ReqErr:   false,
+	}
+	Test.Login(t)
+}
+
+func Test_User_0_Change_Password(t *testing.T) {
+	Test := cliTest.Test{
+		Expected: "(test-user0@pve)",
+		Contains: true,
+		Args:     []string{"-i", "set", "user", "test-user0@pve", "aBc123!"},
+	}
+	Test.StandardTest(t)
+}
+
+func Test_User_0_Login_Password_Changed(t *testing.T) {
+	cliTest.SetEnvironmentVariables()
+	Test := cliTest.LoginTest{
+		UserID:   "test-user0@pve",
+		Password: "aBc123!",
+		ReqErr:   false,
 	}
 	Test.Login(t)
 }
@@ -57,17 +77,17 @@ func Test_User_0_Get_Full(t *testing.T) {
 	"userid": "test-user0@pve",
 	"email": "b.wayne@proxmox.com",
 	"enable": true,
-	"expire": 99999999,
+	"expire": 253370811600,
 	"firstname": "Bruce",
 	"keys": "2fa key",
 	"lastname": "Wayne"
 }`,
-		Args: []string{"-i","get","user","test-user0@pve"},
+		Args: []string{"-i", "get", "user", "test-user0@pve"},
 	}
 	Test.StandardTest(t)
 }
 
-func Test_User_0_Set_Empty(t *testing.T){
+func Test_User_0_Set_Empty(t *testing.T) {
 	Test := cliTest.Test{
 		InputJson: `
 {
@@ -83,7 +103,7 @@ func Test_User_0_Set_Empty(t *testing.T){
 }`,
 		Expected: "(test-user0@pve)",
 		Contains: true,
-		Args: []string{"-i","set","user","test-user0@pve"},
+		Args:     []string{"-i", "set", "user", "test-user0@pve"},
 	}
 	Test.StandardTest(t)
 }
@@ -97,16 +117,16 @@ func Test_User_0_Get_Empty(t *testing.T) {
 	"enable": false,
 	"expire": 0
 }`,
-		Args: []string{"-i","get","user","test-user0@pve"},
+		Args: []string{"-i", "get", "user", "test-user0@pve"},
 	}
 	Test.StandardTest(t)
 }
 
-func Test_User_0_Delete(t *testing.T){
+func Test_User_0_Delete(t *testing.T) {
 	Test := cliTest.Test{
 		Expected: "",
-		ReqErr: false,
-		Args: []string{"-i","delete","user","test-user0@pve"},
+		ReqErr:   false,
+		Args:     []string{"-i", "delete", "user", "test-user0@pve"},
 	}
 	Test.StandardTest(t)
 }

--- a/test/cli/Users/User_1_test.go
+++ b/test/cli/Users/User_1_test.go
@@ -2,20 +2,21 @@ package cli_user_test
 
 import (
 	"testing"
+
 	_ "github.com/Telmate/proxmox-api-go/cli/command/commands"
 	cliTest "github.com/Telmate/proxmox-api-go/test/cli"
 )
 
-func Test_User_1_Cleanup(t *testing.T){
+func Test_User_1_Cleanup(t *testing.T) {
 	Test := cliTest.Test{
-		ReqErr: true,
+		ReqErr:      true,
 		ErrContains: "test-user1@pve",
-		Args: []string{"-i","delete","user","test-user1@pve"},
+		Args:        []string{"-i", "delete", "user", "test-user1@pve"},
 	}
 	Test.StandardTest(t)
 }
 
-func Test_User_1_Set_Empty_Without_Password(t *testing.T){
+func Test_User_1_Set_Empty_Without_Password(t *testing.T) {
 	Test := cliTest.Test{
 		InputJson: `
 {
@@ -24,7 +25,7 @@ func Test_User_1_Set_Empty_Without_Password(t *testing.T){
 }`,
 		Expected: "(test-user1@pve)",
 		Contains: true,
-		Args: []string{"-i","set","user","test-user1@pve"},
+		Args:     []string{"-i", "set", "user", "test-user1@pve"},
 	}
 	Test.StandardTest(t)
 }
@@ -32,9 +33,9 @@ func Test_User_1_Set_Empty_Without_Password(t *testing.T){
 func Test_User_1_Login_Password_Not_Set(t *testing.T) {
 	cliTest.SetEnvironmentVariables()
 	Test := cliTest.LoginTest{
-		UserID: "test-user1@pve",
+		UserID:   "test-user1@pve",
 		Password: "Enter123!",
-		ReqErr: true,
+		ReqErr:   true,
 	}
 	Test.Login(t)
 }
@@ -48,19 +49,19 @@ func Test_User_1_Get_Empty(t *testing.T) {
 	"enable": false,
 	"expire": 0
 }`,
-		Args: []string{"-i","get","user","test-user1@pve"},
+		Args: []string{"-i", "get", "user", "test-user1@pve"},
 	}
 	Test.StandardTest(t)
 }
 
-func Test_User_1_Set_Full_With_Password(t *testing.T){
+func Test_User_1_Set_Full_With_Password(t *testing.T) {
 	Test := cliTest.Test{
 		InputJson: `
 {
 	"comment": "this is a comment",
 	"email": "b.wayne@proxmox.com",
 	"enable": true,
-	"expire": 99999999,
+	"expire": 253370811600,
 	"firstname": "Bruce",
 	"lastname": "Wayne",
 	"groups": [
@@ -69,7 +70,7 @@ func Test_User_1_Set_Full_With_Password(t *testing.T){
 }`,
 		Expected: "(test-user1@pve)",
 		Contains: true,
-		Args: []string{"-i","set","user","test-user1@pve","Enter123!"},
+		Args:     []string{"-i", "set", "user", "test-user1@pve", "Enter123!"},
 	}
 	Test.StandardTest(t)
 }
@@ -77,9 +78,9 @@ func Test_User_1_Set_Full_With_Password(t *testing.T){
 func Test_User_1_Login_Password_Set(t *testing.T) {
 	cliTest.SetEnvironmentVariables()
 	Test := cliTest.LoginTest{
-		UserID: "test-user1@pve",
+		UserID:   "test-user1@pve",
 		Password: "Enter123!",
-		ReqErr: false,
+		ReqErr:   false,
 	}
 	Test.Login(t)
 }
@@ -93,21 +94,21 @@ func Test_User_1_Get_Full(t *testing.T) {
 	"userid": "test-user1@pve",
 	"email": "b.wayne@proxmox.com",
 	"enable": true,
-	"expire": 99999999,
+	"expire": 253370811600,
 	"firstname": "Bruce",
 	"lastname": "Wayne",
 	"keys": "2fa key"
 }`,
-		Args: []string{"-i","get","user","test-user1@pve"},
+		Args: []string{"-i", "get", "user", "test-user1@pve"},
 	}
 	Test.StandardTest(t)
 }
 
-func Test_User_1_Delete(t *testing.T){
+func Test_User_1_Delete(t *testing.T) {
 	Test := cliTest.Test{
 		Expected: "",
-		ReqErr: false,
-		Args: []string{"-i","delete","user","test-user1@pve"},
+		ReqErr:   false,
+		Args:     []string{"-i", "delete", "user", "test-user1@pve"},
 	}
 	Test.StandardTest(t)
 }


### PR DESCRIPTION
Another pull for https://github.com/Telmate/proxmox-api-go/issues/171

Work so far:

- Made the config for the set user command optional, so this command can be used to change a users password.
- Created integration tests for user password change function.
- Made a change to the tests as Proxmox had a bug where it would ignore the value of the "expire" parameter. Which meant that the user would be disabled during the tests.
