### PR TITLE
Add missing protection option for QEMU

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -64,6 +64,8 @@ type ConfigQemu struct {
 	HaGroup         string      `json:"hagroup,omitempty"`
 	Tags            string      `json:"tags"`
 	Args            string      `json:"args"`
+	Protection      bool        `json:"protection"`
+
 
 	// Deprecated single disk.
 	DiskSize    float64 `json:"diskGB"`
@@ -131,6 +133,8 @@ func (config ConfigQemu) CreateVm(vmr *VmRef, client *Client) (err error) {
 		"tags":        config.Tags,
 		"machine":     config.Machine,
 		"args":        config.Args,
+		"protection":  config.Protection,
+
 	}
 
 	if config.QemuIso != "" {
@@ -303,6 +307,7 @@ func (config ConfigQemu) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 		"memory":      config.Memory,
 		"boot":        config.Boot,
 		"hookscript":  config.Hookscript,
+		"protection":  config.Protection,
 	}
 
 	//Array to list deleted parameters
@@ -561,7 +566,10 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 	if _, isSet := vmConfig["tablet"]; isSet {
 		tablet = Itob(int(vmConfig["tablet"].(float64)))
 	}
-
+	protection := false
+	if _, isSet := vmConfig["protection"]; isSet {
+		protection = Itob(int(vmConfig["protection"].(float64)))
+	}
 	agent := 0
 	if _, isSet := vmConfig["agent"]; isSet {
 		switch vmConfig["agent"].(type) {
@@ -640,6 +648,7 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 		Bios:            bios,
 		EFIDisk:         QemuDevice{},
 		Onboot:          onboot,
+		Protection:      protection,
 		Startup:         startup,
 		Tablet:          tablet,
 		Agent:           agent,

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -275,6 +275,10 @@ func (config ConfigQemu) CloneVm(sourceVmr *VmRef, vmr *VmRef, client *Client) (
 		"target": vmr.node,
 		"name":   config.Name,
 		"full":   fullclone,
+		"protection": protection,
+	}
+	if config.Protection != nil {
+		protection = strconv.Itoa(*config.Protection)
 	}
 	if vmr.pool != "" {
 		params["pool"] = vmr.pool
@@ -282,6 +286,10 @@ func (config ConfigQemu) CloneVm(sourceVmr *VmRef, vmr *VmRef, client *Client) (
 
 	if fullclone == "1" {
 		params["storage"] = storage
+	}
+
+	if protection == true {
+		params["protection"] = protection
 	}
 
 	_, err = client.CloneQemuVm(sourceVmr, params)

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -64,7 +64,7 @@ type ConfigQemu struct {
 	HaGroup         string      `json:"hagroup,omitempty"`
 	Tags            string      `json:"tags"`
 	Args            string      `json:"args"`
-	Protection      bool        `json:"protection"`
+	Protection      bool        `json:"protection,omitempty"`
 
 
 	// Deprecated single disk.
@@ -277,9 +277,6 @@ func (config ConfigQemu) CloneVm(sourceVmr *VmRef, vmr *VmRef, client *Client) (
 		"full":   fullclone,
 		"protection": protection,
 	}
-	if config.Protection != nil {
-		protection = strconv.Itoa(*config.Protection)
-	}
 	if vmr.pool != "" {
 		params["pool"] = vmr.pool
 	}
@@ -288,8 +285,8 @@ func (config ConfigQemu) CloneVm(sourceVmr *VmRef, vmr *VmRef, client *Client) (
 		params["storage"] = storage
 	}
 
-	if protection == true {
-		params["protection"] = protection
+	if config.Protection != nil {
+		protection = strconv.Itoa(*config.Protection)
 	}
 
 	_, err = client.CloneQemuVm(sourceVmr, params)


### PR DESCRIPTION
Add missing protection option for QEMU. It is present for LXC, but is missing from QEMU configuration for some reason.