### PR TITLE
Cli overhaul: guest id (no tests yet)

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -5,6 +5,7 @@ import (
 	_ "github.com/Telmate/proxmox-api-go/cli/command/delete"
 	_ "github.com/Telmate/proxmox-api-go/cli/command/example"
 	_ "github.com/Telmate/proxmox-api-go/cli/command/get"
+	_ "github.com/Telmate/proxmox-api-go/cli/command/get/id"
 	_ "github.com/Telmate/proxmox-api-go/cli/command/list"
 	_ "github.com/Telmate/proxmox-api-go/cli/command/set"
 	_ "github.com/Telmate/proxmox-api-go/cli/command/update"

--- a/cli/command/get/get-acmeaccount.go
+++ b/cli/command/get/get-acmeaccount.go
@@ -13,5 +13,5 @@ var get_acmeaccountCmd = &cobra.Command{
 }
 
 func init() {
-	getCmd.AddCommand(get_acmeaccountCmd)
+	GetCmd.AddCommand(get_acmeaccountCmd)
 }

--- a/cli/command/get/get-metricserver.go
+++ b/cli/command/get/get-metricserver.go
@@ -13,5 +13,5 @@ var get_metricserverCmd = &cobra.Command{
 }
 
 func init() {
-	getCmd.AddCommand(get_metricserverCmd)
+	GetCmd.AddCommand(get_metricserverCmd)
 }

--- a/cli/command/get/get-pool.go
+++ b/cli/command/get/get-pool.go
@@ -3,6 +3,7 @@ package get
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/Telmate/proxmox-api-go/cli"
 	"github.com/spf13/cobra"
 )
@@ -21,11 +22,11 @@ var get_poolCmd = &cobra.Command{
 		if err != nil {
 			return
 		}
-		fmt.Fprintln(getCmd.OutOrStdout(),string(poolList))
+		fmt.Fprintln(GetCmd.OutOrStdout(), string(poolList))
 		return
 	},
 }
 
 func init() {
-	getCmd.AddCommand(get_poolCmd)
+	GetCmd.AddCommand(get_poolCmd)
 }

--- a/cli/command/get/get-storage.go
+++ b/cli/command/get/get-storage.go
@@ -13,5 +13,5 @@ var get_storageCmd = &cobra.Command{
 }
 
 func init() {
-	getCmd.AddCommand(get_storageCmd)
+	GetCmd.AddCommand(get_storageCmd)
 }

--- a/cli/command/get/get-user.go
+++ b/cli/command/get/get-user.go
@@ -13,5 +13,5 @@ var get_userCmd = &cobra.Command{
 }
 
 func init() {
-	getCmd.AddCommand(get_userCmd)
+	GetCmd.AddCommand(get_userCmd)
 }

