### PR TITLE
set backup=0 on disk if backup==false

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -1175,8 +1175,17 @@ func FormatDiskParam(disk QemuDevice) string {
 		diskConfParam = append(diskConfParam, diskMountOpts)
 	}
 
+	// Backup
+	if backup, ok := disk["backup"].(bool); ok {
+		// Backups are enabled by default (backup=1)
+		// Only set the parameter if backups are explicitly disabled
+		if backup == false {
+			diskConfParam = append(diskConfParam, "backup=0")
+		}
+	}
+
 	// Keys that are not used as real/direct conf.
-	ignoredKeys := []string{"key", "slot", "type", "storage", "file", "size", "cache", "volume", "container", "vm", "mountoptions", "storage_type"}
+	ignoredKeys := []string{"backup", "key", "slot", "type", "storage", "file", "size", "cache", "volume", "container", "vm", "mountoptions", "storage_type"}
 
 	// Rest of config.
 	diskConfParam = diskConfParam.createDeviceParam(disk, ignoredKeys)

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -1179,7 +1179,7 @@ func FormatDiskParam(disk QemuDevice) string {
 	if backup, ok := disk["backup"].(bool); ok {
 		// Backups are enabled by default (backup=1)
 		// Only set the parameter if backups are explicitly disabled
-		if backup == false {
+		if !backup {
 			diskConfParam = append(diskConfParam, "backup=0")
 		}
 	}


### PR DESCRIPTION
At the moment, backup cannot be disabled with this API.

If proxmox backups have been configured, then the default behavior when `backup` is not set on a VM disk [is to back it up](https://pve.proxmox.com/wiki/Backup_and_Restore#vzdump_configuration):

>Proxmox VE backups are always full backups - containing the VM/CT configuration and all data.

Thus, setting `backup=1` is basically redundant, and `backup=0` is the actual useful option.

The way that `createDeviceParam` logic is currently applied, it only explicitly sets a parameter for a truthy boolean value. This means that there is no way to exclude a disk from backup, since setting the backup option to `false` won't cause the actual `backup=0` parameter to be set.

This PR adds the proper logic to allow disks to be excluded from backup. It *only* sets `backup=0` if `disk["backup"] == false`; it will never set `backup=1` on a VM.