### PR TITLE
Fixed Typo's and small refactoring

### DIFF
--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -11,7 +11,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// Global else the nested folders dont work
+// Global else the nested folders don't work
 var RootCmd = &cobra.Command{
 	Use:   "proxmox-api-go",
 	Short: "Application to configure Proxmox from the Api",

--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -43,9 +43,9 @@ func Client(apiUrl, userID, password, otp string, http_headers string) (c *proxm
 	timeout, _ := RootCmd.Flags().GetInt("timeout")
 	proxyUrl, _ := RootCmd.Flags().GetString("proxyurl")
 
-	tlsconf := &tls.Config{InsecureSkipVerify: true}
+	tlsConf := &tls.Config{InsecureSkipVerify: true}
 	if !insecure {
-		tlsconf = nil
+		tlsConf = nil
 	}
 	if apiUrl == "" {
 		apiUrl = os.Getenv("PM_API_URL")
@@ -62,7 +62,7 @@ func Client(apiUrl, userID, password, otp string, http_headers string) (c *proxm
 	if http_headers == "" {
 		http_headers = os.Getenv("PM_HTTP_HEADERS")
 	}
-	c, err = proxmox.NewClient(apiUrl, nil, http_headers, tlsconf, proxyUrl, timeout)
+	c, err = proxmox.NewClient(apiUrl, nil, http_headers, tlsConf, proxyUrl, timeout)
 	LogFatalError(err)
 	if userRequiresAPIToken(userID) {
 		c.SetAPIToken(userID, password)

--- a/cli/command/create/create-acmeaccount.go
+++ b/cli/command/create/create-acmeaccount.go
@@ -12,6 +12,7 @@ var create_acmeaccountCmd = &cobra.Command{
 	Long: `Creates a new AcmeAccount.
 The config can be set with the --file flag or piped from stdin.
 For config examples see "example acmeaccount"`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		id := cli.RequiredIDset(args, 0, "AcmeAccountID")
 		config, err := proxmox.NewConfigAcmeAccountFromJson(cli.NewConfig())

--- a/cli/command/create/create-pool.go
+++ b/cli/command/create/create-pool.go
@@ -8,6 +8,7 @@ import (
 var create_poolCmd = &cobra.Command{
 	Use:   "pool POOLID [COMMENT]",
 	Short: "Creates a new pool",
+	Args:  cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		id := cli.RequiredIDset(args, 0, "PoolID")
 		var comment string

--- a/cli/command/create/create-snapshot.go
+++ b/cli/command/create/create-snapshot.go
@@ -23,7 +23,7 @@ var (
 				VmState:     memory,
 			}
 			memory = false
-			err = config.CreateSnapshot(uint(id), cli.NewClient())
+			err = config.CreateSnapshot(cli.NewClient(), uint(id))
 			if err != nil {
 				return
 			}

--- a/cli/command/create/create-snapshot.go
+++ b/cli/command/create/create-snapshot.go
@@ -11,7 +11,7 @@ var (
 	memory             bool
 	create_snapshotCmd = &cobra.Command{
 		Use:              "snapshot GUESTID SNAPSHOTNAME [DESCRIPTION]",
-		Short:            "Creates a new snapshot of the specefied guest",
+		Short:            "Creates a new snapshot of the specified guest",
 		TraverseChildren: true,
 		Args:             cobra.RangeArgs(2, 3),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {

--- a/cli/command/create/create-storage.go
+++ b/cli/command/create/create-storage.go
@@ -12,6 +12,7 @@ var create_storageCmd = &cobra.Command{
 	Long: `Creates a new Storage Backend.
 The config can be set with the --file flag or piped from stdin.
 For config examples see "example storage"`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		id := cli.RequiredIDset(args, 0, "StorageID")
 		config, err := proxmox.NewConfigStorageFromJson(cli.NewConfig())

--- a/cli/command/create/guest/create-guest-lxc.go
+++ b/cli/command/create/guest/create-guest-lxc.go
@@ -10,6 +10,7 @@ var guest_lxcCmd = &cobra.Command{
 	Long: `Creates a new Guest System of the type Lxc on the specified Node.
 The config can be set with the --file flag or piped from stdin.
 For config examples see "example guest lxc"`,
+	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		return createGuest(args, "LxcGuest")
 	},

--- a/cli/command/create/guest/create-guest-qemu.go
+++ b/cli/command/create/guest/create-guest-qemu.go
@@ -10,6 +10,7 @@ var guest_qemuCmd = &cobra.Command{
 	Long: `Creates a new Guest System of the type Qemu on the specified Node.
 	The config can be set with the --file flag or piped from stdin.
 	For config examples see "example guest qemu"`,
+	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		return createGuest(args, "QemuGuest")
 	},

--- a/cli/command/delete/delete-acmeaccount.go
+++ b/cli/command/delete/delete-acmeaccount.go
@@ -7,6 +7,7 @@ import (
 var delete_acmeaccountCmd = &cobra.Command{
 	Use:   "acmeaccount ACMEACCOUNTID",
 	Short: "Deletes the Speciefied AcmeAccount",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return deleteID(args, "AcmeAccount")
 	},

--- a/cli/command/delete/delete-acmeaccount.go
+++ b/cli/command/delete/delete-acmeaccount.go
@@ -6,7 +6,7 @@ import (
 
 var delete_acmeaccountCmd = &cobra.Command{
 	Use:   "acmeaccount ACMEACCOUNTID",
-	Short: "Deletes the Speciefied AcmeAccount",
+	Short: "Deletes the Specified AcmeAccount",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return deleteID(args, "AcmeAccount")

--- a/cli/command/delete/delete-guest.go
+++ b/cli/command/delete/delete-guest.go
@@ -11,6 +11,7 @@ import (
 var delete_guestCmd = &cobra.Command{
 	Use:   "guest GUESTID",
 	Short: "Deletes the Speciefied Guest",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		id := cli.ValidateIntIDset(args, "GuestID")
 		vmr := proxmox.NewVmRef(id)

--- a/cli/command/delete/delete-guest.go
+++ b/cli/command/delete/delete-guest.go
@@ -10,7 +10,7 @@ import (
 
 var delete_guestCmd = &cobra.Command{
 	Use:   "guest GUESTID",
-	Short: "Deletes the Speciefied Guest",
+	Short: "Deletes the Specified Guest",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		id := cli.ValidateIntIDset(args, "GuestID")

--- a/cli/command/delete/delete-metricserver.go
+++ b/cli/command/delete/delete-metricserver.go
@@ -6,7 +6,7 @@ import (
 
 var delete_metricserverCmd = &cobra.Command{
 	Use:   "metricserver METRICSID",
-	Short: "Deletes the speciefied MetricServer",
+	Short: "Deletes the specified MetricServer",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return deleteID(args, "MetricServer")

--- a/cli/command/delete/delete-metricserver.go
+++ b/cli/command/delete/delete-metricserver.go
@@ -7,6 +7,7 @@ import (
 var delete_metricserverCmd = &cobra.Command{
 	Use:   "metricserver METRICSID",
 	Short: "Deletes the speciefied MetricServer",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return deleteID(args, "MetricServer")
 	},

--- a/cli/command/delete/delete-pool.go
+++ b/cli/command/delete/delete-pool.go
@@ -7,6 +7,7 @@ import (
 var delete_poolCmd = &cobra.Command{
 	Use:   "pool POOLID",
 	Short: "Deletes the Speciefied pool",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return deleteID(args, "Pool")
 	},

--- a/cli/command/delete/delete-pool.go
+++ b/cli/command/delete/delete-pool.go
@@ -6,7 +6,7 @@ import (
 
 var delete_poolCmd = &cobra.Command{
 	Use:   "pool POOLID",
-	Short: "Deletes the Speciefied pool",
+	Short: "Deletes the Specified pool",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return deleteID(args, "Pool")

--- a/cli/command/delete/delete-snapshot.go
+++ b/cli/command/delete/delete-snapshot.go
@@ -9,7 +9,7 @@ import (
 var (
 	delete_snapshotCmd = &cobra.Command{
 		Use:   "snapshot GUESTID SNAPSHOTNAME",
-		Short: "Deletes the Speciefied snapshot",
+		Short: "Deletes the Specified snapshot",
 		Args:  cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			id := cli.ValidateIntIDset(args, "GuestID")

--- a/cli/command/delete/delete-snapshot.go
+++ b/cli/command/delete/delete-snapshot.go
@@ -14,8 +14,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			id := cli.ValidateIntIDset(args, "GuestID")
 			snapName := cli.RequiredIDset(args, 1, "SnapshotName")
-			c := cli.NewClient()
-			_, err = c.DeleteSnapshot(proxmox.NewVmRef(id), snapName)
+			_, err = proxmox.DeleteSnapshot(cli.NewClient(), proxmox.NewVmRef(id), snapName)
 			if err != nil {
 				return
 			}

--- a/cli/command/delete/delete-storage.go
+++ b/cli/command/delete/delete-storage.go
@@ -6,7 +6,7 @@ import (
 
 var delete_storageCmd = &cobra.Command{
 	Use:   "storage STORAGEID",
-	Short: "Deletes the speciefied Storage",
+	Short: "Deletes the specified Storage",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return deleteID(args, "Storage")

--- a/cli/command/delete/delete-storage.go
+++ b/cli/command/delete/delete-storage.go
@@ -7,6 +7,7 @@ import (
 var delete_storageCmd = &cobra.Command{
 	Use:   "storage STORAGEID",
 	Short: "Deletes the speciefied Storage",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return deleteID(args, "Storage")
 	},

--- a/cli/command/delete/delete-user.go
+++ b/cli/command/delete/delete-user.go
@@ -6,7 +6,7 @@ import (
 
 var delete_userCmd = &cobra.Command{
 	Use:   "user USERID",
-	Short: "Deletes the speciefied User",
+	Short: "Deletes the specified User",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return deleteID(args, "User")

--- a/cli/command/delete/delete-user.go
+++ b/cli/command/delete/delete-user.go
@@ -7,6 +7,7 @@ import (
 var delete_userCmd = &cobra.Command{
 	Use:   "user USERID",
 	Short: "Deletes the speciefied User",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return deleteID(args, "User")
 	},

--- a/cli/command/get/get-acmeaccount.go
+++ b/cli/command/get/get-acmeaccount.go
@@ -7,6 +7,7 @@ import (
 var get_acmeaccountCmd = &cobra.Command{
 	Use:   "acmeaccount ACMEACCOUNTID",
 	Short: "Gets the configuration of the specified AcmeAccount",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		return getConfig(args, "AcmeAccount")
 	},

--- a/cli/command/get/get-guest.go
+++ b/cli/command/get/get-guest.go
@@ -9,6 +9,7 @@ import (
 var get_guestCmd = &cobra.Command{
 	Use:   "guest GUESTID",
 	Short: "Gets the configuration of the specified guest",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		id := cli.ValidateIntIDset(args, "GuestID")
 		vmr := proxmox.NewVmRef(id)

--- a/cli/command/get/get-metricserver.go
+++ b/cli/command/get/get-metricserver.go
@@ -7,6 +7,7 @@ import (
 var get_metricserverCmd = &cobra.Command{
 	Use:   "metricserver METRICSID",
 	Short: "Gets the configuration of the specified MetricServer",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return getConfig(args, "MetricServer")
 	},

--- a/cli/command/get/get-pool.go
+++ b/cli/command/get/get-pool.go
@@ -7,6 +7,7 @@ import (
 var get_poolCmd = &cobra.Command{
 	Use:   "pool POOLID",
 	Short: "Gets the configuration of the specified Pool",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return getConfig(args, "Pool")
 	},

--- a/cli/command/get/get-storage.go
+++ b/cli/command/get/get-storage.go
@@ -7,6 +7,7 @@ import (
 var get_storageCmd = &cobra.Command{
 	Use:   "storage",
 	Short: "Gets the configuration of the specified Storage backend",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return getConfig(args, "Storage")
 	},

--- a/cli/command/get/get-storage.go
+++ b/cli/command/get/get-storage.go
@@ -5,7 +5,7 @@ import (
 )
 
 var get_storageCmd = &cobra.Command{
-	Use:   "storage",
+	Use:   "storage STORAGEID",
 	Short: "Gets the configuration of the specified Storage backend",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cli/command/get/get-user.go
+++ b/cli/command/get/get-user.go
@@ -7,6 +7,7 @@ import (
 var get_userCmd = &cobra.Command{
 	Use:   "user USERID",
 	Short: "Gets the configuration of the specified User",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return getConfig(args, "User")
 	},

--- a/cli/command/get/id/get-id-check.go
+++ b/cli/command/get/id/get-id-check.go
@@ -10,6 +10,7 @@ import (
 var id_checkCmd = &cobra.Command{
 	Use:   "check ID",
 	Short: "Checks if a ID is availible",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		id := cli.ValidateIntIDset(args, "ID")
 		c := cli.NewClient()

--- a/cli/command/get/id/get-id-check.go
+++ b/cli/command/get/id/get-id-check.go
@@ -9,7 +9,7 @@ import (
 
 var id_checkCmd = &cobra.Command{
 	Use:   "check ID",
-	Short: "Checks if a ID is availible",
+	Short: "Checks if a ID is available",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		id := cli.ValidateIntIDset(args, "ID")

--- a/cli/command/get/id/get-id-max.go
+++ b/cli/command/get/id/get-id-max.go
@@ -11,6 +11,7 @@ import (
 var id_maxCmd = &cobra.Command{
 	Use:   "max",
 	Short: "Returns the maximum in use ID number",
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		c := cli.NewClient()
 		id, err := proxmox.MaxVmId(c)

--- a/cli/command/get/id/get-id-next.go
+++ b/cli/command/get/id/get-id-next.go
@@ -10,6 +10,7 @@ import (
 var id_nextCmd = &cobra.Command{
 	Use:   "next",
 	Short: "Returns the lowes availible ID",
+	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		c := cli.NewClient()
 		id, err := c.GetNextID(0)

--- a/cli/command/get/id/get-id-next.go
+++ b/cli/command/get/id/get-id-next.go
@@ -9,7 +9,7 @@ import (
 
 var id_nextCmd = &cobra.Command{
 	Use:   "next",
-	Short: "Returns the lowes availible ID",
+	Short: "Returns the lowest available ID",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		c := cli.NewClient()

--- a/cli/command/guest/guest-rollback.go
+++ b/cli/command/guest/guest-rollback.go
@@ -10,7 +10,7 @@ import (
 
 var guest_rollbackCmd = &cobra.Command{
 	Use:   "rollback GUESTID SNAPSHOT",
-	Short: "Shuts the speciefid guest down",
+	Short: "Shuts the specified guest down",
 	Args:  cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))

--- a/cli/command/guest/guest-rollback.go
+++ b/cli/command/guest/guest-rollback.go
@@ -15,8 +15,7 @@ var guest_rollbackCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		snapName := cli.RequiredIDset(args, 1, "SnapshotName")
-		c := cli.NewClient()
-		_, err = c.RollbackSnapshot(vmr, snapName)
+		_, err = proxmox.RollbackSnapshot(cli.NewClient(), vmr, snapName)
 		if err == nil {
 			fmt.Fprintf(GuestCmd.OutOrStdout(), "Guest with id (%d) has been rolled back to snapshot (%s)\n", vmr.VmId(), snapName)
 		}

--- a/cli/command/guest/guest-shutdown.go
+++ b/cli/command/guest/guest-shutdown.go
@@ -9,6 +9,7 @@ import (
 var guest_shutdownCmd = &cobra.Command{
 	Use:   "shutdown GUESTID",
 	Short: "Shuts the speciefid guest down",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		c := cli.NewClient()

--- a/cli/command/guest/guest-shutdown.go
+++ b/cli/command/guest/guest-shutdown.go
@@ -8,7 +8,7 @@ import (
 
 var guest_shutdownCmd = &cobra.Command{
 	Use:   "shutdown GUESTID",
-	Short: "Shuts the speciefid guest down",
+	Short: "Shuts the specified guest down",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))

--- a/cli/command/guest/guest-start.go
+++ b/cli/command/guest/guest-start.go
@@ -9,6 +9,7 @@ import (
 var guest_statusCmd = &cobra.Command{
 	Use:   "start GUESTID",
 	Short: "Starts the speciefid guest",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		c := cli.NewClient()

--- a/cli/command/guest/guest-start.go
+++ b/cli/command/guest/guest-start.go
@@ -8,7 +8,7 @@ import (
 
 var guest_statusCmd = &cobra.Command{
 	Use:   "start GUESTID",
-	Short: "Starts the speciefid guest",
+	Short: "Starts the specified guest",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))

--- a/cli/command/guest/guest-status.go
+++ b/cli/command/guest/guest-status.go
@@ -10,7 +10,7 @@ import (
 
 var guest_startCmd = &cobra.Command{
 	Use:   "status GUESTID",
-	Short: "Gets the status of the speciefid guest",
+	Short: "Gets the status of the specified guest",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))

--- a/cli/command/guest/guest-status.go
+++ b/cli/command/guest/guest-status.go
@@ -11,6 +11,7 @@ import (
 var guest_startCmd = &cobra.Command{
 	Use:   "status GUESTID",
 	Short: "Gets the status of the speciefid guest",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		c := cli.NewClient()

--- a/cli/command/guest/guest-stop.go
+++ b/cli/command/guest/guest-stop.go
@@ -8,7 +8,7 @@ import (
 
 var guest_stopCmd = &cobra.Command{
 	Use:   "stop GUESTID",
-	Short: "Stops the speciefid guest",
+	Short: "Stops the specified guest",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))

--- a/cli/command/guest/guest-stop.go
+++ b/cli/command/guest/guest-stop.go
@@ -9,6 +9,7 @@ import (
 var guest_stopCmd = &cobra.Command{
 	Use:   "stop GUESTID",
 	Short: "Stops the speciefid guest",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		c := cli.NewClient()

--- a/cli/command/guest/guest-uptime.go
+++ b/cli/command/guest/guest-uptime.go
@@ -10,7 +10,7 @@ import (
 
 var guest_uptimeCmd = &cobra.Command{
 	Use:   "uptime GUESTID",
-	Short: "Gets the uptime of the speciefid guest",
+	Short: "Gets the uptime of the specified guest",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))

--- a/cli/command/guest/guest-uptime.go
+++ b/cli/command/guest/guest-uptime.go
@@ -11,6 +11,7 @@ import (
 var guest_uptimeCmd = &cobra.Command{
 	Use:   "uptime GUESTID",
 	Short: "Gets the uptime of the speciefid guest",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		c := cli.NewClient()

--- a/cli/command/guest/qemu/guest-qemu-hibernate.go
+++ b/cli/command/guest/qemu/guest-qemu-hibernate.go
@@ -9,6 +9,7 @@ import (
 var qemu_hibernateCmd = &cobra.Command{
 	Use:   "hibernate GUESTID",
 	Short: "Hibernates the speciefid guest",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		c := cli.NewClient()

--- a/cli/command/guest/qemu/guest-qemu-hibernate.go
+++ b/cli/command/guest/qemu/guest-qemu-hibernate.go
@@ -8,7 +8,7 @@ import (
 
 var qemu_hibernateCmd = &cobra.Command{
 	Use:   "hibernate GUESTID",
-	Short: "Hibernates the speciefid guest",
+	Short: "Hibernates the specified guest",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))

--- a/cli/command/guest/qemu/guest-qemu-pause.go
+++ b/cli/command/guest/qemu/guest-qemu-pause.go
@@ -8,7 +8,7 @@ import (
 
 var qemu_pauseCmd = &cobra.Command{
 	Use:   "pause GUESTID",
-	Short: "Pauses the speciefid guest",
+	Short: "Pauses the specified guest",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))

--- a/cli/command/guest/qemu/guest-qemu-pause.go
+++ b/cli/command/guest/qemu/guest-qemu-pause.go
@@ -9,6 +9,7 @@ import (
 var qemu_pauseCmd = &cobra.Command{
 	Use:   "pause GUESTID",
 	Short: "Pauses the speciefid guest",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		c := cli.NewClient()

--- a/cli/command/guest/qemu/guest-qemu-reset.go
+++ b/cli/command/guest/qemu/guest-qemu-reset.go
@@ -8,7 +8,7 @@ import (
 
 var qemu_resetCmd = &cobra.Command{
 	Use:   "reset GUESTID",
-	Short: "Resets the speciefid guest",
+	Short: "Resets the specified guest",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))

--- a/cli/command/guest/qemu/guest-qemu-reset.go
+++ b/cli/command/guest/qemu/guest-qemu-reset.go
@@ -9,6 +9,7 @@ import (
 var qemu_resetCmd = &cobra.Command{
 	Use:   "reset GUESTID",
 	Short: "Resets the speciefid guest",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		c := cli.NewClient()

--- a/cli/command/guest/qemu/guest-qemu-resume.go
+++ b/cli/command/guest/qemu/guest-qemu-resume.go
@@ -9,6 +9,7 @@ import (
 var qemu_resumeCmd = &cobra.Command{
 	Use:   "resume GUESTID",
 	Short: "Resumes the speciefid guest",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		c := cli.NewClient()

--- a/cli/command/guest/qemu/guest-qemu-resume.go
+++ b/cli/command/guest/qemu/guest-qemu-resume.go
@@ -8,7 +8,7 @@ import (
 
 var qemu_resumeCmd = &cobra.Command{
 	Use:   "resume GUESTID",
-	Short: "Resumes the speciefid guest",
+	Short: "Resumes the specified guest",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))

--- a/cli/command/list/list-acmeaccounts.go
+++ b/cli/command/list/list-acmeaccounts.go
@@ -7,6 +7,7 @@ import (
 var list_acmeaccountsCmd = &cobra.Command{
 	Use:   "acmeaccounts",
 	Short: "Prints a list of AcmeAccounts in raw json format",
+	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		listRaw("AcmeAccounts")
 	},

--- a/cli/command/list/list-acmeplugins.go
+++ b/cli/command/list/list-acmeplugins.go
@@ -7,6 +7,7 @@ import (
 var list_acmepluginsCmd = &cobra.Command{
 	Use:   "acmeplugins",
 	Short: "Prints a list of AcmePlugins in raw json format",
+	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		listRaw("AcmePlugins")
 	},

--- a/cli/command/list/list-guests.go
+++ b/cli/command/list/list-guests.go
@@ -7,6 +7,7 @@ import (
 var list_qemuguestsCmd = &cobra.Command{
 	Use:   "guests",
 	Short: "Prints a list of Qemu/Lxc Guests in raw json format",
+	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		listRaw("Guests")
 	},

--- a/cli/command/list/list-metricservers.go
+++ b/cli/command/list/list-metricservers.go
@@ -7,6 +7,7 @@ import (
 var list_metricserversCmd = &cobra.Command{
 	Use:   "metricservers",
 	Short: "Prints a list of MetricServers in raw json format",
+	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		listRaw("MetricServers")
 	},

--- a/cli/command/list/list-nodes.go
+++ b/cli/command/list/list-nodes.go
@@ -7,6 +7,7 @@ import (
 var list_nodesCmd = &cobra.Command{
 	Use:   "nodes",
 	Short: "Prints a list of Nodes in raw json format",
+	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		listRaw("Nodes")
 	},

--- a/cli/command/list/list-pools.go
+++ b/cli/command/list/list-pools.go
@@ -7,6 +7,7 @@ import (
 var list_poolsCmd = &cobra.Command{
 	Use:   "pools",
 	Short: "Prints a list of Pools in raw json format",
+	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		listRaw("Pools")
 	},

--- a/cli/command/list/list-snapshots.go
+++ b/cli/command/list/list-snapshots.go
@@ -15,7 +15,7 @@ var (
 		TraverseChildren: true,
 		Args:             cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
-			id := cli.ValidateExistinGuestID(args, 0)
+			id := cli.ValidateExistingGuestID(args, 0)
 			jbody, err := proxmox.ListSnapshots(cli.NewClient(), proxmox.NewVmRef(id))
 			if err != nil {
 				noTree = false

--- a/cli/command/list/list-snapshots.go
+++ b/cli/command/list/list-snapshots.go
@@ -16,7 +16,7 @@ var (
 		Args:             cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			id := cli.ValidateExistinGuestID(args, 0)
-			jbody, err := cli.NewClient().ListSnapshots(proxmox.NewVmRef(id))
+			jbody, err := proxmox.ListSnapshots(cli.NewClient(), proxmox.NewVmRef(id))
 			if err != nil {
 				noTree = false
 				return

--- a/cli/command/list/list-snapshots.go
+++ b/cli/command/list/list-snapshots.go
@@ -16,7 +16,7 @@ var (
 		Args:             cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			id := cli.ValidateExistingGuestID(args, 0)
-			jbody, err := proxmox.ListSnapshots(cli.NewClient(), proxmox.NewVmRef(id))
+			jBody, err := proxmox.ListSnapshots(cli.NewClient(), proxmox.NewVmRef(id))
 			if err != nil {
 				noTree = false
 				return
@@ -24,9 +24,9 @@ var (
 			var list []*proxmox.Snapshot
 			if noTree {
 				noTree = false
-				list = proxmox.FormatSnapshotsList(jbody)
+				list = proxmox.FormatSnapshotsList(jBody)
 			} else {
-				list = proxmox.FormatSnapshotsTree(jbody)
+				list = proxmox.FormatSnapshotsTree(jBody)
 			}
 			if len(list) == 0 {
 				listCmd.Printf("Guest with ID (%d) has no snapshots", id)

--- a/cli/command/list/list-storages.go
+++ b/cli/command/list/list-storages.go
@@ -7,6 +7,7 @@ import (
 var list_storagesCmd = &cobra.Command{
 	Use:   "storages",
 	Short: "Prints a list of Storages in raw json format",
+	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		listRaw("Storages")
 	},

--- a/cli/command/list/list-users.go
+++ b/cli/command/list/list-users.go
@@ -7,6 +7,7 @@ import (
 var list_usersCmd = &cobra.Command{
 	Use:   "users",
 	Short: "Prints a list of Users in raw json format",
+	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		listRaw("Users")
 	},

--- a/cli/command/node/node-reboot.go
+++ b/cli/command/node/node-reboot.go
@@ -16,7 +16,7 @@ var reboot_nodeCmd = &cobra.Command{
 		if err != nil {
 			return
 		}
-		cli.RootCmd.Printf("Node %s is shutting down", node)
+		cli.RootCmd.Printf("Node %s is rebooting", node)
 		return
 	},
 }

--- a/cli/command/node/node-reboot.go
+++ b/cli/command/node/node-reboot.go
@@ -8,6 +8,7 @@ import (
 var reboot_nodeCmd = &cobra.Command{
 	Use:   "reboot NODE",
 	Short: "Reboots the specified node",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		node := cli.RequiredIDset(args, 0, "node")
 		c := cli.NewClient()

--- a/cli/command/node/node-shutdown.go
+++ b/cli/command/node/node-shutdown.go
@@ -8,6 +8,7 @@ import (
 var shutdown_nodeCmd = &cobra.Command{
 	Use:   "shutdown NODE",
 	Short: "Shuts the specified node down",
+	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		node := cli.RequiredIDset(args, 0, "node")
 		c := cli.NewClient()

--- a/cli/command/set/set-metricserver.go
+++ b/cli/command/set/set-metricserver.go
@@ -13,6 +13,7 @@ var set_metricserverCmd = &cobra.Command{
 Depending on the current state of the MetricServer, the MetricServer will be created or updated.
 The config can be set with the --file flag or piped from stdin.
 For config examples see "example metricserver"`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		id := cli.RequiredIDset(args, 0, "MetricServerID")
 		config, err := proxmox.NewConfigMetricsFromJson(cli.NewConfig())

--- a/cli/command/set/set-user.go
+++ b/cli/command/set/set-user.go
@@ -13,6 +13,7 @@ var set_userCmd = &cobra.Command{
 Depending on the current state of the user, the user will be created or updated.
 The config can be set with the --file flag or piped from stdin.
 For config examples see "example user"`,
+	Args: cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		id := cli.RequiredIDset(args, 0, "UserID")
 		config, err := proxmox.NewConfigUserFromJson(cli.NewConfig())

--- a/cli/command/update/update-poolcomment.go
+++ b/cli/command/update/update-poolcomment.go
@@ -7,7 +7,7 @@ import (
 
 var update_poolCmd = &cobra.Command{
 	Use:   "poolcomment POOLID [COMMENT]",
-	Short: "Updates the comment on the speciefied pool",
+	Short: "Updates the comment on the specified pool",
 	Args:  cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		var comment string

--- a/cli/command/update/update-poolcomment.go
+++ b/cli/command/update/update-poolcomment.go
@@ -8,6 +8,7 @@ import (
 var update_poolCmd = &cobra.Command{
 	Use:   "poolcomment POOLID [COMMENT]",
 	Short: "Updates the comment on the speciefied pool",
+	Args:  cobra.RangeArgs(1, 2),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		var comment string
 		id := cli.RequiredIDset(args, 0, "PoolID")

--- a/cli/command/update/update-snapshotdescription.go
+++ b/cli/command/update/update-snapshotdescription.go
@@ -8,7 +8,7 @@ import (
 
 var update_snapshotCmd = &cobra.Command{
 	Use:   "snapshot GUESTID SNAPSHOTNAME [DESCRIPTION]",
-	Short: "Updates the description on the speciefied snapshot",
+	Short: "Updates the description on the specified snapshot",
 	Args:  cobra.RangeArgs(2, 3),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		id := cli.ValidateIntIDset(args, "GuestID")

--- a/cli/command/update/update-snapshotdescription.go
+++ b/cli/command/update/update-snapshotdescription.go
@@ -14,7 +14,7 @@ var update_snapshotCmd = &cobra.Command{
 		id := cli.ValidateIntIDset(args, "GuestID")
 		snapName := cli.RequiredIDset(args, 1, "SnapshotName")
 		des := cli.OptionalIDset(args, 2)
-		err = cli.NewClient().UpdateSnapshotDescription(proxmox.NewVmRef(id), snapName, des)
+		err = proxmox.UpdateSnapshotDescription(cli.NewClient(), proxmox.NewVmRef(id), snapName, des)
 		if err != nil {
 			return
 		}

--- a/cli/command/update/update-storage.go
+++ b/cli/command/update/update-storage.go
@@ -12,6 +12,7 @@ var update_storageCmd = &cobra.Command{
 	Long: `Updates the configuration of the speciefied Storage Backend.
 The config can be set with the --file flag or piped from stdin.
 For config examples see "example storage"`,
+	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		id := cli.RequiredIDset(args, 0, "StorageID")
 		config, err := proxmox.NewConfigStorageFromJson(cli.NewConfig())

--- a/cli/command/update/update-storage.go
+++ b/cli/command/update/update-storage.go
@@ -8,8 +8,8 @@ import (
 
 var update_storageCmd = &cobra.Command{
 	Use:   "storage STORAGEID",
-	Short: "Updates the configuration of the speciefied Storage Backend.",
-	Long: `Updates the configuration of the speciefied Storage Backend.
+	Short: "Updates the configuration of the specified Storage Backend.",
+	Long: `Updates the configuration of the specified Storage Backend.
 The config can be set with the --file flag or piped from stdin.
 For config examples see "example storage"`,
 	Args: cobra.ExactArgs(1),

--- a/cli/validate.go
+++ b/cli/validate.go
@@ -7,7 +7,7 @@ import (
 )
 
 // Should be used for Required IDs.
-// returns if the indexd arg if it is set. It throws and error when the indexed arg is not set.
+// returns if the indexed arg if it is set. It throws and error when the indexed arg is not set.
 func RequiredIDset(args []string, indexPos uint, text string) string {
 	if int(indexPos+1) > len(args) {
 		log.Fatal(fmt.Errorf("error: no %s has been provided", text))
@@ -16,7 +16,7 @@ func RequiredIDset(args []string, indexPos uint, text string) string {
 }
 
 // Should be used for Optional IDs.
-// returns if the indexd arg if it is set. It returns an empty string when the indexed arg is not set.
+// returns if the indexed arg if it is set. It returns an empty string when the indexed arg is not set.
 func OptionalIDset(args []string, indexPos uint) (out string) {
 	if int(indexPos+1) <= len(args) {
 		out = args[indexPos]
@@ -32,7 +32,7 @@ func ValidateIntIDset(args []string, text string) int {
 	return id
 }
 
-func ValidateExistinGuestID(args []string, indexPos uint) int {
+func ValidateExistingGuestID(args []string, indexPos uint) int {
 	id, err := strconv.Atoi(RequiredIDset(args, indexPos, "GuestID"))
 	if err != nil || id < 100 {
 		log.Fatal(fmt.Errorf("error: GuestID must be a positive integer of 100 or greater"))

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -643,15 +643,7 @@ func (c *Client) CloneQemuVm(vmr *VmRef, vmParams map[string]interface{}) (exitS
 	return
 }
 
-func (c *Client) CreateSnapshot(vmr *VmRef, params map[string]interface{}) (exitStatus string, err error) {
-	err = c.CheckVmRef(vmr)
-	if err != nil {
-		return
-	}
-	return c.PostWithTask(params, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/")
-}
-
-// DEPRECATED superceded by (c *Client) CreateSnapshot()
+// DEPRECATED superceded by CreateSnapshot()
 func (c *Client) CreateQemuSnapshot(vmr *VmRef, snapshotName string) (exitStatus string, err error) {
 	err = c.CheckVmRef(vmr)
 	snapshotParams := map[string]interface{}{
@@ -676,28 +668,12 @@ func (c *Client) CreateQemuSnapshot(vmr *VmRef, snapshotName string) (exitStatus
 	return
 }
 
-func (c *Client) DeleteSnapshot(vmr *VmRef, snapshot string) (exitStatus string, err error) {
-	err = c.CheckVmRef(vmr)
-	if err != nil {
-		return
-	}
-	return c.DeleteWithTask("/nodes/" + vmr.node + "/" + vmr.vmType + "/" + strconv.Itoa(vmr.vmId) + "/snapshot/" + snapshot)
-}
-
-// DEPRECATED superceded by (c *Client) DeleteSnapshot()
+// DEPRECATED superceded by DeleteSnapshot()
 func (c *Client) DeleteQemuSnapshot(vmr *VmRef, snapshotName string) (exitStatus string, err error) {
-	return c.DeleteSnapshot(vmr, snapshotName)
+	return DeleteSnapshot(c, vmr, snapshotName)
 }
 
-func (c *Client) ListSnapshots(vmr *VmRef) (taskResponse []interface{}, err error) {
-	err = c.CheckVmRef(vmr)
-	if err != nil {
-		return
-	}
-	return c.GetItemConfigInterfaceArray("/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/", "Guest", "SNAPSHOTS")
-}
-
-// DEPRECATED superceded by (c *Client) ListSnapshots()
+// DEPRECATED superceded by ListSnapshots()
 func (c *Client) ListQemuSnapshot(vmr *VmRef) (taskResponse map[string]interface{}, exitStatus string, err error) {
 	err = c.CheckVmRef(vmr)
 	if err != nil {
@@ -715,26 +691,9 @@ func (c *Client) ListQemuSnapshot(vmr *VmRef) (taskResponse map[string]interface
 	return
 }
 
-func (c *Client) RollbackSnapshot(vmr *VmRef, snapshot string) (exitStatus string, err error) {
-	err = c.CheckVmRef(vmr)
-	if err != nil {
-		return
-	}
-	return c.PostWithTask(nil, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/"+snapshot+"/rollback")
-}
-
-// DEPRECATED superceded by (c *Client) RollbackSnapshot()
+// DEPRECATED superceded by RollbackSnapshot()
 func (c *Client) RollbackQemuVm(vmr *VmRef, snapshot string) (exitStatus string, err error) {
-	return c.RollbackSnapshot(vmr, snapshot)
-}
-
-// Can only be used to update the description of an already existing snapshot
-func (c *Client) UpdateSnapshotDescription(vmr *VmRef, snapshot, description string) (err error) {
-	err = c.CheckVmRef(vmr)
-	if err != nil {
-		return
-	}
-	return c.Put(map[string]interface{}{"description": description}, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/"+snapshot+"/config")
+	return RollbackSnapshot(c, vmr, snapshot)
 }
 
 // SetVmConfig - send config options

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -24,7 +24,7 @@ const TaskStatusCheckInterval = 2
 
 const exitStatusSuccess = "OK"
 
-// Client - URL, user and password to specifc Proxmox node
+// Client - URL, user and password to specific Proxmox node
 type Client struct {
 	session     *Session
 	ApiUrl      string
@@ -419,7 +419,7 @@ func (c *Client) Sendkey(vmr *VmRef, qmKey string) error {
 func (c *Client) WaitForCompletion(taskResponse map[string]interface{}) (waitExitStatus string, err error) {
 	if taskResponse["errors"] != nil {
 		errJSON, _ := json.MarshalIndent(taskResponse["errors"], "", "  ")
-		return string(errJSON), fmt.Errorf("error reponse")
+		return string(errJSON), fmt.Errorf("error response")
 	}
 	if taskResponse["data"] == nil {
 		return "", nil
@@ -643,7 +643,7 @@ func (c *Client) CloneQemuVm(vmr *VmRef, vmParams map[string]interface{}) (exitS
 	return
 }
 
-// DEPRECATED superceded by CreateSnapshot()
+// DEPRECATED superseded by CreateSnapshot()
 func (c *Client) CreateQemuSnapshot(vmr *VmRef, snapshotName string) (exitStatus string, err error) {
 	err = c.CheckVmRef(vmr)
 	snapshotParams := map[string]interface{}{
@@ -668,12 +668,12 @@ func (c *Client) CreateQemuSnapshot(vmr *VmRef, snapshotName string) (exitStatus
 	return
 }
 
-// DEPRECATED superceded by DeleteSnapshot()
+// DEPRECATED superseded by DeleteSnapshot()
 func (c *Client) DeleteQemuSnapshot(vmr *VmRef, snapshotName string) (exitStatus string, err error) {
 	return DeleteSnapshot(c, vmr, snapshotName)
 }
 
-// DEPRECATED superceded by ListSnapshots()
+// DEPRECATED superseded by ListSnapshots()
 func (c *Client) ListQemuSnapshot(vmr *VmRef) (taskResponse map[string]interface{}, exitStatus string, err error) {
 	err = c.CheckVmRef(vmr)
 	if err != nil {
@@ -691,7 +691,7 @@ func (c *Client) ListQemuSnapshot(vmr *VmRef) (taskResponse map[string]interface
 	return
 }
 
-// DEPRECATED superceded by RollbackSnapshot()
+// DEPRECATED superseded by RollbackSnapshot()
 func (c *Client) RollbackQemuVm(vmr *VmRef, snapshot string) (exitStatus string, err error) {
 	return RollbackSnapshot(c, vmr, snapshot)
 }
@@ -947,7 +947,7 @@ func (c *Client) CreateNewDisk(vmr *VmRef, disk string, volume string) (exitStat
 }
 
 // DeleteVMDisks - Delete VM disks from host node.
-// By default the VM disks are deteled when the VM is deleted,
+// By default the VM disks are deleted when the VM is deleted,
 // so mainly this is used to delete the disks in case VM creation didn't complete.
 func (c *Client) DeleteVMDisks(
 	node string,

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -466,7 +466,7 @@ func (c *Client) StatusChangeVm(vmr *VmRef, params map[string]interface{}, setSt
 	}
 	url := fmt.Sprintf("/nodes/%s/%s/%d/status/%s", vmr.node, vmr.vmType, vmr.vmId, setStatus)
 	for i := 0; i < 3; i++ {
-		exitStatus, err = c.CreateItemWithTask(params, url)
+		exitStatus, err = c.PostWithTask(params, url)
 		if err != nil {
 			time.Sleep(TaskStatusCheckInterval * time.Second)
 		} else {
@@ -648,7 +648,7 @@ func (c *Client) CreateSnapshot(vmr *VmRef, params map[string]interface{}) (exit
 	if err != nil {
 		return
 	}
-	return c.CreateItemWithTask(params, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/")
+	return c.PostWithTask(params, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/")
 }
 
 // DEPRECATED superceded by (c *Client) CreateSnapshot()
@@ -681,7 +681,7 @@ func (c *Client) DeleteSnapshot(vmr *VmRef, snapshot string) (exitStatus string,
 	if err != nil {
 		return
 	}
-	return c.DeleteUrlWithTask("/nodes/" + vmr.node + "/" + vmr.vmType + "/" + strconv.Itoa(vmr.vmId) + "/snapshot/" + snapshot)
+	return c.DeleteWithTask("/nodes/" + vmr.node + "/" + vmr.vmType + "/" + strconv.Itoa(vmr.vmId) + "/snapshot/" + snapshot)
 }
 
 // DEPRECATED superceded by (c *Client) DeleteSnapshot()
@@ -720,7 +720,7 @@ func (c *Client) RollbackSnapshot(vmr *VmRef, snapshot string) (exitStatus strin
 	if err != nil {
 		return
 	}
-	return c.CreateItemWithTask(nil, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/"+snapshot+"/rollback")
+	return c.PostWithTask(nil, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/"+snapshot+"/rollback")
 }
 
 // DEPRECATED superceded by (c *Client) RollbackSnapshot()
@@ -734,12 +734,12 @@ func (c *Client) UpdateSnapshotDescription(vmr *VmRef, snapshot, description str
 	if err != nil {
 		return
 	}
-	return c.UpdateItem(map[string]interface{}{"description": description}, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/"+snapshot+"/config")
+	return c.Put(map[string]interface{}{"description": description}, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/"+snapshot+"/config")
 }
 
 // SetVmConfig - send config options
 func (c *Client) SetVmConfig(vmr *VmRef, params map[string]interface{}) (exitStatus interface{}, err error) {
-	return c.CreateItemWithTask(params, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/config")
+	return c.PostWithTask(params, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/config")
 }
 
 // SetLxcConfig - send config options
@@ -1589,21 +1589,21 @@ func (c *Client) GetPoolInfo(poolid string) (poolInfo map[string]interface{}, er
 }
 
 func (c *Client) CreatePool(poolid string, comment string) error {
-	return c.CreateItem(map[string]interface{}{
+	return c.Post(map[string]interface{}{
 		"poolid":  poolid,
 		"comment": comment,
 	}, "/pools")
 }
 
 func (c *Client) UpdatePoolComment(poolid string, comment string) error {
-	return c.UpdateItem(map[string]interface{}{
+	return c.Put(map[string]interface{}{
 		"poolid":  poolid,
 		"comment": comment,
 	}, "/pools/"+poolid)
 }
 
 func (c *Client) DeletePool(poolid string) error {
-	return c.DeleteUrl("/pools/" + poolid)
+	return c.Delete("/pools/" + poolid)
 }
 
 // User
@@ -1620,7 +1620,7 @@ func (c *Client) UpdateUserPassword(userid string, password string) error {
 	if err != nil {
 		return err
 	}
-	return c.UpdateItem(map[string]interface{}{
+	return c.Put(map[string]interface{}{
 		"userid":   userid,
 		"password": password,
 	}, "/access/password")
@@ -1631,11 +1631,11 @@ func (c *Client) CreateUser(params map[string]interface{}) (err error) {
 	if err != nil {
 		return err
 	}
-	return c.CreateItem(params, "/access/users")
+	return c.Post(params, "/access/users")
 }
 
 func (c *Client) UpdateUser(id string, params map[string]interface{}) error {
-	return c.UpdateItem(params, "/access/users/"+id)
+	return c.Put(params, "/access/users/"+id)
 }
 
 func (c *Client) CheckUserExistance(id string) (existance bool, err error) {
@@ -1653,7 +1653,7 @@ func (c *Client) DeleteUser(id string) (err error) {
 		return fmt.Errorf("user (%s) could not be deleted, the user does not exist", id)
 	}
 	// Proxmox silently fails a user delete if the users does not exist
-	return c.DeleteUrl("/access/users/" + id)
+	return c.Delete("/access/users/" + id)
 }
 
 //permissions check
@@ -1704,18 +1704,18 @@ func (c *Client) GetAcmeAccountConfig(id string) (config map[string]interface{},
 }
 
 func (c *Client) CreateAcmeAccount(params map[string]interface{}) (exitStatus string, err error) {
-	return c.CreateItemWithTask(params, "/cluster/acme/account/")
+	return c.PostWithTask(params, "/cluster/acme/account/")
 }
 
 func (c *Client) UpdateAcmeAccountEmails(id, emails string) (exitStatus string, err error) {
 	params := map[string]interface{}{
 		"contact": emails,
 	}
-	return c.UpdateItemWithTask(params, "/cluster/acme/account/"+id)
+	return c.PutWithTask(params, "/cluster/acme/account/"+id)
 }
 
 func (c *Client) DeleteAcmeAccount(id string) (exitStatus string, err error) {
-	return c.DeleteUrlWithTask("/cluster/acme/account/" + id)
+	return c.DeleteWithTask("/cluster/acme/account/" + id)
 }
 
 // ACME Plugin
@@ -1728,11 +1728,11 @@ func (c *Client) GetAcmePluginConfig(id string) (config map[string]interface{}, 
 }
 
 func (c *Client) CreateAcmePlugin(params map[string]interface{}) error {
-	return c.CreateItem(params, "/cluster/acme/plugins/")
+	return c.Post(params, "/cluster/acme/plugins/")
 }
 
 func (c *Client) UpdateAcmePlugin(id string, params map[string]interface{}) error {
-	return c.UpdateItem(params, "/cluster/acme/plugins/"+id)
+	return c.Put(params, "/cluster/acme/plugins/"+id)
 }
 
 func (c *Client) CheckAcmePluginExistance(id string) (existance bool, err error) {
@@ -1742,7 +1742,7 @@ func (c *Client) CheckAcmePluginExistance(id string) (existance bool, err error)
 }
 
 func (c *Client) DeleteAcmePlugin(id string) (err error) {
-	return c.DeleteUrl("/cluster/acme/plugins/" + id)
+	return c.Delete("/cluster/acme/plugins/" + id)
 }
 
 // Metrics
@@ -1755,11 +1755,11 @@ func (c *Client) GetMetricsServerList() (metricServers map[string]interface{}, e
 }
 
 func (c *Client) CreateMetricServer(id string, params map[string]interface{}) error {
-	return c.CreateItem(params, "/cluster/metrics/server/"+id)
+	return c.Post(params, "/cluster/metrics/server/"+id)
 }
 
 func (c *Client) UpdateMetricServer(id string, params map[string]interface{}) error {
-	return c.UpdateItem(params, "/cluster/metrics/server/"+id)
+	return c.Put(params, "/cluster/metrics/server/"+id)
 }
 
 func (c *Client) CheckMetricServerExistance(id string) (existance bool, err error) {
@@ -1769,12 +1769,12 @@ func (c *Client) CheckMetricServerExistance(id string) (existance bool, err erro
 }
 
 func (c *Client) DeleteMetricServer(id string) error {
-	return c.DeleteUrl("/cluster/metrics/server/" + id)
+	return c.Delete("/cluster/metrics/server/" + id)
 }
 
 // storage
 func (c *Client) EnableStorage(id string) error {
-	return c.UpdateItem(map[string]interface{}{
+	return c.Put(map[string]interface{}{
 		"disable": false,
 	}, "/storage/"+id)
 }
@@ -1788,7 +1788,7 @@ func (c *Client) GetStorageConfig(id string) (config map[string]interface{}, err
 }
 
 func (c *Client) CreateStorage(params map[string]interface{}) error {
-	return c.CreateItem(params, "/storage")
+	return c.Post(params, "/storage")
 }
 
 func (c *Client) CheckStorageExistance(id string) (existance bool, err error) {
@@ -1798,11 +1798,11 @@ func (c *Client) CheckStorageExistance(id string) (existance bool, err error) {
 }
 
 func (c *Client) UpdateStorage(id string, params map[string]interface{}) error {
-	return c.UpdateItem(params, "/storage/"+id)
+	return c.Put(params, "/storage/"+id)
 }
 
 func (c *Client) DeleteStorage(id string) error {
-	return c.DeleteUrl("/storage/" + id)
+	return c.Delete("/storage/" + id)
 }
 
 // Network
@@ -1831,7 +1831,7 @@ func (c *Client) GetNetworkInterface(node string, iface string) (exitStatus stri
 	return
 }
 
-// CreateNetwork creates a network with the configuration of the passed in parameters 
+// CreateNetwork creates a network with the configuration of the passed in parameters
 // on the passed in node.
 // It returns the body from the API response and any HTTP error the API returns.
 func (c *Client) CreateNetwork(node string, params map[string]interface{}) (exitStatus string, err error) {
@@ -1839,7 +1839,7 @@ func (c *Client) CreateNetwork(node string, params map[string]interface{}) (exit
 	return c.CreateItemReturnStatus(params, url)
 }
 
-// UpdateNetwork updates the network corresponding to the passed in interface name on the passed 
+// UpdateNetwork updates the network corresponding to the passed in interface name on the passed
 // in node with the configuration in the passed in parameters.
 // It returns the body from the API response and any HTTP error the API returns.
 func (c *Client) UpdateNetwork(node string, iface string, params map[string]interface{}) (exitStatus string, err error) {
@@ -1853,21 +1853,21 @@ func (c *Client) DeleteNetwork(node string, iface string) (exitStatus string, er
 	url := fmt.Sprintf("/nodes/%s/network/%s", node, iface)
 	resp, err := c.session.Delete(url, nil, nil)
 	exitStatus = c.HandleTaskError(resp)
-	return 
+	return
 }
 
 // ApplyNetwork applies the pending network configuration on the passed in node.
 // It returns the body from the API response and any HTTP error the API returns.
 func (c Client) ApplyNetwork(node string) (exitStatus string, err error) {
 	url := fmt.Sprintf("/nodes/%s/network", node)
-	return c.UpdateItemWithTask(nil, url)
+	return c.PutWithTask(nil, url)
 }
 
 // RevertNetwork reverts the pending network configuration on the passed in node.
 // It returns the body from the API response and any HTTP error the API returns.
 func (c *Client) RevertNetwork(node string) (exitStatus string, err error) {
 	url := fmt.Sprintf("/nodes/%s/network", node)
-	return c.DeleteUrlWithTask(url)
+	return c.DeleteWithTask(url)
 }
 
 // Shared
@@ -1906,7 +1906,9 @@ func (c *Client) GetItemConfig(url, text, message string) (config map[string]int
 	return
 }
 
-func (c *Client) CreateItem(Params map[string]interface{}, url string) (err error) {
+// Makes a POST request without waiting on proxmox for the task to complete.
+// It returns the HTTP error as 'err'.
+func (c *Client) Post(Params map[string]interface{}, url string) (err error) {
 	reqbody := ParamsToBody(Params)
 	_, err = c.session.Post(url, nil, nil, &reqbody)
 	return
@@ -1921,8 +1923,9 @@ func (c *Client) CreateItemReturnStatus(params map[string]interface{}, url strin
 	return
 }
 
-// Create Item and wait on proxmox for the task to complete
-func (c *Client) CreateItemWithTask(Params map[string]interface{}, url string) (exitStatus string, err error) {
+// Makes a POST request and waits on proxmox for the task to complete.
+// It returns the status of the test as 'exitStatus' and the HTTP error as 'err'.
+func (c *Client) PostWithTask(Params map[string]interface{}, url string) (exitStatus string, err error) {
 	reqbody := ParamsToBody(Params)
 	var resp *http.Response
 	resp, err = c.session.Post(url, nil, nil, &reqbody)
@@ -1932,7 +1935,9 @@ func (c *Client) CreateItemWithTask(Params map[string]interface{}, url string) (
 	return c.CheckTask(resp)
 }
 
-func (c *Client) UpdateItem(Params map[string]interface{}, url string) (err error) {
+// Makes a PUT request without waiting on proxmox for the task to complete.
+// It returns the HTTP error as 'err'.
+func (c *Client) Put(Params map[string]interface{}, url string) (err error) {
 	reqbody := ParamsToBodyWithAllEmpty(Params)
 	_, err = c.session.Put(url, nil, nil, &reqbody)
 	return
@@ -1947,8 +1952,9 @@ func (c *Client) UpdateItemReturnStatus(params map[string]interface{}, url strin
 	return
 }
 
-// Update Item and wait on proxmox for the task to complete
-func (c *Client) UpdateItemWithTask(Params map[string]interface{}, url string) (exitStatus string, err error) {
+// Makes a PUT request and waits on proxmox for the task to complete.
+// It returns the status of the test as 'exitStatus' and the HTTP error as 'err'.
+func (c *Client) PutWithTask(Params map[string]interface{}, url string) (exitStatus string, err error) {
 	reqbody := ParamsToBodyWithAllEmpty(Params)
 	var resp *http.Response
 	resp, err = c.session.Put(url, nil, nil, &reqbody)
@@ -1958,13 +1964,16 @@ func (c *Client) UpdateItemWithTask(Params map[string]interface{}, url string) (
 	return c.CheckTask(resp)
 }
 
-func (c *Client) DeleteUrl(url string) (err error) {
+// Makes a DELETE request without waiting on proxmox for the task to complete.
+// It returns the HTTP error as 'err'.
+func (c *Client) Delete(url string) (err error) {
 	_, err = c.session.Delete(url, nil, nil)
 	return
 }
 
-// Delete Item and wait on proxmox for the task to complete
-func (c *Client) DeleteUrlWithTask(url string) (exitStatus string, err error) {
+// Makes a DELETE request and waits on proxmox for the task to complete.
+// It returns the status of the test as 'exitStatus' and the HTTP error as 'err'.
+func (c *Client) DeleteWithTask(url string) (exitStatus string, err error) {
 	var resp *http.Response
 	resp, err = c.session.Delete(url, nil, nil)
 	if err != nil {

--- a/proxmox/config_lxc.go
+++ b/proxmox/config_lxc.go
@@ -405,7 +405,7 @@ func (config ConfigLxc) CloneLxc(vmr *VmRef, client *Client) (err error) {
 func (config ConfigLxc) UpdateConfig(vmr *VmRef, client *Client) (err error) {
 	paramMap := config.mapToAPIParams()
 
-	// delete parameters wich are not supported in updated operations
+	// delete parameters which are not supported in updated operations
 	delete(paramMap, "pool")
 	delete(paramMap, "storage")
 	delete(paramMap, "password")
@@ -456,7 +456,7 @@ func (config ConfigLxc) mapToAPIParams() map[string]interface{} {
 
 	// build list of features
 	// add features as parameter list to lxc parameters
-	// this overwrites the orginal formatting with a
+	// this overwrites the original formatting with a
 	// comma separated list of "key=value" pairs
 	paramMap["features"] = formatDeviceParam(config.Features)
 

--- a/proxmox/config_storage.go
+++ b/proxmox/config_storage.go
@@ -67,7 +67,7 @@ func (c *ConfigStorageContent) Validate(storageType string) error {
 			list = AddToList(list, strorageContentTypesStruct[i])
 		}
 	}
-	return fmt.Errorf("error atleast one of the keys (content:{ %s }) must be true", list)
+	return fmt.Errorf("error at least one of the keys (content:{ %s }) must be true", list)
 }
 
 type ConfigStorageBackupRetention struct {

--- a/proxmox/session.go
+++ b/proxmox/session.go
@@ -279,7 +279,7 @@ func (s *Session) Request(
 	return s.Do(req)
 }
 
-// Perform a simple get to an endpoint and unmarshall returned JSON
+// Perform a simple get to an endpoint and unmarshal returned JSON
 func (s *Session) RequestJSON(
 	method string,
 	url string,

--- a/proxmox/validate.go
+++ b/proxmox/validate.go
@@ -44,7 +44,7 @@ func ValidateStringNotEmpty(value, text string) error {
 	return ErrorKeyEmpty(text)
 }
 
-// check if a key is allowd to be changed after creation.
+// check if a key is allowed to be changed after creation.
 func ValidateStringsEqual(value1, value2, text string) error {
 	if value1 == value2 {
 		return nil


### PR DESCRIPTION

- Fixed lots of typos in comments, error messages and the description of CLI commands.
- Specified the number of arguments for each CLI command.
- Moved the snapshot function out of the `*Client` class.
- Renamed the `CreateItem`, `UpdateItem` and `DeleteItem` in the `*Client` class to `Post`, `Put` and `Delete`. also improved the description of these commands.
- Refactored some internal variables to be CamelCase.
- Checked i didn't rename anything used by the Terraform provider.
- Ran CLI integration test, they all where successful.