--- a/cli/command/get/get.go
+++ b/cli/command/get/get.go
@@ -6,13 +6,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var getCmd = &cobra.Command{
+var GetCmd = &cobra.Command{
 	Use:   "get",
 	Short: "get shows the current configuration an item in proxmox",
 }
 
 func init() {
-	cli.RootCmd.AddCommand(getCmd)
+	cli.RootCmd.AddCommand(GetCmd)
 }
 
 func GetConfig(args []string, IDtype string) (err error) {
@@ -32,6 +32,6 @@ func GetConfig(args []string, IDtype string) (err error) {
 	if err != nil {
 		return
 	}
-	cli.PrintFormattedJson(getCmd.OutOrStdout(), config)
+	cli.PrintFormattedJson(GetCmd.OutOrStdout(), config)
 	return
 }

--- a/cli/command/get/id/get-id-check.go
+++ b/cli/command/get/id/get-id-check.go
@@ -1,0 +1,31 @@
+package id
+
+import (
+	"fmt"
+
+	"github.com/Telmate/proxmox-api-go/cli"
+	"github.com/spf13/cobra"
+)
+
+var id_checkCmd = &cobra.Command{
+	Use:   "check ID",
+	Short: "Checks if a ID is availible",
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		id := cli.ValidateIntIDset(args, "ID")
+		c := cli.NewClient()
+		exixst, err := c.VMIdExists(id)
+		if err != nil {
+			return
+		}
+		if exixst {
+			fmt.Fprintf(idCmd.OutOrStdout(), "Selected ID is in use: %d\n", id)
+		} else {
+			fmt.Fprintf(idCmd.OutOrStdout(), "Selected ID is free: %d\n", id)
+		}
+		return
+	},
+}
+
+func init() {
+	idCmd.AddCommand(id_checkCmd)
+}

--- a/cli/command/get/id/get-id-check.go
+++ b/cli/command/get/id/get-id-check.go
@@ -13,11 +13,11 @@ var id_checkCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		id := cli.ValidateIntIDset(args, "ID")
 		c := cli.NewClient()
-		exixst, err := c.VMIdExists(id)
+		exists, err := c.VMIdExists(id)
 		if err != nil {
 			return
 		}
-		if exixst {
+		if exists {
 			fmt.Fprintf(idCmd.OutOrStdout(), "Selected ID is in use: %d\n", id)
 		} else {
 			fmt.Fprintf(idCmd.OutOrStdout(), "Selected ID is free: %d\n", id)

--- a/cli/command/get/id/get-id-max.go
+++ b/cli/command/get/id/get-id-max.go
@@ -1,0 +1,27 @@
+package id
+
+import (
+	"fmt"
+
+	"github.com/Telmate/proxmox-api-go/cli"
+	"github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/spf13/cobra"
+)
+
+var id_maxCmd = &cobra.Command{
+	Use:   "max",
+	Short: "Returns the maximum in use ID number",
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		c := cli.NewClient()
+		id, err := proxmox.MaxVmId(c)
+		if err != nil {
+			return
+		}
+		fmt.Fprintf(idCmd.OutOrStdout(), "Max in use ID: %d\n", id)
+		return
+	},
+}
+
+func init() {
+	idCmd.AddCommand(id_maxCmd)
+}

--- a/cli/command/get/id/get-id-next.go
+++ b/cli/command/get/id/get-id-next.go
@@ -1,0 +1,26 @@
+package id
+
+import (
+	"fmt"
+
+	"github.com/Telmate/proxmox-api-go/cli"
+	"github.com/spf13/cobra"
+)
+
+var id_nextCmd = &cobra.Command{
+	Use:   "next",
+	Short: "Returns the lowes availible ID",
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		c := cli.NewClient()
+		id, err := c.GetNextID(0)
+		if err != nil {
+			return
+		}
+		fmt.Fprintf(idCmd.OutOrStdout(), "Getting Next Free ID: %d\n", id)
+		return
+	},
+}
+
+func init() {
+	idCmd.AddCommand(id_nextCmd)
+}

--- a/cli/command/get/id/get-id.go
+++ b/cli/command/get/id/get-id.go
@@ -1,0 +1,15 @@
+package id
+
+import (
+	"github.com/Telmate/proxmox-api-go/cli/command/get"
+	"github.com/spf13/cobra"
+)
+
+var idCmd = &cobra.Command{
+	Use:   "id",
+	Short: "Commands to get information about guestIDs",
+}
+
+func init() {
+	get.GetCmd.AddCommand(idCmd)
+}

--- a/cli/validate.go
+++ b/cli/validate.go
@@ -1,19 +1,27 @@
 package cli
 
 import (
-	"strconv"
 	"fmt"
 	"log"
+	"strconv"
 )
 
-func ValidateIDset(args []string, indexPos int, text string) (string){
+func ValidateIDset(args []string, indexPos int, text string) string {
 	if indexPos+1 > len(args) {
 		log.Fatal(fmt.Errorf("error: no %s has been provided", text))
 	}
 	return args[indexPos]
 }
 
-func ValidateExistinGuestID(args []string, indexPos int) (int){
+func ValidateIntIDset(args []string, text string) int {
+	id, err := strconv.Atoi(ValidateIDset(args, 0, text))
+	if err != nil && id <= 0 {
+		log.Fatal(fmt.Errorf("error: %s must be a positive integer", text))
+	}
+	return id
+}
+
+func ValidateExistinGuestID(args []string, indexPos int) int {
 	id, err := strconv.Atoi(ValidateIDset(args, indexPos, "GuestID"))
 	if err != nil || id < 100 {
 		log.Fatal(fmt.Errorf("error: GuestID must be a positive integer of 100 or greater"))

--- a/main.go
+++ b/main.go
@@ -11,9 +11,9 @@ import (
 	"regexp"
 	"strconv"
 
-	"github.com/Telmate/proxmox-api-go/proxmox"
 	"github.com/Telmate/proxmox-api-go/cli"
 	_ "github.com/Telmate/proxmox-api-go/cli/command/commands"
+	"github.com/Telmate/proxmox-api-go/proxmox"
 )
 
 func main() {
@@ -297,9 +297,15 @@ func main() {
 		}
 		i, err := strconv.Atoi(flag.Args()[1])
 		failError(err)
-		id, err := c.VMIdExists(i)
-		failError(err)
-		log.Printf("Selected ID is free: %d\n", id)
+		exists, err := c.VMIdExists(i)
+		if err != nil {
+			return
+		}
+		if exists {
+			log.Printf("Selected ID is in use: %d\n", i)
+		} else {
+			log.Printf("Selected ID is free: %d\n", i)
+		}
 
 	case "migrate":
 		vmr := proxmox.NewVmRef(vmid)

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -855,6 +855,22 @@ func (c *Client) GetNextID(currentID int) (nextID int, err error) {
 	return
 }
 
+// VMIdExists - If you pass an VMID that exists it will return true, otherwise it wil return false
+func (c *Client) VMIdExists(vmID int) (exists bool, err error) {
+	resp, err := c.GetVmList()
+	if err != nil {
+		return
+	}
+	vms := resp["data"].([]interface{})
+	for vmii := range vms {
+		vm := vms[vmii].(map[string]interface{})
+		if vmID == int(vm["vmid"].(float64)) {
+			return true, err
+		}
+	}
+	return
+}
+
 // CreateVMDisk - Create single disk for VM on host node.
 func (c *Client) CreateVMDisk(
 	nodeName string,

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -480,7 +480,9 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 func NewConfigQemuFromJson(input []byte) (config *ConfigQemu, err error) {
 	config = &ConfigQemu{QemuVlanTag: -1, QemuKVM: true}
 	err = json.Unmarshal([]byte(input), config)
-	if err != nil {log.Fatal(err)}
+	if err != nil {
+		log.Fatal(err)
+	}
 	return
 }
 
@@ -1418,13 +1420,4 @@ func (confMap QemuDevice) readDeviceConfig(confList []string) error {
 func (c ConfigQemu) String() string {
 	jsConf, _ := json.Marshal(c)
 	return string(jsConf)
-}
-
-// VMIdExists - If you pass an VMID that exists it will raise an error otherwise it will return the vmID
-func (c *Client) VMIdExists(vmID int) (id int, err error) {
-	_, err = c.session.Get(fmt.Sprintf("/cluster/nextid?vmid=%d", vmID), nil, nil)
-	if err != nil {
-		return -1, err
-	}
-	return vmID, nil
 }

--- a/test/cli/preperations.go
+++ b/test/cli/preperations.go
@@ -4,9 +4,8 @@ import (
 	"os"
 )
 
-
 func SetEnvironmentVariables() {
-	os.Setenv("PM_API_URL","https://192.168.67.4:8006/api2/json")
-	os.Setenv("PM_USER","root@pam")
-	os.Setenv("PM_PASS","Enter123!")	
+	os.Setenv("PM_API_URL", "https://192.168.67.50:8006/api2/json")
+	os.Setenv("PM_USER", "root@pam")
+	os.Setenv("PM_PASS", "Enter123!")
 }


### PR DESCRIPTION
Another pull for https://github.com/Telmate/proxmox-api-go/issues/171

Work so far:

- Made the commands for getting id inforamation.
- Reimplemented the VMIdExists function to not rely on proxmox returning an error. this fuction is not used by the terraform provider so this change should't break anything there.
- Reinplemented the legacy `idstatus` command as the new VMIdExists function broke this.

No tests yet for these command as they are dependent on the CRUD operations of LXC and Qemu which haven't been implemented yet.