### PR TITLE
fix the problem, 1. cdrom triger panic 2. qemut agent can not get right value

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -568,7 +568,8 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 		case float64:
 			agent = int(vmConfig["agent"].(float64))
 		case string:
-			agent, _ = strconv.Atoi(vmConfig["agent"].(string))
+			AgentConfList := strings.Split(vmConfig["agent"].(string), ",")
+			agent, _ = strconv.Atoi(AgentConfList[0])
 		}
 
 	}

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -480,7 +480,9 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 func NewConfigQemuFromJson(input []byte) (config *ConfigQemu, err error) {
 	config = &ConfigQemu{QemuVlanTag: -1, QemuKVM: true}
 	err = json.Unmarshal([]byte(input), config)
-	if err != nil {log.Fatal(err)}
+	if err != nil {
+		log.Fatal(err)
+	}
 	return
 }
 
@@ -757,6 +759,11 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 		diskType := rxDiskType.FindStringSubmatch(diskName)[0]
 
 		diskConfMap := ParsePMConf(diskConfStr, "volume")
+
+		if diskConfMap["volume"].(string) == "none" {
+			continue
+		}
+
 		diskConfMap["slot"] = diskID
 		diskConfMap["type"] = diskType
 


### PR DESCRIPTION
1. UpdateConfig format is not right.
2. fix the problem, when cdrom is scsi and have no cd, it will triger panic.
3. fix the problem, agent can not get right value when agent have orther parameter.



![1662686553031](https://user-images.githubusercontent.com/100996593/189252564-3ede397a-6491-4527-830f-848d13c0b826.png)

![1662780129971](https://user-images.githubusercontent.com/100996593/189466844-d2c4df8f-f924-4d49-b57d-08b26d5ac2a0.png)
![image](https://user-images.githubusercontent.com/100996593/189466863-10544424-fb1f-43de-b512-56c95b5afcc0.png)

```
	agent := 0
	if _, isSet := vmConfig["agent"]; isSet {
		switch vmConfig["agent"].(type) {
		case float64:
			agent = int(vmConfig["agent"].(float64))
		case string:
                       // atoi always get 0 
			agent, _ = strconv.Atoi(vmConfig["agent"].(string))
		}

	}

```