### PR TITLE
Cli overhaul: guest create,get,delete commands (partial basic tests)

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	_ "github.com/Telmate/proxmox-api-go/cli/command/create"
+	_ "github.com/Telmate/proxmox-api-go/cli/command/create/guest"
 	_ "github.com/Telmate/proxmox-api-go/cli/command/delete"
 	_ "github.com/Telmate/proxmox-api-go/cli/command/example"
 	_ "github.com/Telmate/proxmox-api-go/cli/command/get"

--- a/cli/command/create/create-acmeaccount.go
+++ b/cli/command/create/create-acmeaccount.go
@@ -23,11 +23,11 @@ For config examples see "example acmeaccount"`,
 		if err != nil {
 			return
 		}
-		cli.PrintItemCreated(createCmd.OutOrStdout(), id, "AcmeAccount")
+		cli.PrintItemCreated(CreateCmd.OutOrStdout(), id, "AcmeAccount")
 		return
 	},
 }
 
 func init() {
-	createCmd.AddCommand(create_acmeaccountCmd)
+	CreateCmd.AddCommand(create_acmeaccountCmd)
 }

--- a/cli/command/create/create-pool.go
+++ b/cli/command/create/create-pool.go
@@ -6,10 +6,10 @@ import (
 )
 
 var create_poolCmd = &cobra.Command{
-	Use:   "pool POOLID [COMMENT]" ,
+	Use:   "pool POOLID [COMMENT]",
 	Short: "Creates a new pool",
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
-		id := cli.ValidateIDset(args, 0 ,"PoolID")
+		id := cli.ValidateIDset(args, 0, "PoolID")
 		var comment string
 		if len(args) > 1 {
 			comment = args[1]
@@ -19,11 +19,11 @@ var create_poolCmd = &cobra.Command{
 		if err != nil {
 			return
 		}
-		cli.PrintItemCreated(createCmd.OutOrStdout() ,id, "Pool")
+		cli.PrintItemCreated(CreateCmd.OutOrStdout(), id, "Pool")
 		return
 	},
 }
 
 func init() {
-	createCmd.AddCommand(create_poolCmd)
+	CreateCmd.AddCommand(create_poolCmd)
 }

--- a/cli/command/create/create-storage.go
+++ b/cli/command/create/create-storage.go
@@ -23,11 +23,11 @@ For config examples see "example storage"`,
 		if err != nil {
 			return
 		}
-		cli.PrintItemCreated(createCmd.OutOrStdout(), id, "Storage")
+		cli.PrintItemCreated(CreateCmd.OutOrStdout(), id, "Storage")
 		return
 	},
 }
 
 func init() {
-	createCmd.AddCommand(create_storageCmd)
+	CreateCmd.AddCommand(create_storageCmd)
 }

--- a/cli/command/create/create.go
+++ b/cli/command/create/create.go
@@ -5,11 +5,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var createCmd = &cobra.Command{
+var CreateCmd = &cobra.Command{
 	Use:   "create",
 	Short: "With this command you can create new items in proxmox",
 }
 
 func init() {
-	cli.RootCmd.AddCommand(createCmd)
+	cli.RootCmd.AddCommand(CreateCmd)
 }

--- a/cli/command/create/guest/create-guest-lxc.go
+++ b/cli/command/create/guest/create-guest-lxc.go
@@ -1,0 +1,20 @@
+package guest
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var guest_lxcCmd = &cobra.Command{
+	Use:   "lxc GUESTID NODEID",
+	Short: "Creates a new Guest System of the type Lxc on the specified Node",
+	Long: `Creates a new Guest System of the type Lxc on the specified Node.
+The config can be set with the --file flag or piped from stdin.
+For config examples see "example guest lxc"`,
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		return createGuest(args, "LxcGuest")
+	},
+}
+
+func init() {
+	guestCmd.AddCommand(guest_lxcCmd)
+}

--- a/cli/command/create/guest/create-guest-qemu.go
+++ b/cli/command/create/guest/create-guest-qemu.go
@@ -1,0 +1,20 @@
+package guest
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var guest_qemuCmd = &cobra.Command{
+	Use:   "qemu GUESTID NODEID",
+	Short: "Creates a new Guest System of the type Qemu on the specified Node",
+	Long: `Creates a new Guest System of the type Qemu on the specified Node.
+	The config can be set with the --file flag or piped from stdin.
+	For config examples see "example guest qemu"`,
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		return createGuest(args, "QemuGuest")
+	},
+}
+
+func init() {
+	guestCmd.AddCommand(guest_qemuCmd)
+}

