### PR TITLE
feat: Download ISO files

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	_ "github.com/Telmate/proxmox-api-go/cli/command/content"
+	_ "github.com/Telmate/proxmox-api-go/cli/command/content/iso"
 	_ "github.com/Telmate/proxmox-api-go/cli/command/content/template"
 	_ "github.com/Telmate/proxmox-api-go/cli/command/create"
 	_ "github.com/Telmate/proxmox-api-go/cli/command/create/guest"

--- a/cli/command/content/iso/download.go
+++ b/cli/command/content/iso/download.go
@@ -1,0 +1,38 @@
+package iso
+
+import (
+	"github.com/Telmate/proxmox-api-go/cli"
+	"github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/spf13/cobra"
+)
+
+var iso_downloadCmd = &cobra.Command{
+	Use:   "download NODE STORAGE URL FILENAME [CHECKSUMALGORITHM] [CHECKSUM]",
+	Short: "download iso file from URL",
+	Args:  cobra.RangeArgs(4, 7),
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		c := cli.NewClient()
+		config := proxmox.ConfigContent_Iso{
+			Node:              cli.RequiredIDset(args, 0, "Node"),
+			Storage:           cli.RequiredIDset(args, 1, "Storage"),
+			DownloadUrl:       cli.RequiredIDset(args, 2, "URL"),
+			Filename:          cli.RequiredIDset(args, 3, "Filename"),
+			ChecksumAlgorithm: cli.OptionalIDset(args, 4),
+			Checksum:          cli.OptionalIDset(args, 5),
+		}
+		err = config.Validate()
+		if err != nil {
+			return
+		}
+		err = proxmox.DownloadIsoFromUrl(c, config)
+		if err != nil {
+			return
+		}
+		cli.PrintItemCreated(isoCmd.OutOrStdout(), config.Filename, "ISO file")
+		return
+	},
+}
+
+func init() {
+	isoCmd.AddCommand(iso_downloadCmd)
+}

--- a/cli/command/content/iso/iso.go
+++ b/cli/command/content/iso/iso.go
@@ -1,0 +1,15 @@
+package iso
+
+import (
+	"github.com/Telmate/proxmox-api-go/cli/command/content"
+	"github.com/spf13/cobra"
+)
+
+var isoCmd = &cobra.Command{
+	Use:   "iso",
+	Short: "With this command you can download iso files to a Proxmox storage.",
+}
+
+func init() {
+	content.ContentCmd.AddCommand(isoCmd)
+}

--- a/proxmox/content_iso.go
+++ b/proxmox/content_iso.go
@@ -1,0 +1,56 @@
+package proxmox
+
+import (
+	"errors"
+)
+
+type ConfigContent_Iso struct {
+	Checksum          string
+	ChecksumAlgorithm string
+	DownloadUrl       string
+	Filename          string
+	Node              string
+	Storage           string
+}
+
+func (content ConfigContent_Iso) error(text string) error {
+	return errors.New("the value of (" + text + ") may not be empty")
+}
+
+func (content ConfigContent_Iso) mapToApiValues() map[string]interface{} {
+	return map[string]interface{}{
+		"checksum-algorithm": content.ChecksumAlgorithm,
+		"checksum":           content.Checksum,
+		"content":            "iso",
+		"filename":           content.Filename,
+		"storage":            content.Storage,
+		"url":                content.DownloadUrl,
+	}
+}
+
+// Return an error if the one of the values is empty.
+func (content ConfigContent_Iso) Validate() (err error) {
+	if content.Node == "" {
+		return content.error("Node")
+	}
+	if content.Storage == "" {
+		return content.error("Storage")
+	}
+	if content.DownloadUrl == "" {
+		return content.error("URL")
+	}
+	if content.Filename == "" {
+		return content.error("Filename")
+	}
+	return
+}
+
+// Download an Iso file from a given URL.
+// https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/storage/{storage}/download-url
+func DownloadIsoFromUrl(client *Client, content ConfigContent_Iso) (err error) {
+	_, err = client.PostWithTask(content.mapToApiValues(), "/nodes/"+content.Node+"/storage/"+content.Storage+"/download-url")
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/proxmox/content_iso_test.go
+++ b/proxmox/content_iso_test.go
@@ -1,0 +1,83 @@
+package proxmox
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ConfigContent_Iso_error(t *testing.T) {
+	require.Equal(t, errors.New("the value of (Node) may not be empty"), ConfigContent_Iso{}.error("Node"))
+}
+
+func Test_ConfigContent_Iso_mapToApiValues(t *testing.T) {
+	testData := []struct {
+		input  ConfigContent_Iso
+		output map[string]interface{}
+	}{
+		{
+			input: ConfigContent_Iso{
+				Checksum:          "xxx",
+				ChecksumAlgorithm: "sha512",
+				DownloadUrl:       "https://eample.com/distro.iso",
+				Filename:          "distro.iso",
+				Storage:           "local",
+			},
+			output: map[string]interface{}{
+				"checksum-algorithm": "sha512",
+				"checksum":           "xxx",
+				"content":            "iso",
+				"filename":           "distro.iso",
+				"storage":            "local",
+				"url":                "https://eample.com/distro.iso",
+			},
+		},
+	}
+	for _, e := range testData {
+		require.Equal(t, e.output, e.input.mapToApiValues())
+	}
+}
+
+func Test_ConfigContent_Iso_Validate(t *testing.T) {
+	testData := []struct {
+		input  ConfigContent_Iso
+		output error
+	}{
+		{
+			input:  ConfigContent_Iso{},
+			output: ConfigContent_Iso{}.error("Node"),
+		},
+		{
+			input:  ConfigContent_Iso{Node: "notEmpty"},
+			output: ConfigContent_Iso{}.error("Storage"),
+		},
+		{
+			input: ConfigContent_Iso{
+				Node:    "notEmpty",
+				Storage: "notEmpty",
+			},
+			output: ConfigContent_Iso{}.error("URL"),
+		},
+		{
+			input: ConfigContent_Iso{
+				Node:        "notEmpty",
+				Storage:     "notEmpty",
+				DownloadUrl: "notEmpty",
+			},
+			output: ConfigContent_Iso{}.error("Filename"),
+		},
+		{
+			input: ConfigContent_Iso{
+				Node:        "notEmpty",
+				Storage:     "notEmpty",
+				DownloadUrl: "notEmpty",
+				Filename:    "notEmpty",
+			},
+			output: nil,
+		},
+	}
+	for _, e := range testData {
+		require.Equal(t, e.output, e.input.Validate())
+	}
+}


### PR DESCRIPTION
Inspired by Pull #224 I added functionality to download ISO files.
Proxmox API documentation: https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/storage/{storage}/download-url

A CLI command and integration tests were also added.
Tested successfully on a PVE 7.3

This will help to fix https://github.com/hashicorp/packer-plugin-proxmox/issues/79