### PR TITLE
feat: LXC Template Download

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	_ "github.com/Telmate/proxmox-api-go/cli/command/content"
+	_ "github.com/Telmate/proxmox-api-go/cli/command/content/template"
 	_ "github.com/Telmate/proxmox-api-go/cli/command/create"
 	_ "github.com/Telmate/proxmox-api-go/cli/command/create/guest"
 	_ "github.com/Telmate/proxmox-api-go/cli/command/delete"

--- a/cli/command/content/content.go
+++ b/cli/command/content/content.go
@@ -1,0 +1,15 @@
+package content
+
+import (
+	"github.com/Telmate/proxmox-api-go/cli"
+	"github.com/spf13/cobra"
+)
+
+var ContentCmd = &cobra.Command{
+	Use:   "content",
+	Short: "With this command you can manage storage content",
+}
+
+func init() {
+	cli.RootCmd.AddCommand(ContentCmd)
+}

--- a/cli/command/content/template/download.go
+++ b/cli/command/content/template/download.go
@@ -1,0 +1,35 @@
+package template
+
+import (
+	"github.com/Telmate/proxmox-api-go/cli"
+	"github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/spf13/cobra"
+)
+
+var template_downloadCmd = &cobra.Command{
+	Use:   "download NODE STORAGE TEMPLATE",
+	Short: "download te specified LXC template",
+	Args:  cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		c := cli.NewClient()
+		config := proxmox.ConfigContent_Template{
+			Node:     args[0],
+			Storage:  args[1],
+			Template: args[2],
+		}
+		err = config.Validate()
+		if err != nil {
+			return
+		}
+		err = proxmox.DownloadLxcTemplate(c, config)
+		if err != nil {
+			return
+		}
+		cli.PrintItemCreated(templateCmd.OutOrStdout(), config.Template, "LXC Template")
+		return
+	},
+}
+
+func init() {
+	templateCmd.AddCommand(template_downloadCmd)
+}

--- a/cli/command/content/template/list.go
+++ b/cli/command/content/template/list.go
@@ -1,0 +1,33 @@
+package template
+
+import (
+	"github.com/Telmate/proxmox-api-go/cli"
+	"github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/spf13/cobra"
+)
+
+var template_listCmd = &cobra.Command{
+	Use:   "list NODE",
+	Short: "Prints a list of all LXC templates available for download in raw json format",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		templates, err := proxmox.ListTemplates(cli.NewClient(), args[0])
+		if err != nil {
+			return
+		}
+		cli.PrintRawJson(templateCmd.OutOrStdout(), format(templates))
+		return
+	},
+}
+
+func init() {
+	templateCmd.AddCommand(template_listCmd)
+}
+
+func format(templates *[]proxmox.TemplateItem) *[]string {
+	list := make([]string, len(*templates))
+	for i, e := range *templates {
+		list[i] = e.Template
+	}
+	return &list
+}

--- a/cli/command/content/template/template.go
+++ b/cli/command/content/template/template.go
@@ -1,0 +1,15 @@
+package template
+
+import (
+	"github.com/Telmate/proxmox-api-go/cli/command/content"
+	"github.com/spf13/cobra"
+)
+
+var templateCmd = &cobra.Command{
+	Use:   "template",
+	Short: "With this command you can manage Lxc container templates in proxmox",
+}
+
+func init() {
+	content.ContentCmd.AddCommand(templateCmd)
+}

--- a/cli/command/delete/delete-file.go
+++ b/cli/command/delete/delete-file.go
@@ -1,0 +1,34 @@
+package delete
+
+import (
+	"github.com/Telmate/proxmox-api-go/cli"
+	"github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/spf13/cobra"
+)
+
+var delete_fileCmd = &cobra.Command{
+	Use:   "file NODE STORAGE TYPE FILE",
+	Short: "Deletes the specified File",
+	Args:  cobra.ExactArgs(4),
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		c := cli.NewClient()
+		Type := proxmox.ContentType(args[2])
+		if Type.Validate() != nil {
+			return
+		}
+		err = proxmox.DeleteFile(c, args[0], proxmox.Content_File{
+			Storage:     args[1],
+			ContentType: Type,
+			FilePath:    args[3],
+		})
+		if err != nil {
+			return
+		}
+		cli.PrintItemDeleted(deleteCmd.OutOrStdout(), args[3], "File")
+		return
+	},
+}
+
+func init() {
+	deleteCmd.AddCommand(delete_fileCmd)
+}