--- a/cli/command/create/guest/create-guest.go
+++ b/cli/command/create/guest/create-guest.go
@@ -1,0 +1,48 @@
+package guest
+
+import (
+	"strconv"
+
+	"github.com/Telmate/proxmox-api-go/cli"
+	"github.com/Telmate/proxmox-api-go/cli/command/create"
+	"github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/spf13/cobra"
+)
+
+var guestCmd = &cobra.Command{
+	Use:   "guest",
+	Short: "With this command you can create new Lxc containers and Qemu virtual machines in proxmox",
+}
+
+func init() {
+	create.CreateCmd.AddCommand(guestCmd)
+}
+
+func createGuest(args []string, IDtype string) (err error) {
+	id := cli.ValidateIntIDset(args, IDtype+"ID")
+	node := cli.ValidateIDset(args, 1, "NodeID")
+	vmr := proxmox.NewVmRef(id)
+	vmr.SetNode(node)
+	c := cli.NewClient()
+	switch IDtype {
+	case "LxcGuest":
+		var config proxmox.ConfigLxc
+		config, err = proxmox.NewConfigLxcFromJson(cli.NewConfig())
+		if err != nil {
+			return
+		}
+		err = config.CreateLxc(vmr, c)
+	case "QemuGuest":
+		var config *proxmox.ConfigQemu
+		config, err = proxmox.NewConfigQemuFromJson(cli.NewConfig())
+		if err != nil {
+			return
+		}
+		err = config.CreateVm(vmr, c)
+	}
+	if err != nil {
+		return
+	}
+	cli.PrintItemCreated(guestCmd.OutOrStdout(), strconv.Itoa(id), IDtype)
+	return
+}

--- a/cli/command/delete/delete-acmeaccount.go
+++ b/cli/command/delete/delete-acmeaccount.go
@@ -8,7 +8,7 @@ var delete_acmeaccountCmd = &cobra.Command{
 	Use:   "acmeaccount ACMEACCOUNTID",
 	Short: "Deletes the Speciefied AcmeAccount",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return DeleteID(args, "AcmeAccount")
+		return deleteID(args, "AcmeAccount")
 	},
 }
 

--- a/cli/command/delete/delete-guest.go
+++ b/cli/command/delete/delete-guest.go
@@ -1,0 +1,33 @@
+package delete
+
+import (
+	"strconv"
+
+	"github.com/Telmate/proxmox-api-go/cli"
+	"github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/spf13/cobra"
+)
+
+var delete_guestCmd = &cobra.Command{
+	Use:   "guest GUESTID",
+	Short: "Deletes the Speciefied Guest",
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		id := cli.ValidateIntIDset(args, "GuestID")
+		vmr := proxmox.NewVmRef(id)
+		c := cli.NewClient()
+		_, err = c.StopVm(vmr)
+		if err != nil {
+			return
+		}
+		_, err = c.DeleteVm(vmr)
+		if err != nil {
+			return
+		}
+		cli.PrintItemDeleted(deleteCmd.OutOrStdout(), strconv.Itoa(id), "GuestID")
+		return
+	},
+}
+
+func init() {
+	deleteCmd.AddCommand(delete_guestCmd)
+}

--- a/cli/command/delete/delete-metricserver.go
+++ b/cli/command/delete/delete-metricserver.go
@@ -8,7 +8,7 @@ var delete_metricserverCmd = &cobra.Command{
 	Use:   "metricserver METRICSID",
 	Short: "Deletes the speciefied MetricServer",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return DeleteID(args, "MetricServer")
+		return deleteID(args, "MetricServer")
 	},
 }
 

--- a/cli/command/delete/delete-pool.go
+++ b/cli/command/delete/delete-pool.go
@@ -8,7 +8,7 @@ var delete_poolCmd = &cobra.Command{
 	Use:   "pool POOLID",
 	Short: "Deletes the Speciefied pool",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return DeleteID(args, "Pool")
+		return deleteID(args, "Pool")
 	},
 }
 

--- a/cli/command/delete/delete-pool.go
+++ b/cli/command/delete/delete-pool.go
@@ -7,9 +7,8 @@ import (
 var delete_poolCmd = &cobra.Command{
 	Use:   "pool POOLID",
 	Short: "Deletes the Speciefied pool",
-	RunE: func(cmd *cobra.Command, args []string) (err error) {
-		err = DeleteID(args, "Pool")	
-		return
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return DeleteID(args, "Pool")
 	},
 }
 

--- a/cli/command/delete/delete-storage.go
+++ b/cli/command/delete/delete-storage.go
@@ -8,7 +8,7 @@ var delete_storageCmd = &cobra.Command{
 	Use:   "storage STORAGEID",
 	Short: "Deletes the speciefied Storage",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return DeleteID(args, "Storage")
+		return deleteID(args, "Storage")
 	},
 }
 

--- a/cli/command/delete/delete-user.go
+++ b/cli/command/delete/delete-user.go
@@ -7,9 +7,8 @@ import (
 var delete_userCmd = &cobra.Command{
 	Use:   "user USERID",
 	Short: "Deletes the speciefied User",
-	RunE: func(cmd *cobra.Command, args []string) (err error) {
-		err = DeleteID(args, "User")
-		return
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return DeleteID(args, "User")
 	},
 }
 

--- a/cli/command/delete/delete-user.go
+++ b/cli/command/delete/delete-user.go
@@ -8,7 +8,7 @@ var delete_userCmd = &cobra.Command{
 	Use:   "user USERID",
 	Short: "Deletes the speciefied User",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return DeleteID(args, "User")
+		return deleteID(args, "User")
 	},
 }
 

--- a/cli/command/delete/delete.go
+++ b/cli/command/delete/delete.go
@@ -16,7 +16,7 @@ func init() {
 	cli.RootCmd.AddCommand(deleteCmd)
 }
 
