### PR TITLE
Small Refactoring

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -1694,7 +1694,7 @@ func (c *Client) UpdateAcmePlugin(id string, params map[string]interface{}) erro
 	return c.Put(params, "/cluster/acme/plugins/"+id)
 }
 
-func (c *Client) CheckAcmePluginExistance(id string) (existance bool, err error) {
+func (c *Client) CheckAcmePluginExistence(id string) (existance bool, err error) {
 	list, err := c.GetAcmePluginList()
 	existance = ItemInKeyOfArray(list["data"].([]interface{}), "plugin", id)
 	return
@@ -1721,7 +1721,7 @@ func (c *Client) UpdateMetricServer(id string, params map[string]interface{}) er
 	return c.Put(params, "/cluster/metrics/server/"+id)
 }
 
-func (c *Client) CheckMetricServerExistance(id string) (existance bool, err error) {
+func (c *Client) CheckMetricServerExistence(id string) (existance bool, err error) {
 	list, err := c.GetMetricsServerList()
 	existance = ItemInKeyOfArray(list["data"].([]interface{}), "id", id)
 	return

--- a/proxmox/config_acme_account.go
+++ b/proxmox/config_acme_account.go
@@ -16,9 +16,9 @@ type ConfigAcmeAccount struct {
 	Tos       bool     `json:"tos,omitempty"`
 }
 
-func (config ConfigAcmeAccount) CreateAcmeAccount(acmeid string, client *Client) (err error) {
+func (config ConfigAcmeAccount) CreateAcmeAccount(acmeId string, client *Client) (err error) {
 	params := map[string]interface{}{
-		"name":    acmeid,
+		"name":    acmeId,
 		"contact": ArrayToCSV(config.Contact),
 	}
 	if !config.Tos {

--- a/proxmox/config_acme_plugin.go
+++ b/proxmox/config_acme_plugin.go
@@ -28,15 +28,15 @@ func (config ConfigAcmePlugin) mapToApiValues() (params map[string]interface{}) 
 	return
 }
 
-func (config ConfigAcmePlugin) SetAcmePlugin(pluginid string, client *Client) (err error) {
+func (config ConfigAcmePlugin) SetAcmePlugin(pluginId string, client *Client) (err error) {
 	err = ValidateIntInRange(0, 172800, config.ValidationDelay, "validation-delay")
 	if err != nil {
 		return
 	}
 
-	config.ID = pluginid
+	config.ID = pluginId
 
-	pluginExists, err := client.CheckAcmePluginExistance(pluginid)
+	pluginExists, err := client.CheckAcmePluginExistance(pluginId)
 	if err != nil {
 		return
 	}

--- a/proxmox/config_acme_plugin.go
+++ b/proxmox/config_acme_plugin.go
@@ -17,7 +17,7 @@ type ConfigAcmePlugin struct {
 	ValidationDelay int      `json:"validation-delay"`
 }
 
-func (config ConfigAcmePlugin) MapAcmePluginValues() (params map[string]interface{}) {
+func (config ConfigAcmePlugin) mapToApiValues() (params map[string]interface{}) {
 	params = map[string]interface{}{
 		"api":              config.API,
 		"data":             base64.StdEncoding.EncodeToString([]byte(config.Data)),
@@ -50,7 +50,7 @@ func (config ConfigAcmePlugin) SetAcmePlugin(pluginid string, client *Client) (e
 }
 
 func (config ConfigAcmePlugin) CreateAcmePlugin(client *Client) (err error) {
-	params := config.MapAcmePluginValues()
+	params := config.mapToApiValues()
 	params["id"] = config.ID
 	params["type"] = "dns"
 	err = client.CreateAcmePlugin(params)
@@ -62,7 +62,7 @@ func (config ConfigAcmePlugin) CreateAcmePlugin(client *Client) (err error) {
 }
 
 func (config ConfigAcmePlugin) UpdateAcmePlugin(client *Client) (err error) {
-	params := config.MapAcmePluginValues()
+	params := config.mapToApiValues()
 	err = client.UpdateAcmePlugin(config.ID, params)
 	if err != nil {
 		params, _ := json.Marshal(&params)

--- a/proxmox/config_acme_plugin.go
+++ b/proxmox/config_acme_plugin.go
@@ -36,7 +36,7 @@ func (config ConfigAcmePlugin) SetAcmePlugin(pluginId string, client *Client) (e
 
 	config.ID = pluginId
 
-	pluginExists, err := client.CheckAcmePluginExistance(pluginId)
+	pluginExists, err := client.CheckAcmePluginExistence(pluginId)
 	if err != nil {
 		return
 	}

--- a/proxmox/config_lxc.go
+++ b/proxmox/config_lxc.go
@@ -333,7 +333,7 @@ func NewConfigLxcFromApi(vmr *VmRef, client *Client) (config *ConfigLxc, err err
 // create LXC container using the Proxmox API
 func (config ConfigLxc) CreateLxc(vmr *VmRef, client *Client) (err error) {
 	vmr.SetVmType("lxc")
-	paramMap := config.mapToAPIParams()
+	paramMap := config.mapToApiValues()
 
 	// amend vmid
 	paramMap["vmid"] = vmr.vmId
@@ -403,7 +403,7 @@ func (config ConfigLxc) CloneLxc(vmr *VmRef, client *Client) (err error) {
 }
 
 func (config ConfigLxc) UpdateConfig(vmr *VmRef, client *Client) (err error) {
-	paramMap := config.mapToAPIParams()
+	paramMap := config.mapToApiValues()
 
 	// delete parameters which are not supported in updated operations
 	delete(paramMap, "pool")
@@ -448,7 +448,7 @@ func ParseLxcDisk(diskStr string) QemuDevice {
 	return disk
 }
 
-func (config ConfigLxc) mapToAPIParams() map[string]interface{} {
+func (config ConfigLxc) mapToApiValues() map[string]interface{} {
 	// convert config to map
 	params, _ := json.Marshal(&config)
 	var paramMap map[string]interface{}

--- a/proxmox/config_metrics.go
+++ b/proxmox/config_metrics.go
@@ -113,15 +113,15 @@ func (config *ConfigMetrics) ValidateMetrics() (err error) {
 	return
 }
 
-func (config *ConfigMetrics) SetMetrics(metricsid string, client *Client) (err error) {
+func (config *ConfigMetrics) SetMetrics(metricsId string, client *Client) (err error) {
 	err = config.ValidateMetrics()
 	if err != nil {
 		return
 	}
 
-	config.Name = metricsid
+	config.Name = metricsId
 
-	metricsExists, err := client.CheckMetricServerExistance(metricsid)
+	metricsExists, err := client.CheckMetricServerExistence(metricsId)
 	if err != nil {
 		return err
 	}
@@ -177,16 +177,16 @@ func InstantiateConfigMetrics() *ConfigMetrics {
 	}
 }
 
-func NewConfigMetricsFromApi(metricsid string, client *Client) (config *ConfigMetrics, err error) {
+func NewConfigMetricsFromApi(metricsId string, client *Client) (config *ConfigMetrics, err error) {
 	// prepare json map to receive the information from the api
 	var rawConfig map[string]interface{}
-	rawConfig, err = client.GetMetricServerConfig(metricsid)
+	rawConfig, err = client.GetMetricServerConfig(metricsId)
 	if err != nil {
 		return nil, err
 	}
 	config = InstantiateConfigMetrics()
 
-	config.Name = metricsid
+	config.Name = metricsId
 	config.Port = int(rawConfig["port"].(float64))
 	config.Server = rawConfig["server"].(string)
 	config.Type = rawConfig["type"].(string)

--- a/proxmox/config_metrics.go
+++ b/proxmox/config_metrics.go
@@ -17,24 +17,24 @@ type ConfigMetricsInfluxDB struct {
 	Protocol          string `json:"protocol"`
 	MaxBodySize       int    `json:"max-body-size,omitempty"`
 	Organization      string `json:"organization,omitempty"`
-	Token             string `json:"token,omitempty"`//token key is never returned from api
+	Token             string `json:"token,omitempty"` //token key is never returned from api
 	VerifyCertificate bool   `json:"verify-certificate"`
 }
 
 // Metrics options for the Proxmox API
 type ConfigMetrics struct {
-	Name    string `json:"name"`
-	Port    int    `json:"port"`
-	Server  string `json:"server"`
-	Type    string `json:"type"`//type key is only used on create
-	Enable  bool   `json:"enable"`
-	MTU     int    `json:"mtu"`
-	Timeout int    `json:"timeout,omitempty"`
+	Name     string                 `json:"name"`
+	Port     int                    `json:"port"`
+	Server   string                 `json:"server"`
+	Type     string                 `json:"type"` //type key is only used on create
+	Enable   bool                   `json:"enable"`
+	MTU      int                    `json:"mtu"`
+	Timeout  int                    `json:"timeout,omitempty"`
 	Graphite *ConfigMetricsGraphite `json:"graphite,omitempty"`
 	InfluxDB *ConfigMetricsInfluxDB `json:"influxdb,omitempty"`
 }
 
-func (config *ConfigMetrics) MapMetricsToApiValues(create bool) (params map[string]interface{}) {
+func (config *ConfigMetrics) mapToApiValues(create bool) (params map[string]interface{}) {
 	var deletions string
 	params = map[string]interface{}{
 		"port":    config.Port,
@@ -46,11 +46,11 @@ func (config *ConfigMetrics) MapMetricsToApiValues(create bool) (params map[stri
 	if create {
 		params["type"] = config.Type
 	}
-	if config.Graphite != nil{
+	if config.Graphite != nil {
 		params["path"] = config.Graphite.Path
 		params["proto"] = config.Graphite.Protocol
 	}
-	if config.InfluxDB != nil{
+	if config.InfluxDB != nil {
 		if config.InfluxDB.ApiPathPrefix != "" {
 			params["api-path-prefix"] = config.InfluxDB.ApiPathPrefix
 		} else {
@@ -73,7 +73,7 @@ func (config *ConfigMetrics) MapMetricsToApiValues(create bool) (params map[stri
 }
 
 func (config *ConfigMetrics) RemoveMetricsNestedStructs() {
-	if config.Type != "graphite"{
+	if config.Type != "graphite" {
 		config.Graphite = nil
 	} else {
 		config.InfluxDB = nil
@@ -82,31 +82,31 @@ func (config *ConfigMetrics) RemoveMetricsNestedStructs() {
 
 func (config *ConfigMetrics) ValidateMetrics() (err error) {
 	err = ValidateStringInArray([]string{"graphite", "influxdb"}, config.Type, "type")
-	if err != nil{
+	if err != nil {
 		return
 	}
 	err = ValidateStringNotEmpty(config.Server, "server")
-	if err != nil{
+	if err != nil {
 		return
-	}	
+	}
 	err = ValidateStringInArray([]string{"udp", "tcp"}, config.Graphite.Protocol, "graphite:{ protocol }")
-	if err != nil{
+	if err != nil {
 		return
 	}
 	err = ValidateStringInArray([]string{"udp", "http", "https"}, config.InfluxDB.Protocol, "influxdb:{ protocol }")
-	if err != nil{
+	if err != nil {
 		return
 	}
 	err = ValidateIntInRange(1, 65536, config.Port, "port")
-	if err != nil{
+	if err != nil {
 		return
 	}
 	err = ValidateIntGreaterOrEquals(1, config.InfluxDB.MaxBodySize, "influxdb:{ max-body-size }")
-	if err != nil{
+	if err != nil {
 		return
 	}
 	err = ValidateIntInRange(512, 65536, config.MTU, "mtu")
-	if err != nil{
+	if err != nil {
 		return
 	}
 	err = ValidateIntGreaterOrEquals(0, config.Timeout, "timeout")
@@ -115,7 +115,7 @@ func (config *ConfigMetrics) ValidateMetrics() (err error) {
 
 func (config *ConfigMetrics) SetMetrics(metricsid string, client *Client) (err error) {
 	err = config.ValidateMetrics()
-	if err != nil{
+	if err != nil {
 		return
 	}
 
@@ -136,7 +136,7 @@ func (config *ConfigMetrics) SetMetrics(metricsid string, client *Client) (err e
 
 func (config *ConfigMetrics) CreateMetrics(client *Client) (err error) {
 	config.RemoveMetricsNestedStructs()
-	params := config.MapMetricsToApiValues(true)
+	params := config.mapToApiValues(true)
 	err = client.CreateMetricServer(config.Name, params)
 	if err != nil {
 		params, _ := json.Marshal(&params)
@@ -147,7 +147,7 @@ func (config *ConfigMetrics) CreateMetrics(client *Client) (err error) {
 
 func (config *ConfigMetrics) UpdateMetrics(client *Client) (err error) {
 	config.RemoveMetricsNestedStructs()
-	params := config.MapMetricsToApiValues(false)
+	params := config.mapToApiValues(false)
 	err = client.UpdateMetricServer(config.Name, params)
 	if err != nil {
 		params, _ := json.Marshal(&params)
@@ -158,14 +158,14 @@ func (config *ConfigMetrics) UpdateMetrics(client *Client) (err error) {
 
 func InstantiateConfigMetrics() *ConfigMetrics {
 	graphite := ConfigMetricsGraphite{
-		Path: "proxmox",
+		Path:     "proxmox",
 		Protocol: "udp",
 	}
 	influxdb := ConfigMetricsInfluxDB{
-		Bucket: "proxmox",
-		MaxBodySize: 25000000,
-		Organization: "proxmox",
-		Protocol: "udp",
+		Bucket:            "proxmox",
+		MaxBodySize:       25000000,
+		Organization:      "proxmox",
+		Protocol:          "udp",
 		VerifyCertificate: true,
 	}
 	return &ConfigMetrics{
@@ -191,24 +191,48 @@ func NewConfigMetricsFromApi(metricsid string, client *Client) (config *ConfigMe
 	config.Server = rawConfig["server"].(string)
 	config.Type = rawConfig["type"].(string)
 
-	if _, isSet := rawConfig["disable"]; isSet {config.Enable = BoolInvert(Itob(int(rawConfig["disable"].(float64))))}
-	if _, isSet := rawConfig["mtu"]; isSet {config.MTU = int(rawConfig["mtu"].(float64))}
-	if _, isSet := rawConfig["timeout"]; isSet {config.Timeout = int(rawConfig["timeout"].(float64))}
+	if _, isSet := rawConfig["disable"]; isSet {
+		config.Enable = BoolInvert(Itob(int(rawConfig["disable"].(float64))))
+	}
+	if _, isSet := rawConfig["mtu"]; isSet {
+		config.MTU = int(rawConfig["mtu"].(float64))
+	}
+	if _, isSet := rawConfig["timeout"]; isSet {
+		config.Timeout = int(rawConfig["timeout"].(float64))
+	}
 
 	config.RemoveMetricsNestedStructs()
 
-	if config.Graphite != nil{
-		if _, isSet := rawConfig["path"]; isSet {config.Graphite.Path = rawConfig["path"].(string)}
-		if _, isSet := rawConfig["proto"]; isSet {config.Graphite.Protocol = rawConfig["proto"].(string)}
-	} 
-	if config.InfluxDB != nil{
-		if _, isSet := rawConfig["api-path-prefix"]; isSet {config.InfluxDB.ApiPathPrefix = rawConfig["api-path-prefix"].(string)}
-		if _, isSet := rawConfig["bucket"]; isSet {config.InfluxDB.Bucket = rawConfig["bucket"].(string)}
-		if _, isSet := rawConfig["influxdbproto"]; isSet {config.InfluxDB.Protocol = rawConfig["influxdbproto"].(string)}
-		if _, isSet := rawConfig["max-body-size"]; isSet {config.InfluxDB.MaxBodySize = int(rawConfig["max-body-size"].(float64))}
-		if _, isSet := rawConfig["organization"]; isSet {config.InfluxDB.Organization = rawConfig["organization"].(string)}
-		if _, isSet := rawConfig["token"]; isSet {config.InfluxDB.Token = rawConfig["token"].(string)}
-		if _, isSet := rawConfig["verify-certificate"]; isSet {config.InfluxDB.VerifyCertificate = Itob(int(rawConfig["verify-certificate"].(float64)))}
+	if config.Graphite != nil {
+		if _, isSet := rawConfig["path"]; isSet {
+			config.Graphite.Path = rawConfig["path"].(string)
+		}
+		if _, isSet := rawConfig["proto"]; isSet {
+			config.Graphite.Protocol = rawConfig["proto"].(string)
+		}
+	}
+	if config.InfluxDB != nil {
+		if _, isSet := rawConfig["api-path-prefix"]; isSet {
+			config.InfluxDB.ApiPathPrefix = rawConfig["api-path-prefix"].(string)
+		}
+		if _, isSet := rawConfig["bucket"]; isSet {
+			config.InfluxDB.Bucket = rawConfig["bucket"].(string)
+		}
+		if _, isSet := rawConfig["influxdbproto"]; isSet {
+			config.InfluxDB.Protocol = rawConfig["influxdbproto"].(string)
+		}
+		if _, isSet := rawConfig["max-body-size"]; isSet {
+			config.InfluxDB.MaxBodySize = int(rawConfig["max-body-size"].(float64))
+		}
+		if _, isSet := rawConfig["organization"]; isSet {
+			config.InfluxDB.Organization = rawConfig["organization"].(string)
+		}
+		if _, isSet := rawConfig["token"]; isSet {
+			config.InfluxDB.Token = rawConfig["token"].(string)
+		}
+		if _, isSet := rawConfig["verify-certificate"]; isSet {
+			config.InfluxDB.VerifyCertificate = Itob(int(rawConfig["verify-certificate"].(float64)))
+		}
 	}
 	return
 }

--- a/proxmox/config_network.go
+++ b/proxmox/config_network.go
@@ -37,7 +37,7 @@ type ConfigNetwork struct {
 	VlanRawDevice      string `json:"vlan-raw-device,omitempty"`
 }
 
-// NewConfigNetworkFromJSON takes in a byte array from a json encoded network 
+// NewConfigNetworkFromJSON takes in a byte array from a json encoded network
 // configuration and stores it in config.
 // It returns the newly created config with the passed in configuration stored
 // and an error if one occurs unmarshalling the input data.
@@ -47,9 +47,9 @@ func NewConfigNetworkFromJSON(input []byte) (config *ConfigNetwork, err error) {
 	return
 }
 
-// MapToAPIParams converts the stored config into a parameter map to be
+// mapToApiValues converts the stored config into a parameter map to be
 // sent to the API.
-func (config ConfigNetwork) MapToAPIParams() map[string]interface{} {
+func (config ConfigNetwork) mapToApiValues() map[string]interface{} {
 	params, _ := json.Marshal(&config)
 	var paramMap map[string]interface{}
 	json.Unmarshal(params, &paramMap)
@@ -60,7 +60,7 @@ func (config ConfigNetwork) MapToAPIParams() map[string]interface{} {
 // config.
 // It returns an error if the creation of the network fails.
 func (config ConfigNetwork) CreateNetwork(client *Client) (err error) {
-	paramMap := config.MapToAPIParams()
+	paramMap := config.mapToApiValues()
 
 	exitStatus, err := client.CreateNetwork(config.Node, paramMap)
 	if err != nil {
@@ -70,12 +70,11 @@ func (config ConfigNetwork) CreateNetwork(client *Client) (err error) {
 	return
 }
 
-
 // UpdateNetwork updates a network on the Proxmox host with the stored
 // config.
 // It returns an error if updating the network fails.
 func (config ConfigNetwork) UpdateNetwork(client *Client) (err error) {
-	paramMap := config.MapToAPIParams()
+	paramMap := config.mapToApiValues()
 
 	exitStatus, err := client.UpdateNetwork(config.Node, config.Iface, paramMap)
 	if err != nil {

--- a/proxmox/config_storage.go
+++ b/proxmox/config_storage.go
@@ -746,7 +746,7 @@ func (newConfig *ConfigStorage) Validate(id string, create bool, client *Client)
 	return newConfig.BackupRetention.Validate()
 }
 
-func (config *ConfigStorage) MapToApiValues(create bool) (params map[string]interface{}) {
+func (config *ConfigStorage) mapToApiValues(create bool) (params map[string]interface{}) {
 	var deletions string
 	params = map[string]interface{}{
 		"storage": config.ID,
@@ -954,7 +954,7 @@ func (config *ConfigStorage) Create(id string, errorSupression bool, client *Cli
 		enableStorage = true
 	}
 	config.ID = id
-	params := config.MapToApiValues(true)
+	params := config.mapToApiValues(true)
 	err = client.CreateStorage(params)
 	if err != nil {
 		params, _ := json.Marshal(&params)
@@ -977,7 +977,7 @@ func (config *ConfigStorage) UpdateWithValidate(id string, client *Client) (err 
 
 func (config *ConfigStorage) Update(id string, client *Client) (err error) {
 	config.ID = id
-	params := config.MapToApiValues(false)
+	params := config.mapToApiValues(false)
 	err = client.UpdateStorage(id, params)
 	if err != nil {
 		params, _ := json.Marshal(&params)

--- a/proxmox/config_storage.go
+++ b/proxmox/config_storage.go
@@ -9,8 +9,8 @@ import (
 )
 
 // matrix of storage types and which content types they support.
-var strorageContentTypesAPI = []string{"backup", "rootdir", "images", "iso", "snippets", "vztmpl"}
-var strorageContentTypesStruct = []string{"backup", "container", "diskimage", "iso", "snippets", "template"}
+var storageContentTypesAPI = []string{"backup", "rootdir", "images", "iso", "snippets", "vztmpl"}
+var storageContentTypesStruct = []string{"backup", "container", "diskimage", "iso", "snippets", "template"}
 var storageContentTypes = map[string]interface{}{
 	"directory":      []bool{true, true, true, true, true, true},
 	"lvm":            []bool{false, true, true, false, false, false},
@@ -40,7 +40,7 @@ func (c *ConfigStorageContent) MapStorageContent(array []bool) (list string) {
 		for i, e := range []interface{}{c.Backup, c.Container, c.DiskImage, c.Iso, c.Snippets, c.Template} {
 			if e.(*bool) != nil {
 				if *e.(*bool) && array[i] {
-					list = AddToList(list, strorageContentTypesAPI[i])
+					list = AddToList(list, storageContentTypesAPI[i])
 				}
 			}
 		}
@@ -64,7 +64,7 @@ func (c *ConfigStorageContent) Validate(storageType string) error {
 	var list string
 	for i, e := range array {
 		if e {
-			list = AddToList(list, strorageContentTypesStruct[i])
+			list = AddToList(list, storageContentTypesStruct[i])
 		}
 	}
 	return fmt.Errorf("error at least one of the keys (content:{ %s }) must be true", list)
@@ -1152,22 +1152,22 @@ func NewConfigStorageFromApi(storageid string, client *Client) (config *ConfigSt
 			contentArray := CSVtoArray(content)
 			config.Content = new(ConfigStorageContent)
 			if storageContentTypes[config.Type].([]bool)[0] {
-				config.Content.Backup = PointerBool(inArray(contentArray, strorageContentTypesAPI[0]))
+				config.Content.Backup = PointerBool(inArray(contentArray, storageContentTypesAPI[0]))
 			}
 			if storageContentTypes[config.Type].([]bool)[1] {
-				config.Content.Container = PointerBool(inArray(contentArray, strorageContentTypesAPI[1]))
+				config.Content.Container = PointerBool(inArray(contentArray, storageContentTypesAPI[1]))
 			}
 			if storageContentTypes[config.Type].([]bool)[2] {
-				config.Content.DiskImage = PointerBool(inArray(contentArray, strorageContentTypesAPI[2]))
+				config.Content.DiskImage = PointerBool(inArray(contentArray, storageContentTypesAPI[2]))
 			}
 			if storageContentTypes[config.Type].([]bool)[3] {
-				config.Content.Iso = PointerBool(inArray(contentArray, strorageContentTypesAPI[3]))
+				config.Content.Iso = PointerBool(inArray(contentArray, storageContentTypesAPI[3]))
 			}
 			if storageContentTypes[config.Type].([]bool)[4] {
-				config.Content.Snippets = PointerBool(inArray(contentArray, strorageContentTypesAPI[4]))
+				config.Content.Snippets = PointerBool(inArray(contentArray, storageContentTypesAPI[4]))
 			}
 			if storageContentTypes[config.Type].([]bool)[5] {
-				config.Content.Template = PointerBool(inArray(contentArray, strorageContentTypesAPI[5]))
+				config.Content.Template = PointerBool(inArray(contentArray, storageContentTypesAPI[5]))
 			}
 		} else {
 			// Edge cases

--- a/proxmox/snapshot.go
+++ b/proxmox/snapshot.go
@@ -12,7 +12,7 @@ type ConfigSnapshot struct {
 	VmState     bool   `json:"ram,omitempty"`
 }
 
-func (config *ConfigSnapshot) mapValues() map[string]interface{} {
+func (config *ConfigSnapshot) mapToApiValues() map[string]interface{} {
 	return map[string]interface{}{
 		"snapname":    config.Name,
 		"description": config.Description,
@@ -21,7 +21,7 @@ func (config *ConfigSnapshot) mapValues() map[string]interface{} {
 }
 
 func (config *ConfigSnapshot) CreateSnapshot(c *Client, guestId uint) (err error) {
-	params := config.mapValues()
+	params := config.mapToApiValues()
 	vmr := NewVmRef(int(guestId))
 	_, err = c.GetVmInfo(vmr)
 	if err != nil {


### PR DESCRIPTION
Work done this pull.

- Changed the name of the functions responsible for mapping values to the Proxmox API to `mapToApiValues()`. This should make the code more readable and homogeneous.
- Made variable names Camel Case.
- Fixed typos.

The major change in `proxmox/config_metrics.go` is the linter changing the formatting.