--- a/cli/command/list/list-files.go
+++ b/cli/command/list/list-files.go
@@ -1,0 +1,26 @@
+package list
+
+import (
+	"github.com/Telmate/proxmox-api-go/cli"
+	"github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/spf13/cobra"
+)
+
+var list_FileCmd = &cobra.Command{
+	Use:   "files NODE STORAGE TYPE",
+	Short: "Prints a list of Files of the specified type in raw json format",
+	Args:  cobra.ExactArgs(3),
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		c := cli.NewClient()
+		templates, err := proxmox.ListFiles(c, args[0], args[1], proxmox.ContentType(args[2]))
+		if err != nil {
+			return
+		}
+		cli.PrintRawJson(listCmd.OutOrStdout(), templates)
+		return
+	},
+}
+
+func init() {
+	listCmd.AddCommand(list_FileCmd)
+}

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -1941,6 +1941,14 @@ func (c *Client) DeleteWithTask(url string) (exitStatus string, err error) {
 	return c.CheckTask(resp)
 }
 
+func (c *Client) GetItemListInterfaceArray(url string) ([]interface{}, error) {
+	list, err := c.GetItemList(url)
+	if err != nil {
+		return nil, err
+	}
+	return list["data"].([]interface{}), nil
+}
+
 func (c *Client) GetItemList(url string) (list map[string]interface{}, err error) {
 	err = c.GetJsonRetryable(url, &list, 3)
 	return

--- a/proxmox/content.go
+++ b/proxmox/content.go
@@ -73,6 +73,7 @@ func (c Content_File) format() (fullPath string) {
 	return "/" + c.Storage + ":" + string(c.ContentType) + "/" + strings.TrimPrefix(c.FilePath, "/")
 }
 
+// Return an error if the required fields are empty
 func (c Content_File) Validate() (err error) {
 	err = c.ContentType.Validate()
 	if err != nil {
@@ -94,6 +95,7 @@ type Content_FileProperties struct {
 	Size         uint      `json:"size"`
 }
 
+// Check if a file with the specific name exists in the list of files.
 func CheckFileExistence(fileName string, files *[]Content_FileProperties) bool {
 	for _, e := range *files {
 		if e.Name == fileName {
@@ -125,6 +127,7 @@ func createFilesList(fileList []interface{}) *[]Content_FileProperties {
 	return &files
 }
 
+// Deletes te specified file from the specified storage.
 func DeleteFile(client *Client, node string, content Content_File) (err error) {
 	content.ContentType, err = content.ContentType.toApiValueAndValidate()
 	if err != nil {
@@ -134,6 +137,7 @@ func DeleteFile(client *Client, node string, content Content_File) (err error) {
 	return
 }
 
+// List all files of the given type in the the specified storage
 func ListFiles(client *Client, node, storage string, content ContentType) (files *[]Content_FileProperties, err error) {
 	content, err = content.toApiValueAndValidate()
 	if err != nil {

--- a/proxmox/content.go
+++ b/proxmox/content.go
@@ -1,0 +1,103 @@
+package proxmox
+
+import (
+	"errors"
+	"strings"
+	"time"
+)
+
+type ContentType string
+
+const (
+	ContentType_Backup             ContentType = "backup"
+	ContentType_Container          ContentType = "container"
+	ContentType_DiskImage          ContentType = "diskimage"
+	ContentType_Iso                ContentType = "iso"
+	ContentType_Snippets           ContentType = "snippets"
+	ContentType_Template           ContentType = "template"
+	contentType_Backup_ApiValue    ContentType = "backup"
+	contentType_Container_ApiValue ContentType = "rootdir"
+	contentType_DiskImage_ApiValue ContentType = "images"
+	contentType_Snippets_ApiValue  ContentType = "snippets"
+	contentType_Iso_ApiValue       ContentType = "iso"
+	contentType_Template_ApiValue  ContentType = "vztmpl"
+)
+
+// Converts the user friendly enum value to a value the proxmox api understands.
+func (c ContentType) toApiValue() ContentType {
+	switch c {
+	case ContentType_Backup:
+		return contentType_Backup_ApiValue
+	case ContentType_Container, contentType_Container_ApiValue:
+		return contentType_Container_ApiValue
+	case ContentType_DiskImage, contentType_DiskImage_ApiValue:
+		return contentType_DiskImage_ApiValue
+	case ContentType_Iso:
+		return contentType_Iso_ApiValue
+	case ContentType_Snippets:
+		return contentType_Snippets_ApiValue
+	case ContentType_Template, contentType_Template_ApiValue:
+		return contentType_Template_ApiValue
+	}
+	return ""
+}
+
+// Converts the user friendly enum value to a value the proxmox api understands.
+// If the input enum value is invalid it will return an error.
+func (c ContentType) toApiValueAndValidate() (api ContentType, err error) {
+	api = c.toApiValue()
+	if api == "" {
+		err = errors.New("value should be one of (" + c.enumList() + ")")
+	}
+	return
+}
+
+// Returns a list of all enum options.
+func (c ContentType) enumList() string {
+	return string(ContentType_Backup) + "," + string(ContentType_Container) + "," + string(ContentType_DiskImage) + "," + string(ContentType_Iso) + "," + string(ContentType_Snippets) + "," + string(ContentType_Template)
+}
+
+type Content_FileProperties struct {
+	Name         string    `json:"name"`
+	CreationTime time.Time `json:"time"`
+	Format       string    `json:"format"`
+	Size         uint      `json:"size"`
+}
+
+func createFilesList(fileList []interface{}) *[]Content_FileProperties {
+	files := make([]Content_FileProperties, len(fileList))
+	for i := range fileList {
+		itemMap := fileList[i].(map[string]interface{})
+		tmpFile := Content_FileProperties{}
+		if _, isSet := itemMap["volid"]; isSet {
+			tmpFile.Name = volumeIdToFileName(itemMap["volid"].(string))
+		}
+		if _, isSet := itemMap["ctime"]; isSet {
+			tmpFile.CreationTime = time.UnixMilli(int64(itemMap["ctime"].(float64)) * 1000)
+		}
+		if _, isSet := itemMap["format"]; isSet {
+			tmpFile.Format = itemMap["format"].(string)
+		}
+		if _, isSet := itemMap["size"]; isSet {
+			tmpFile.Size = uint(itemMap["size"].(float64))
+		}
+		files[i] = tmpFile
+	}
+	return &files
+}
+
+func ListFiles(client *Client, node, storage string, content ContentType) (files *[]Content_FileProperties, err error) {
+	content, err = content.toApiValueAndValidate()
+	if err != nil {
+		return
+	}
+	fileList, err := client.GetItemListInterfaceArray("/nodes/" + node + "/storage/" + storage + "/content?content=" + string(content))
+	if err != nil {
+		return
+	}
+	return createFilesList(fileList), nil
+}
+
+func volumeIdToFileName(volumeId string) string {
+	return volumeId[strings.Index(volumeId, "/")+1:]
+}

--- a/proxmox/content_template.go
+++ b/proxmox/content_template.go
@@ -34,7 +34,85 @@ func (content ConfigContent_Template) Validate() (err error) {
 	return
 }
 
+type TemplateItem struct {
+	Architecture   string
+	Description    string
+	Headline       string
+	InfoPage       string
+	Location       string
+	ManageURL      string
+	OS             string
+	Package        string
+	Section        string
+	SHA512Checksum string
+	Source         string
+	Template       string
+	Type           string
+	Version        string
+}
+
+func createTemplateList(templateList []interface{}) *[]TemplateItem {
+	templates := make([]TemplateItem, len(templateList))
+	for i := range templateList {
+		itemMap := templateList[i].(map[string]interface{})
+		tmp := TemplateItem{}
+		if _, isSet := itemMap["architecture"]; isSet {
+			tmp.Architecture = itemMap["architecture"].(string)
+		}
+		if _, isSet := itemMap["description"]; isSet {
+			tmp.Description = itemMap["description"].(string)
+		}
+		if _, isSet := itemMap["headline"]; isSet {
+			tmp.Headline = itemMap["headline"].(string)
+		}
+		if _, isSet := itemMap["infopage"]; isSet {
+			tmp.InfoPage = itemMap["infopage"].(string)
+		}
+		if _, isSet := itemMap["location"]; isSet {
+			tmp.Location = itemMap["location"].(string)
+		}
+		if _, isSet := itemMap["manageurl"]; isSet {
+			tmp.ManageURL = itemMap["manageurl"].(string)
+		}
+		if _, isSet := itemMap["os"]; isSet {
+			tmp.OS = itemMap["os"].(string)
+		}
+		if _, isSet := itemMap["package"]; isSet {
+			tmp.Package = itemMap["package"].(string)
+		}
+		if _, isSet := itemMap["section"]; isSet {
+			tmp.Section = itemMap["section"].(string)
+		}
+		if _, isSet := itemMap["sha512sum"]; isSet {
+			tmp.SHA512Checksum = itemMap["sha512sum"].(string)
+		}
+		if _, isSet := itemMap["source"]; isSet {
+			tmp.Source = itemMap["source"].(string)
+		}
+		if _, isSet := itemMap["template"]; isSet {
+			tmp.Template = itemMap["template"].(string)
+		}
+		if _, isSet := itemMap["type"]; isSet {
+			tmp.Type = itemMap["type"].(string)
+		}
+		if _, isSet := itemMap["version"]; isSet {
+			tmp.Version = itemMap["version"].(string)
+		}
+		templates[i] = tmp
+	}
+	return &templates
+}
+
 func DownloadLxcTemplate(client *Client, content ConfigContent_Template) (err error) {
 	_, err = client.PostWithTask(content.mapToApiValues(), "/nodes/"+content.Node+"/aplinfo")
+	return
+}
+
+func ListTemplates(client *Client, node string) (templateList *[]TemplateItem, err error) {
+	tmpList, err := client.GetItemListInterfaceArray("/nodes/" + node + "/aplinfo")
+	if err != nil {
+		return
+	}
+	templateList = createTemplateList(tmpList)
 	return
 }

--- a/proxmox/content_template.go
+++ b/proxmox/content_template.go
@@ -21,6 +21,7 @@ func (content ConfigContent_Template) mapToApiValues() map[string]interface{} {
 	}
 }
 
+// Return an error if the one of the values is empty.
 func (content ConfigContent_Template) Validate() (err error) {
 	if content.Node == "" {
 		return content.error("Node")
@@ -51,6 +52,7 @@ type TemplateItem struct {
 	Version        string
 }
 
+// Map values from the API to the TemplateItem struct.
 func createTemplateList(templateList []interface{}) *[]TemplateItem {
 	templates := make([]TemplateItem, len(templateList))
 	for i := range templateList {
@@ -103,11 +105,13 @@ func createTemplateList(templateList []interface{}) *[]TemplateItem {
 	return &templates
 }
 
+// Download an LXC template.
 func DownloadLxcTemplate(client *Client, content ConfigContent_Template) (err error) {
 	_, err = client.PostWithTask(content.mapToApiValues(), "/nodes/"+content.Node+"/aplinfo")
 	return
 }
 
+// List all LXC templates available for download.
 func ListTemplates(client *Client, node string) (templateList *[]TemplateItem, err error) {
 	tmpList, err := client.GetItemListInterfaceArray("/nodes/" + node + "/aplinfo")
 	if err != nil {

--- a/proxmox/content_template.go
+++ b/proxmox/content_template.go
@@ -1,9 +1,17 @@
 package proxmox
 
+import (
+	"errors"
+)
+
 type ConfigContent_Template struct {
 	Node     string
 	Storage  string
 	Template string
+}
+
+func (content ConfigContent_Template) error(text string) error {
+	return errors.New("the value of (" + text + ") may not be empty")
 }
 
 func (content ConfigContent_Template) mapToApiValues() map[string]interface{} {
@@ -11,6 +19,19 @@ func (content ConfigContent_Template) mapToApiValues() map[string]interface{} {
 		"storage":  content.Storage,
 		"template": content.Template,
 	}
+}
+
+func (content ConfigContent_Template) Validate() (err error) {
+	if content.Node == "" {
+		return content.error("Node")
+	}
+	if content.Storage == "" {
+		return content.error("Storage")
+	}
+	if content.Template == "" {
+		return content.error("Template")
+	}
+	return
 }
 
 func DownloadLxcTemplate(client *Client, content ConfigContent_Template) (err error) {

--- a/proxmox/content_template.go
+++ b/proxmox/content_template.go
@@ -1,0 +1,19 @@
+package proxmox
+
+type ConfigContent_Template struct {
+	Node     string
+	Storage  string
+	Template string
+}
+
+func (content ConfigContent_Template) mapToApiValues() map[string]interface{} {
+	return map[string]interface{}{
+		"storage":  content.Storage,
+		"template": content.Template,
+	}
+}
+
+func DownloadLxcTemplate(client *Client, content ConfigContent_Template) (err error) {
+	_, err = client.PostWithTask(content.mapToApiValues(), "/nodes/"+content.Node+"/aplinfo")
+	return
+}

--- a/proxmox/content_template_test.go
+++ b/proxmox/content_template_test.go
@@ -65,3 +65,102 @@ func Test_ConfigContent_Template_Validate(t *testing.T) {
 		require.Equal(t, e.output, e.input.Validate())
 	}
 }
+
+func Test_createTemplateList(t *testing.T) {
+	testData := []struct {
+		Input  []interface{}
+		Output *[]TemplateItem
+	}{
+		{
+			Input: []interface{}{
+				map[string]interface{}{
+					"location":    "http://mirror.turnkeylinux.org/turnkeylinux/images/proxmox/debian-11-turnkey-drupal7_17.1-1_amd64.tar.gz",
+					"manageurl":   "http://__IPADDRESS__/",
+					"description": "TurnKey Drupal 7 - Content Management Framework",
+					"version":     "17.1-1",
+					"template":    "debian-11-turnkey-drupal7_17.1-1_amd64.tar.gz",
+					"headline":    "TurnKey Drupal 7",
+					"source":      "https://releases.turnkeylinux.org/pve",
+					"package":     "turnkey-drupal7",
+					"section":     "turnkeylinux",
+				},
+				map[string]interface{}{
+					"infopage":     "http://www.turnkeylinux.org/mumble",
+					"section":      "turnkeylinux",
+					"headline":     "TurnKey Mumble",
+					"manageurl":    "http://__IPADDRESS__/",
+					"sha512sum":    "30a81eec66968817b9e06502141a476d0707643e3649034f0edc69692fcbff6ccde49e43ec9ef6ee09e2655faab1202e915428cc30e77af30749dabbac944d28",
+					"type":         "lxc",
+					"architecture": "amd64",
+					"os":           "debian-11",
+					"template":     "debian-11-turnkey-mumble_17.1-1_amd64.tar.gz",
+				},
+				map[string]interface{}{
+					"location":     "http://mirror.turnkeylinux.org/turnkeylinux/images/proxmox/debian-11-turnkey-mattermost_17.1-1_amd64.tar.gz",
+					"type":         "lxc",
+					"os":           "debian-11",
+					"package":      "turnkey-mattermost",
+					"sha512sum":    "5b6d3cdd8fac06494cd094dac36a9b2820889c4b3e0ef033a17b3f4d82d12390fccbcb0ab1425472595d163c6ce28c047bda5bd8e4e9c551a7db2744ada3c130",
+					"architecture": "amd64",
+					"description":  "TurnKey Mattermost - Open Source, self-hosted Slack-alternative",
+					"version":      "17.1-1",
+					"infopage":     "http://www.turnkeylinux.org/mattermost",
+					"source":       "https://releases.turnkeylinux.org/pve",
+				},
+			},
+			Output: &[]TemplateItem{
+				{
+					Architecture:   "",
+					Description:    "TurnKey Drupal 7 - Content Management Framework",
+					Headline:       "TurnKey Drupal 7",
+					InfoPage:       "",
+					Location:       "http://mirror.turnkeylinux.org/turnkeylinux/images/proxmox/debian-11-turnkey-drupal7_17.1-1_amd64.tar.gz",
+					ManageURL:      "http://__IPADDRESS__/",
+					OS:             "",
+					Package:        "turnkey-drupal7",
+					Section:        "turnkeylinux",
+					SHA512Checksum: "",
+					Source:         "https://releases.turnkeylinux.org/pve",
+					Template:       "debian-11-turnkey-drupal7_17.1-1_amd64.tar.gz",
+					Type:           "",
+					Version:        "17.1-1",
+				},
+				{
+					Architecture:   "amd64",
+					Description:    "",
+					Headline:       "TurnKey Mumble",
+					InfoPage:       "http://www.turnkeylinux.org/mumble",
+					Location:       "",
+					ManageURL:      "http://__IPADDRESS__/",
+					OS:             "debian-11",
+					Package:        "",
+					Section:        "turnkeylinux",
+					SHA512Checksum: "30a81eec66968817b9e06502141a476d0707643e3649034f0edc69692fcbff6ccde49e43ec9ef6ee09e2655faab1202e915428cc30e77af30749dabbac944d28",
+					Source:         "",
+					Template:       "debian-11-turnkey-mumble_17.1-1_amd64.tar.gz",
+					Type:           "lxc",
+					Version:        "",
+				},
+				{
+					Architecture:   "amd64",
+					Description:    "TurnKey Mattermost - Open Source, self-hosted Slack-alternative",
+					Headline:       "",
+					InfoPage:       "http://www.turnkeylinux.org/mattermost",
+					Location:       "http://mirror.turnkeylinux.org/turnkeylinux/images/proxmox/debian-11-turnkey-mattermost_17.1-1_amd64.tar.gz",
+					ManageURL:      "",
+					OS:             "debian-11",
+					Package:        "turnkey-mattermost",
+					Section:        "",
+					SHA512Checksum: "5b6d3cdd8fac06494cd094dac36a9b2820889c4b3e0ef033a17b3f4d82d12390fccbcb0ab1425472595d163c6ce28c047bda5bd8e4e9c551a7db2744ada3c130",
+					Source:         "https://releases.turnkeylinux.org/pve",
+					Template:       "",
+					Type:           "lxc",
+					Version:        "17.1-1",
+				},
+			},
+		},
+	}
+	for _, e := range testData {
+		require.Equal(t, e.Output, createTemplateList(e.Input))
+	}
+}

--- a/proxmox/content_template_test.go
+++ b/proxmox/content_template_test.go
@@ -1,10 +1,15 @@
 package proxmox
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func Test_ConfigContent_Template_error(t *testing.T) {
+	require.Equal(t, errors.New("the value of (Node) may not be empty"), ConfigContent_Template{}.error("Node"))
+}
 
 func Test_ConfigContent_Template_mapToApiValues(t *testing.T) {
 	testData := []struct {
@@ -24,5 +29,39 @@ func Test_ConfigContent_Template_mapToApiValues(t *testing.T) {
 	}
 	for _, e := range testData {
 		require.Equal(t, e.output, e.input.mapToApiValues())
+	}
+}
+
+func Test_ConfigContent_Template_Validate(t *testing.T) {
+	testData := []struct {
+		input  ConfigContent_Template
+		output error
+	}{
+		{
+			input:  ConfigContent_Template{},
+			output: ConfigContent_Template{}.error("Node"),
+		},
+		{
+			input:  ConfigContent_Template{Node: "notEmpty"},
+			output: ConfigContent_Template{}.error("Storage"),
+		},
+		{
+			input: ConfigContent_Template{
+				Node:    "notEmpty",
+				Storage: "notEmpty",
+			},
+			output: ConfigContent_Template{}.error("Template"),
+		},
+		{
+			input: ConfigContent_Template{
+				Node:     "notEmpty",
+				Storage:  "notEmpty",
+				Template: "notEmpty",
+			},
+			output: nil,
+		},
+	}
+	for _, e := range testData {
+		require.Equal(t, e.output, e.input.Validate())
 	}
 }

--- a/proxmox/content_template_test.go
+++ b/proxmox/content_template_test.go
@@ -1,0 +1,28 @@
+package proxmox
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ConfigContent_Template_mapToApiValues(t *testing.T) {
+	testData := []struct {
+		input  ConfigContent_Template
+		output map[string]interface{}
+	}{
+		{
+			input: ConfigContent_Template{
+				Storage:  "a",
+				Template: "b",
+			},
+			output: map[string]interface{}{
+				"storage":  "a",
+				"template": "b",
+			},
+		},
+	}
+	for _, e := range testData {
+		require.Equal(t, e.output, e.input.mapToApiValues())
+	}
+}

--- a/proxmox/content_test.go
+++ b/proxmox/content_test.go
@@ -1,0 +1,158 @@
+package proxmox
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type test_Content_ContentType struct {
+	ApiValue ContentType
+	err      error
+}
+
+// test if the ContentType value is properly converted to API values
+func Test_Content_ContentType_toApiValue(t *testing.T) {
+	input := test_Content_ContentType_Input()
+	output := test_Content_ContentType_Output()
+	for i := range input {
+		require.Equal(t, output[i].ApiValue, input[i].toApiValue())
+	}
+}
+
+// test if the ContentType value is properly converted to API values and test if its a valid enum
+func Test_Content_ContentType_toApiValueAndValidate(t *testing.T) {
+	input := test_Content_ContentType_Input()
+	output := test_Content_ContentType_Output()
+	for i := range input {
+		api, err := input[i].toApiValueAndValidate()
+		require.Equal(t, output[i].ApiValue, api)
+		require.Equal(t, output[i].err, err)
+	}
+}
+
+// input data for testing
+func test_Content_ContentType_Input() []ContentType {
+	return []ContentType{
+		ContentType_Backup,
+		ContentType_Container,
+		ContentType_DiskImage,
+		ContentType_Iso,
+		ContentType_Snippets,
+		ContentType_Template,
+		"invalid input",
+		contentType_Backup_ApiValue,
+		contentType_Container_ApiValue,
+		contentType_DiskImage_ApiValue,
+		contentType_Iso_ApiValue,
+		contentType_Snippets_ApiValue,
+		contentType_Template_ApiValue,
+		"",
+	}
+}
+
+// result data for testing
+func test_Content_ContentType_Output() []test_Content_ContentType {
+	var c ContentType
+	testArray := []test_Content_ContentType{
+		{
+			ApiValue: contentType_Backup_ApiValue,
+			err:      nil,
+		},
+		{
+			ApiValue: contentType_Container_ApiValue,
+			err:      nil,
+		},
+		{
+			ApiValue: contentType_DiskImage_ApiValue,
+			err:      nil,
+		},
+		{
+			ApiValue: contentType_Iso_ApiValue,
+			err:      nil,
+		},
+		{
+			ApiValue: contentType_Snippets_ApiValue,
+			err:      nil,
+		},
+		{
+			ApiValue: contentType_Template_ApiValue,
+			err:      nil,
+		},
+		{
+			ApiValue: "",
+			err:      errors.New("value should be one of (" + c.enumList() + ")"),
+		},
+	}
+	return append(testArray, testArray...)
+}
+
+// test the conversion from a volumeID to a file path
+func Test_Content_createFilesList(t *testing.T) {
+	input := [][]interface{}{
+		{
+			map[string]interface{}{
+				"ctime":  float64(1671032208),
+				"format": "txz",
+				"volid":  "local:vztmpl/alpine-3.16-default_20220622_amd64.tar.xz",
+				"size":   float64(2540360),
+			},
+			map[string]interface{}{
+				"ctime":  float64(1671032191),
+				"format": "txz",
+				"volid":  "local:vztmpl/centos-8-default_20201210_amd64.tar.xz",
+				"size":   float64(99098368),
+			},
+			map[string]interface{}{
+				"ctime":  float64(1671032200),
+				"format": "tgz",
+				"volid":  "local:vztmpl/debian-10-standard_10.7-1_amd64.tar.gz",
+				"size":   float64(231060971),
+			},
+		}, {
+			map[string]interface{}{
+				"ctime":  float64(1665838226),
+				"format": "txz",
+				"volid":  "local:vztmpl/root-fs.tar.xz",
+				"size":   float64(77551540),
+			},
+		},
+	}
+	output := []*[]Content_FileProperties{
+		{
+			{
+				Name:         "alpine-3.16-default_20220622_amd64.tar.xz",
+				CreationTime: time.UnixMilli(1671032208 * 1000),
+				Format:       "txz",
+				Size:         2540360,
+			}, {
+				Name:         "centos-8-default_20201210_amd64.tar.xz",
+				CreationTime: time.UnixMilli(1671032191 * 1000),
+				Format:       "txz",
+				Size:         99098368,
+			}, {
+				Name:         "debian-10-standard_10.7-1_amd64.tar.gz",
+				CreationTime: time.UnixMilli(1671032200 * 1000),
+				Format:       "tgz",
+				Size:         231060971,
+			}}, {{
+			Name:         "root-fs.tar.xz",
+			CreationTime: time.UnixMilli(1665838226 * 1000),
+			Format:       "txz",
+			Size:         77551540,
+		}}}
+	for i := range input {
+		require.Equal(t, output[i], createFilesList(input[i]))
+	}
+}
+
+// test the conversion from a volumeID to a file path
+func Test_Content_volumeIdToFileName(t *testing.T) {
+	input := []string{"local:vztmpl/alpine-3.16-default_20220622_amd64.tar.xz"}
+	output := []string{"alpine-3.16-default_20220622_amd64.tar.xz"}
+	for i := range input {
+		require.Equal(t, output[i], volumeIdToFileName(input[i]))
+	}
+}

--- a/proxmox/content_test.go
+++ b/proxmox/content_test.go
@@ -33,6 +33,15 @@ func Test_Content_ContentType_toApiValueAndValidate(t *testing.T) {
 	}
 }
 
+// test if the ContentType value is a valid enum
+func Test_Content_ContentType_Validate(t *testing.T) {
+	input := test_Content_ContentType_Input()
+	output := test_Content_ContentType_Output()
+	for i := range input {
+		require.Equal(t, output[i].err, input[i].Validate())
+	}
+}
+
 // input data for testing
 func test_Content_ContentType_Input() []ContentType {
 	return []ContentType{
@@ -87,6 +96,78 @@ func test_Content_ContentType_Output() []test_Content_ContentType {
 		},
 	}
 	return append(testArray, testArray...)
+}
+
+// test the formatting of the file object into a single string
+func Test_Content_File_format(t *testing.T) {
+	input := []Content_File{
+		{
+			Storage:     "Local",
+			ContentType: "vztmpl",
+			FilePath:    "debian-11-standard_11.0-1_amd64.tar.gz",
+		},
+		{
+			Storage:     "local",
+			ContentType: "vztmpl",
+			FilePath:    "/ubuntu-22.10-standard_22.10-1_amd64.tar.zst",
+		},
+	}
+	output := []string{"/Local:vztmpl/debian-11-standard_11.0-1_amd64.tar.gz",
+		"/local:vztmpl/ubuntu-22.10-standard_22.10-1_amd64.tar.zst"}
+	for i := range input {
+		require.Equal(t, output[i], input[i].format())
+	}
+}
+
+// test if the existence of the file wil be detected
+func Test_Content_CheckFileExistence(t *testing.T) {
+	fileList := func() []Content_FileProperties {
+		return []Content_FileProperties{
+			{
+				Name: "aaaC",
+			},
+			{
+				Name: "aaaB",
+			},
+			{
+				Name: "aaaA",
+			},
+		}
+	}
+	data := []struct {
+		FileName       string
+		Existence      bool
+		FileProperties []Content_FileProperties
+	}{
+		{
+			FileName:       "aaaA",
+			Existence:      true,
+			FileProperties: fileList(),
+		},
+		{
+			FileName:       "aaaB",
+			Existence:      true,
+			FileProperties: fileList(),
+		},
+		{
+			FileName:       "",
+			Existence:      false,
+			FileProperties: fileList(),
+		},
+		{
+			FileName:       "aaaA",
+			Existence:      false,
+			FileProperties: []Content_FileProperties{},
+		},
+		{
+			FileName:       "aaaX",
+			Existence:      false,
+			FileProperties: fileList(),
+		},
+	}
+	for _, e := range data {
+		require.Equal(t, e.Existence, CheckFileExistence(e.FileName, &e.FileProperties))
+	}
 }
 
 // test the conversion from a volumeID to a file path

--- a/test/cli/Content/Template/ContentTemplate_test.go
+++ b/test/cli/Content/Template/ContentTemplate_test.go
@@ -1,0 +1,70 @@
+package content_template_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	_ "github.com/Telmate/proxmox-api-go/cli/command/commands"
+	"github.com/Telmate/proxmox-api-go/proxmox"
+	cliTest "github.com/Telmate/proxmox-api-go/test/cli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const storage string = "local"
+
+func checkIfTemplateDoesNotExist(t *testing.T, template, node, storage string) {
+	Test := cliTest.Test{
+		NotExpected: template,
+		NotContains: true,
+		Args:        []string{"-i", "list", "files", cliTest.FirstNode, storage, string(proxmox.ContentType_Template)},
+	}
+	Test.StandardTest(t)
+}
+
+func Test_ContentTemplate_Download_Cleanup(t *testing.T) {
+	Test := cliTest.Test{
+		Args: []string{"-i", "delete", "file", cliTest.FirstNode, storage, string(proxmox.ContentType_Template), cliTest.DownloadedLXCTemplate},
+	}
+	Test.StandardTest(t)
+}
+
+func Test_ContentTemplate_Existence_Removed_0(t *testing.T) {
+	checkIfTemplateDoesNotExist(t, cliTest.DownloadedLXCTemplate, cliTest.FirstNode, storage)
+}
+
+func Test_ContentTemplate_Download(t *testing.T) {
+	Test := cliTest.Test{
+		Expected: "(" + cliTest.DownloadedLXCTemplate + ")",
+		Contains: true,
+		Args:     []string{"-i", "content", "template", "download", cliTest.FirstNode, storage, cliTest.DownloadedLXCTemplate},
+	}
+	Test.StandardTest(t)
+}
+
+func Test_ContentTemplate_List(t *testing.T) {
+	Test := cliTest.Test{
+		Return: true,
+		Args:   []string{"-i", "list", "files", cliTest.FirstNode, storage, string(proxmox.ContentType_Template)},
+	}
+	var data []*proxmox.Content_FileProperties
+	require.NoError(t, json.Unmarshal(Test.StandardTest(t), &data))
+	assert.Equal(t, cliTest.DownloadedLXCTemplate, data[0].Name)
+	assert.NotEqual(t, "", data[0].Format)
+	assert.Greater(t, data[0].Size, uint(0))
+	assert.Greater(t, data[0].CreationTime, time.UnixMilli(0))
+}
+
+func Test_ContentTemplate_Download_Delete(t *testing.T) {
+	Test := cliTest.Test{
+		Expected: cliTest.DownloadedLXCTemplate,
+		Contains: true,
+		Args:     []string{"-i", "delete", "file", cliTest.FirstNode, storage, string(proxmox.ContentType_Template), cliTest.DownloadedLXCTemplate},
+	}
+	Test.StandardTest(t)
+}
+
+func Test_ContentTemplate_Existence_Removed_1(t *testing.T) {
+	checkIfTemplateDoesNotExist(t, cliTest.DownloadedLXCTemplate, cliTest.FirstNode, storage)
+}

--- a/test/cli/constants.go
+++ b/test/cli/constants.go
@@ -1,0 +1,4 @@
+package test
+
+const DownloadedLXCTemplate string = "alpine-3.17-default_20221129_amd64.tar.xz"
+const FirstNode string = "pve"


### PR DESCRIPTION
Work done for this feature:

- Added commands to download and list LXC templates available for download.
- Added commands to list and delete files in a Proxmox storage.
- Added integration test for downloading LXC templates.
- Added test for all new pure functions.

Now we are able to download LXC templates in an automated fashion. The integration test for LXC guest can be created.

Ran all integration tests and they completed successfully.