-func DeleteID(args []string, IDtype string) (err error) {
+func deleteID(args []string, IDtype string) (err error) {
 	var exitStatus string
 	id := cli.ValidateIDset(args, 0, IDtype+"ID")
 	c := cli.NewClient()

--- a/cli/command/get/get-acmeaccount.go
+++ b/cli/command/get/get-acmeaccount.go
@@ -8,7 +8,7 @@ var get_acmeaccountCmd = &cobra.Command{
 	Use:   "acmeaccount ACMEACCOUNTID",
 	Short: "Gets the configuration of the specified AcmeAccount",
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
-		return GetConfig(args, "AcmeAccount")
+		return getConfig(args, "AcmeAccount")
 	},
 }
 

--- a/cli/command/get/get-guest.go
+++ b/cli/command/get/get-guest.go
@@ -1,0 +1,38 @@
+package get
+
+import (
+	"github.com/Telmate/proxmox-api-go/cli"
+	"github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/spf13/cobra"
+)
+
+var get_guestCmd = &cobra.Command{
+	Use:   "guest GUESTID",
+	Short: "Gets the configuration of the specified guest",
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		id := cli.ValidateIntIDset(args, "GuestID")
+		vmr := proxmox.NewVmRef(id)
+		c := cli.NewClient()
+		err = c.CheckVmRef(vmr)
+		if err != nil {
+			return
+		}
+		vmType := vmr.GetVmType()
+		var config interface{}
+		switch vmType {
+		case "qemu":
+			config, err = proxmox.NewConfigQemuFromApi(vmr, c)
+		case "lxc":
+			config, err = proxmox.NewConfigLxcFromApi(vmr, c)
+		}
+		if err != nil {
+			return
+		}
+		cli.PrintFormattedJson(GetCmd.OutOrStdout(), config)
+		return
+	},
+}
+
+func init() {
+	GetCmd.AddCommand(get_guestCmd)
+}

--- a/cli/command/get/get-metricserver.go
+++ b/cli/command/get/get-metricserver.go
@@ -8,7 +8,7 @@ var get_metricserverCmd = &cobra.Command{
 	Use:   "metricserver METRICSID",
 	Short: "Gets the configuration of the specified MetricServer",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return GetConfig(args, "MetricServer")
+		return getConfig(args, "MetricServer")
 	},
 }
 

--- a/cli/command/get/get-pool.go
+++ b/cli/command/get/get-pool.go
@@ -1,10 +1,6 @@
 package get
 
 import (
-	"encoding/json"
-	"fmt"
-
-	"github.com/Telmate/proxmox-api-go/cli"
 	"github.com/spf13/cobra"
 )
 
@@ -12,18 +8,7 @@ var get_poolCmd = &cobra.Command{
 	Use:   "pool POOLID",
 	Short: "Gets the configuration of the specified Pool",
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
-		id := cli.ValidateIDset(args, 0, "PoolID")
-		c := cli.NewClient()
-		poolinfo, err := c.GetPoolInfo(id)
-		if err != nil {
-			return
-		}
-		poolList, err := json.Marshal(poolinfo)
-		if err != nil {
-			return
-		}
-		fmt.Fprintln(GetCmd.OutOrStdout(), string(poolList))
-		return
+		return GetConfig(args, "Pool")
 	},
 }
 

--- a/cli/command/get/get-pool.go
+++ b/cli/command/get/get-pool.go
@@ -8,7 +8,7 @@ var get_poolCmd = &cobra.Command{
 	Use:   "pool POOLID",
 	Short: "Gets the configuration of the specified Pool",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return GetConfig(args, "Pool")
+		return getConfig(args, "Pool")
 	},
 }
 

--- a/cli/command/get/get-pool.go
+++ b/cli/command/get/get-pool.go
@@ -7,7 +7,7 @@ import (
 var get_poolCmd = &cobra.Command{
 	Use:   "pool POOLID",
 	Short: "Gets the configuration of the specified Pool",
-	RunE: func(cmd *cobra.Command, args []string) (err error) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		return GetConfig(args, "Pool")
 	},
 }

--- a/cli/command/get/get-storage.go
+++ b/cli/command/get/get-storage.go
@@ -8,7 +8,7 @@ var get_storageCmd = &cobra.Command{
 	Use:   "storage",
 	Short: "Gets the configuration of the specified Storage backend",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return GetConfig(args, "Storage")
+		return getConfig(args, "Storage")
 	},
 }
 

--- a/cli/command/get/get-user.go
+++ b/cli/command/get/get-user.go
@@ -8,7 +8,7 @@ var get_userCmd = &cobra.Command{
 	Use:   "user USERID",
 	Short: "Gets the configuration of the specified User",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return GetConfig(args, "User")
+		return getConfig(args, "User")
 	},
 }
 

--- a/cli/command/get/get.go
+++ b/cli/command/get/get.go
@@ -15,7 +15,7 @@ func init() {
 	cli.RootCmd.AddCommand(GetCmd)
 }
 
-func GetConfig(args []string, IDtype string) (err error) {
+func getConfig(args []string, IDtype string) (err error) {
 	id := cli.ValidateIDset(args, 0, IDtype+"ID")
 	c := cli.NewClient()
 	var config interface{}

--- a/cli/command/get/get.go
+++ b/cli/command/get/get.go
@@ -24,6 +24,8 @@ func GetConfig(args []string, IDtype string) (err error) {
 		config, err = proxmox.NewConfigAcmeAccountFromApi(id, c)
 	case "MetricServer":
 		config, err = proxmox.NewConfigMetricsFromApi(id, c)
+	case "Pool":
+		config, err = c.GetPoolInfo(id)
 	case "Storage":
 		config, err = proxmox.NewConfigStorageFromApi(id, c)
 	case "User":

--- a/cli/command/list/list-acmeaccounts.go
+++ b/cli/command/list/list-acmeaccounts.go
@@ -8,10 +8,9 @@ var list_acmeaccountsCmd = &cobra.Command{
 	Use:   "acmeaccounts",
 	Short: "Prints a list of AcmeAccounts in raw json format",
 	Run: func(cmd *cobra.Command, args []string) {
-		ListRaw("AcmeAccounts")
+		listRaw("AcmeAccounts")
 	},
 }
-
 
 func init() {
 	listCmd.AddCommand(list_acmeaccountsCmd)

--- a/cli/command/list/list-acmeplugins.go
+++ b/cli/command/list/list-acmeplugins.go
@@ -8,10 +8,9 @@ var list_acmepluginsCmd = &cobra.Command{
 	Use:   "acmeplugins",
 	Short: "Prints a list of AcmePlugins in raw json format",
 	Run: func(cmd *cobra.Command, args []string) {
-		ListRaw("AcmePlugins")
+		listRaw("AcmePlugins")
 	},
 }
-
 
 func init() {
 	listCmd.AddCommand(list_acmepluginsCmd)

--- a/cli/command/list/list-guests.go
+++ b/cli/command/list/list-guests.go
@@ -8,7 +8,7 @@ var list_qemuguestsCmd = &cobra.Command{
 	Use:   "guests",
 	Short: "Prints a list of Qemu/Lxc Guests in raw json format",
 	Run: func(cmd *cobra.Command, args []string) {
-		ListRaw("Guests")
+		listRaw("Guests")
 	},
 }
 

--- a/cli/command/list/list-metricservers.go
+++ b/cli/command/list/list-metricservers.go
@@ -8,10 +8,9 @@ var list_metricserversCmd = &cobra.Command{
 	Use:   "metricservers",
 	Short: "Prints a list of MetricServers in raw json format",
 	Run: func(cmd *cobra.Command, args []string) {
-		ListRaw("MetricServers")
+		listRaw("MetricServers")
 	},
 }
-
 
 func init() {
 	listCmd.AddCommand(list_metricserversCmd)

--- a/cli/command/list/list-nodes.go
+++ b/cli/command/list/list-nodes.go
@@ -8,7 +8,7 @@ var list_nodesCmd = &cobra.Command{
 	Use:   "nodes",
 	Short: "Prints a list of Nodes in raw json format",
 	Run: func(cmd *cobra.Command, args []string) {
-		ListRaw("Nodes")
+		listRaw("Nodes")
 	},
 }
 

--- a/cli/command/list/list-pools.go
+++ b/cli/command/list/list-pools.go
@@ -8,10 +8,9 @@ var list_poolsCmd = &cobra.Command{
 	Use:   "pools",
 	Short: "Prints a list of Pools in raw json format",
 	Run: func(cmd *cobra.Command, args []string) {
-		ListRaw("Pools")
+		listRaw("Pools")
 	},
 }
-
 
 func init() {
 	listCmd.AddCommand(list_poolsCmd)

--- a/cli/command/list/list-storages.go
+++ b/cli/command/list/list-storages.go
@@ -8,10 +8,9 @@ var list_storagesCmd = &cobra.Command{
 	Use:   "storages",
 	Short: "Prints a list of Storages in raw json format",
 	Run: func(cmd *cobra.Command, args []string) {
-		ListRaw("Storages")
+		listRaw("Storages")
 	},
 }
-
 
 func init() {
 	listCmd.AddCommand(list_storagesCmd)

--- a/cli/command/list/list-users.go
+++ b/cli/command/list/list-users.go
@@ -8,7 +8,7 @@ var list_usersCmd = &cobra.Command{
 	Use:   "users",
 	Short: "Prints a list of Users in raw json format",
 	Run: func(cmd *cobra.Command, args []string) {
-		ListRaw("Users")
+		listRaw("Users")
 	},
 }
 

--- a/cli/command/list/list.go
+++ b/cli/command/list/list.go
@@ -14,7 +14,7 @@ func init() {
 	cli.RootCmd.AddCommand(listCmd)
 }
 
-func ListRaw(IDtype string){
+func listRaw(IDtype string) {
 	c := cli.NewClient()
 	var list map[string]interface{}
 	var err error
@@ -37,5 +37,5 @@ func ListRaw(IDtype string){
 		list, err = c.GetUserList()
 	}
 	cli.LogFatalListing(IDtype, err)
-	cli.PrintRawJson(listCmd.OutOrStdout(),list)
+	cli.PrintRawJson(listCmd.OutOrStdout(), list)
 }

--- a/main.go
+++ b/main.go
@@ -103,14 +103,14 @@ func main() {
 		vmr = proxmox.NewVmRef(vmid)
 		jbody, err = c.StopVm(vmr)
 		failError(err)
-		// TODO make destroy in new cli
+
 	case "destroy":
 		vmr = proxmox.NewVmRef(vmid)
 		jbody, err = c.StopVm(vmr)
 		failError(err)
 		jbody, err = c.DeleteVm(vmr)
 		failError(err)
-		// TODO make getConfig in new cli
+
 	case "getConfig":
 		vmr = proxmox.NewVmRef(vmid)
 		err := c.CheckVmRef(vmr)
@@ -138,7 +138,7 @@ func main() {
 		networkInterfaceJSON, err := json.Marshal(networkInterfaces)
 		failError(err)
 		fmt.Println(string(networkInterfaceJSON))
-		// TODO make createQemu in new cli
+
 	case "createQemu":
 		config, err := proxmox.NewConfigQemuFromJson(GetConfig(*fConfigFile))
 		failError(err)
@@ -146,7 +146,7 @@ func main() {
 		vmr.SetNode(flag.Args()[2])
 		failError(config.CreateVm(vmr, c))
 		log.Println("Complete")
-		// TODO make createLxc in new cli
+
 	case "createLxc":
 		config, err := proxmox.NewConfigLxcFromJson(GetConfig(*fConfigFile))
 		failError(err)
@@ -345,7 +345,7 @@ func main() {
 			os.Exit(1)
 		}
 		log.Printf("VM %d is moved on %s\n", vmid, args[1])
-		// TODO make getNodeList in new cli
+
 	case "getNodeList":
 		nodes, err := c.GetNodeList()
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -72,6 +72,7 @@ func main() {
 
 	switch flag.Args()[0] {
 
+	// TODO make testUserPermissions in new cli
 	case "testUserPermissions":
 		// testuserpermission [user] [path]
 		// ex: testuserpermission root@pam(default) /(default)
@@ -102,14 +103,14 @@ func main() {
 		vmr = proxmox.NewVmRef(vmid)
 		jbody, err = c.StopVm(vmr)
 		failError(err)
-
+		// TODO make destroy in new cli
 	case "destroy":
 		vmr = proxmox.NewVmRef(vmid)
 		jbody, err = c.StopVm(vmr)
 		failError(err)
 		jbody, err = c.DeleteVm(vmr)
 		failError(err)
-
+		// TODO make getConfig in new cli
 	case "getConfig":
 		vmr = proxmox.NewVmRef(vmid)
 		err := c.CheckVmRef(vmr)
@@ -126,7 +127,7 @@ func main() {
 		cj, err := json.MarshalIndent(config, "", "  ")
 		failError(err)
 		log.Println(string(cj))
-
+		// TODO make getNetworkInterfaces in new cli
 	case "getNetworkInterfaces":
 		vmr = proxmox.NewVmRef(vmid)
 		err := c.CheckVmRef(vmr)
@@ -137,7 +138,7 @@ func main() {
 		networkInterfaceJSON, err := json.Marshal(networkInterfaces)
 		failError(err)
 		fmt.Println(string(networkInterfaceJSON))
-
+		// TODO make createQemu in new cli
 	case "createQemu":
 		config, err := proxmox.NewConfigQemuFromJson(GetConfig(*fConfigFile))
 		failError(err)
@@ -145,7 +146,7 @@ func main() {
 		vmr.SetNode(flag.Args()[2])
 		failError(config.CreateVm(vmr, c))
 		log.Println("Complete")
-
+		// TODO make createLxc in new cli
 	case "createLxc":
 		config, err := proxmox.NewConfigLxcFromJson(GetConfig(*fConfigFile))
 		failError(err)
@@ -153,7 +154,7 @@ func main() {
 		vmr.SetNode(flag.Args()[2])
 		failError(config.CreateLxc(vmr, c))
 		log.Println("Complete")
-
+		// TODO make installQemu in new cli
 	case "installQemu":
 		config, err := proxmox.NewConfigQemuFromJson(GetConfig(*fConfigFile))
 		var mode string
@@ -203,7 +204,7 @@ func main() {
 		log.Printf("MaxID: %d\n", maxid)
 		log.Printf("NextID: %d\n", nextid)
 		log.Println("---")
-
+		// TODO make cloneQemu in new cli
 	case "cloneQemu":
 		config, err := proxmox.NewConfigQemuFromJson(GetConfig(*fConfigFile))
 		failError(err)
@@ -234,13 +235,13 @@ func main() {
 		failError(config.CloneVm(sourceVmr, vmr, c))
 		failError(config.UpdateConfig(vmr, c))
 		log.Println("Complete")
-
+		// TODO make createQemuSnapshot in new cli
 	case "createQemuSnapshot":
 		sourceVmr, err := c.GetVmRefByName(flag.Args()[1])
 		failError(err)
 		jbody, err = c.CreateQemuSnapshot(sourceVmr, flag.Args()[2])
 		failError(err)
-
+		// TODO make deleteQemuSnapshot in new cli
 	case "deleteQemuSnapshot":
 		sourceVmr, err := c.GetVmRefByName(flag.Args()[1])
 		failError(err)
@@ -284,36 +285,36 @@ func main() {
 			}
 		}
 		failError(err)
-
+		// TODO make rollbackQemu in new cli
 	case "rollbackQemu":
 		sourceVmr, err := c.GetVmRefByName(flag.Args()[1])
 		failError(err)
 		jbody, err = c.RollbackQemuVm(sourceVmr, flag.Args()[2])
 		failError(err)
-
+		// TODO make sshforward in new cli
 	case "sshforward":
 		vmr = proxmox.NewVmRef(vmid)
 		sshPort, err := proxmox.SshForwardUsernet(vmr, c)
 		failError(err)
 		log.Println("SSH Portforward on:" + sshPort)
-
+		// TODO make sshbackward in new cli
 	case "sshbackward":
 		vmr = proxmox.NewVmRef(vmid)
 		err = proxmox.RemoveSshForwardUsernet(vmr, c)
 		failError(err)
 		log.Println("SSH Portforward off")
-
+		// TODO make sendstring in new cli
 	case "sendstring":
 		vmr = proxmox.NewVmRef(vmid)
 		err = proxmox.SendKeysString(vmr, c, flag.Args()[2])
 		failError(err)
 		log.Println("Keys sent")
-
+		// TODO make nextid in new cli
 	case "nextid":
 		id, err := c.GetNextID(0)
 		failError(err)
 		log.Printf("Getting Next Free ID: %d\n", id)
-
+		// TODO make checkid in new cli
 	case "checkid":
 		if len(flag.Args()) < 2 {
 			fmt.Printf("Missing vmid\n")
@@ -328,7 +329,7 @@ func main() {
 		} else {
 			log.Printf("Selected ID is free: %d\n", i)
 		}
-
+		// TODO make migrate in new cli
 	case "migrate":
 		vmr := proxmox.NewVmRef(vmid)
 		c.GetVmInfo(vmr)
@@ -344,7 +345,7 @@ func main() {
 			os.Exit(1)
 		}
 		log.Printf("VM %d is moved on %s\n", vmid, args[1])
-
+		// TODO make getNodeList in new cli
 	case "getNodeList":
 		nodes, err := c.GetNodeList()
 		if err != nil {
@@ -356,6 +357,7 @@ func main() {
 		fmt.Println(string(nodeList))
 
 	// only returns enabled resources
+	// TODO make getResourceList in new cli
 	case "getResourceList":
 		resource, err := c.GetResourceList("")
 		if err != nil {
@@ -387,7 +389,7 @@ func main() {
 		config, err := proxmox.NewConfigQemuFromApi(vmr, c)
 		failError(err)
 		fmt.Println(config)
-
+		// TODO make getVmInfo in new cli
 	case "getVersion":
 		versionInfo, err := c.GetVersion()
 		failError(err)
@@ -546,7 +548,7 @@ func main() {
 		acmeid := flag.Args()[1]
 		failError(config.CreateAcmeAccount(acmeid, c))
 		log.Printf("Acme account %s has been created\n", acmeid)
-
+		// TODO make updateAcmeAccountEmail in new cli
 	case "updateAcmeAccountEmail":
 		if len(flag.Args()) < 3 {
 			log.Printf("Error: acme name and email(s) required")
@@ -577,7 +579,7 @@ func main() {
 		pluginList, err := json.Marshal(plugins)
 		failError(err)
 		fmt.Println(string(pluginList))
-
+		// TODO make getAcmePlugin in new cli
 	case "getAcmePlugin":
 		var config interface{}
 		pluginid := flag.Args()[1]
@@ -586,7 +588,7 @@ func main() {
 		cj, err := json.MarshalIndent(config, "", "  ")
 		failError(err)
 		log.Println(string(cj))
-
+		// TODO make setAcmePlugin in new cli
 	case "setAcmePlugin":
 		if len(flag.Args()) < 2 {
 			log.Printf("Error: Acme plugin name required")
@@ -597,7 +599,7 @@ func main() {
 		pluginid := flag.Args()[1]
 		failError(config.SetAcmePlugin(pluginid, c))
 		log.Printf("Acme plugin %s has been configured\n", pluginid)
-
+		// TODO make deleteAcmePlugin in new cli
 	case "deleteAcmePlugin":
 		if len(flag.Args()) < 2 {
 			log.Printf("Error: Acme plugin name required")

--- a/main.go
+++ b/main.go
@@ -309,12 +309,12 @@ func main() {
 		err = proxmox.SendKeysString(vmr, c, flag.Args()[2])
 		failError(err)
 		log.Println("Keys sent")
-		// TODO make nextid in new cli
+
 	case "nextid":
 		id, err := c.GetNextID(0)
 		failError(err)
 		log.Printf("Getting Next Free ID: %d\n", id)
-		// TODO make checkid in new cli
+
 	case "checkid":
 		if len(flag.Args()) < 2 {
 			fmt.Printf("Missing vmid\n")

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -244,7 +244,7 @@ func (c *Client) GetVmState(vmr *VmRef) (vmState map[string]interface{}, err err
 	if err != nil {
 		return nil, err
 	}
-	return c.GetItemConfigMapStringInterface(fmt.Sprintf("/nodes/%s/%s/%d/status/current", vmr.node, vmr.vmType, vmr.vmId), "vm", "STATE")
+	return c.GetItemConfigMapStringInterface("/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/status/current", "vm", "STATE")
 }
 
 func (c *Client) GetVmConfig(vmr *VmRef) (vmConfig map[string]interface{}, err error) {
@@ -252,17 +252,7 @@ func (c *Client) GetVmConfig(vmr *VmRef) (vmConfig map[string]interface{}, err e
 	if err != nil {
 		return nil, err
 	}
-	var data map[string]interface{}
-	url := fmt.Sprintf("/nodes/%s/%s/%d/config", vmr.node, vmr.vmType, vmr.vmId)
-	err = c.GetJsonRetryable(url, &data, 3)
-	if err != nil {
-		return nil, err
-	}
-	if data["data"] == nil {
-		return nil, fmt.Errorf("vm CONFIG not readable")
-	}
-	vmConfig = data["data"].(map[string]interface{})
-	return
+	return c.GetItemConfigMapStringInterface("/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/config", "vm", "CONFIG")
 }
 
 func (c *Client) GetStorageStatus(vmr *VmRef, storageName string) (storageStatus map[string]interface{}, err error) {
@@ -715,21 +705,8 @@ func (c *Client) RollbackQemuVm(vmr *VmRef, snapshot string) (exitStatus string,
 }
 
 // SetVmConfig - send config options
-func (c *Client) SetVmConfig(vmr *VmRef, vmParams map[string]interface{}) (exitStatus interface{}, err error) {
-	reqbody := ParamsToBody(vmParams)
-	url := fmt.Sprintf("/nodes/%s/%s/%d/config", vmr.node, vmr.vmType, vmr.vmId)
-	resp, err := c.session.Post(url, nil, nil, &reqbody)
-	if err == nil {
-		taskResponse, err := ResponseJSON(resp)
-		if err != nil {
-			return nil, err
-		}
-		exitStatus, err = c.WaitForCompletion(taskResponse)
-		if err != nil {
-			return "", err
-		}
-	}
-	return
+func (c *Client) SetVmConfig(vmr *VmRef, params map[string]interface{}) (exitStatus interface{}, err error) {
+	return c.CreateItemWithTask(params, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/config")
 }
 
 // SetLxcConfig - send config options
@@ -1575,30 +1552,25 @@ func (c *Client) GetPoolList() (pools map[string]interface{}, err error) {
 }
 
 func (c *Client) GetPoolInfo(poolid string) (poolInfo map[string]interface{}, err error) {
-	url := fmt.Sprintf("/pools/%s", poolid)
-	return c.GetItemConfigMapStringInterface(url, "pool", "CONFIG")
+	return c.GetItemConfigMapStringInterface("/pools/"+poolid, "pool", "CONFIG")
 }
 
 func (c *Client) CreatePool(poolid string, comment string) error {
-	paramMap := map[string]interface{}{
+	return c.CreateItem(map[string]interface{}{
 		"poolid":  poolid,
 		"comment": comment,
-	}
-	return c.CreateItem(paramMap, "/pools")
+	}, "/pools")
 }
 
 func (c *Client) UpdatePoolComment(poolid string, comment string) error {
-	paramMap := map[string]interface{}{
+	return c.UpdateItem(map[string]interface{}{
 		"poolid":  poolid,
 		"comment": comment,
-	}
-	url := fmt.Sprintf("/pools/%s", poolid)
-	return c.UpdateItem(paramMap, url)
+	}, "/pools/"+poolid)
 }
 
 func (c *Client) DeletePool(poolid string) error {
-	url := fmt.Sprintf("/pools/%s", poolid)
-	return c.DeleteUrl(url)
+	return c.DeleteUrl("/pools/" + poolid)
 }
 
 // User
@@ -1607,7 +1579,7 @@ func (c *Client) GetUserConfig(id string) (config map[string]interface{}, err er
 }
 
 func (c *Client) GetUserList() (users map[string]interface{}, err error) {
-	return c.GetItemList("/access/users" + "?full=1")
+	return c.GetItemList("/access/users?full=1")
 }
 
 func (c *Client) UpdateUserPassword(userid string, password string) error {
@@ -1615,11 +1587,10 @@ func (c *Client) UpdateUserPassword(userid string, password string) error {
 	if err != nil {
 		return err
 	}
-	paramMap := map[string]interface{}{
+	return c.UpdateItem(map[string]interface{}{
 		"userid":   userid,
 		"password": password,
-	}
-	return c.UpdateItem(paramMap, "/access/password")
+	}, "/access/password")
 }
 
 func (c *Client) CreateUser(params map[string]interface{}) (err error) {
@@ -1711,8 +1682,7 @@ func (c *Client) UpdateAcmeAccountEmails(id, emails string) (exitStatus string, 
 }
 
 func (c *Client) DeleteAcmeAccount(id string) (exitStatus string, err error) {
-	exitStatus, err = c.DeleteUrlWithTask("/cluster/acme/account/" + id)
-	return
+	return c.DeleteUrlWithTask("/cluster/acme/account/" + id)
 }
 
 // ACME Plugin
@@ -1771,10 +1741,9 @@ func (c *Client) DeleteMetricServer(id string) error {
 
 // storage
 func (c *Client) EnableStorage(id string) error {
-	param := map[string]interface{}{
+	return c.UpdateItem(map[string]interface{}{
 		"disable": false,
-	}
-	return c.UpdateItem(param, "/storage/"+id)
+	}, "/storage/"+id)
 }
 
 func (c *Client) GetStorageList() (metricServers map[string]interface{}, err error) {
@@ -1785,7 +1754,7 @@ func (c *Client) GetStorageConfig(id string) (config map[string]interface{}, err
 	return c.GetItemConfigMapStringInterface("/storage/"+id, "storage", "CONFIG")
 }
 
-func (c *Client) CreateStorage(id string, params map[string]interface{}) error {
+func (c *Client) CreateStorage(params map[string]interface{}) error {
 	return c.CreateItem(params, "/storage")
 }
 
@@ -1899,8 +1868,7 @@ func (c *Client) HandleTaskError(resp *http.Response) (exitStatus string) {
 	// This might not work if we never got a body. We'll ignore errors in trying to read,
 	// but extract the body if possible to give any error information back in the exitStatus
 	b, _ := io.ReadAll(resp.Body)
-	exitStatus = string(b)
-	return
+	return string(b)
 }
 
 // Check if the proxmox task has been completed

--- a/proxmox/config_storage.go
+++ b/proxmox/config_storage.go
@@ -955,7 +955,7 @@ func (config *ConfigStorage) Create(id string, errorSupression bool, client *Cli
 	}
 	config.ID = id
 	params := config.MapToApiValues(true)
-	err = client.CreateStorage(id, params)
+	err = client.CreateStorage(params)
 	if err != nil {
 		params, _ := json.Marshal(&params)
 		return fmt.Errorf("error creating Storage Backend: %v, (params: %v)", err, string(params))

--- a/test/cli/Guest/Lxc/GuestLxc_200_test.go
+++ b/test/cli/Guest/Lxc/GuestLxc_200_test.go
@@ -1,0 +1,3 @@
+package cli_guestlxc_test
+
+// TODO test can not be made until uploading templates to storage is inplemented

--- a/test/cli/Guest/Qemu/GuestQemu_100_test.go
+++ b/test/cli/Guest/Qemu/GuestQemu_100_test.go
@@ -1,0 +1,96 @@
+package cli_guestqemu_test
+
+import (
+	"testing"
+
+	_ "github.com/Telmate/proxmox-api-go/cli/command/commands"
+	cliTest "github.com/Telmate/proxmox-api-go/test/cli"
+)
+
+func Test_GuestQemu_100_Cleanup(t *testing.T) {
+	Test := cliTest.Test{
+		ReqErr:      true,
+		ErrContains: "100",
+		Args:        []string{"-i", "delete", "guest", "100"},
+	}
+	Test.StandardTest(t)
+}
+
+// TODO add more parameters to test
+func Test_GuestQemu_100_Create(t *testing.T) {
+	Test := cliTest.Test{
+		InputJson: `
+{
+	"name": "test-qemu01",
+	"bios": "seabios",
+	"tablet": true,
+	"memory": 128,
+	"os": "l26",
+	"cores": 1,
+	"sockets": 1,
+	"cpu": "host",
+	"numa": false,
+	"kvm": true,
+	"hotplug": "network,disk,usb",
+	"iso": "none",
+	"boot": "order=ide2;net0",
+	"scsihw": "virtio-scsi-pci",
+	"network": {
+		"0": {
+			"bridge": "vmbr0",
+			"firewall": true,
+			"id": 0,
+			"macaddr": "B6:8F:9D:7C:8F:BC",
+			"model": "virtio"
+		}
+	}
+}`,
+		Expected: "(100)",
+		Contains: true,
+		Args:     []string{"-i", "create", "guest", "qemu", "100", "pve"},
+	}
+	Test.StandardTest(t)
+}
+
+func Test_GuestQemu_100_Get(t *testing.T) {
+	Test := cliTest.Test{
+		OutputJson: `
+{
+	"name": "test-qemu01",
+	"bios": "seabios",
+	"onboot": true,
+	"tablet": true,
+	"memory": 128,
+	"os": "l26",
+	"cores": 1,
+	"sockets": 1,
+	"cpu": "host",
+	"numa": false,
+	"kvm": true,
+	"hotplug": "network,disk,usb",
+	"iso": "none",
+	"boot": "order=ide2;net0",
+	"scsihw": "virtio-scsi-pci",
+	"network": {
+		"0": {
+			"bridge": "vmbr0",
+			"firewall": true,
+			"id": 0,
+			"macaddr": "B6:8F:9D:7C:8F:BC",
+			"model": "virtio"
+		}
+	}
+}`,
+		Args: []string{"-i", "get", "guest", "100"},
+	}
+	Test.StandardTest(t)
+}
+
+func Test_GuestQemu_100_Delete(t *testing.T) {
+	Test := cliTest.Test{
+		Expected: "",
+		ReqErr:   false,
+		Args:     []string{"-i", "delete", "guest", "100"},
+	}
+	Test.StandardTest(t)
+}


### PR DESCRIPTION
Another pull for https://github.com/Telmate/proxmox-api-go/issues/171

Work so far:

- Added the commands for creating, deleting and retrieving the configuration of qemu and lxc guests.
- Added TODO items to keep track of which commands have been migrated to the new cli.
- Added basic test for Qemu creating, retrieving and destroying.
- refactored some code to make the implementation more DRY (only refactored code that has tests).

Only some basic test for Qemu. No test for Lxc yet, Lxc relies on a template which we cant upload yet in an automated fashion.
