### PR TITLE
Upload: Don't overwrite HTTP headers

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -1294,12 +1294,13 @@ func (c *Client) Upload(node string, storage string, contentType string, filenam
 	}
 
 	url := fmt.Sprintf("%s/nodes/%s/storage/%s/upload", c.session.ApiUrl, node, storage)
-	req, err := c.session.NewRequest(http.MethodPost, url, &c.session.Headers, body)
+	headers := c.session.Headers.Clone()
+	headers.Add("Content-Type", mimetype)
+	headers.Add("Accept", "application/json")
+	req, err := c.session.NewRequest(http.MethodPost, url, &headers, body)
 	if err != nil {
 		return err
 	}
-	req.Header.Add("Content-Type", mimetype)
-	req.Header.Add("Accept", "application/json")
 
 	if doStreamingIO {
 		req.ContentLength = contentLength


### PR DESCRIPTION
`Upload()` currently modifies `Client.session.Headers` diretly. If the same Client struct is used for another request after `Upload()` was called, the request will fail.

`packer-plugin-proxmox` frequently reuses the Client struct to upload an ISO and then create a VM. `CreateVm()` fails after uploading a file because of wrong headers:
```
==> proxmox-iso.alpine: Error creating VM: error creating VM: 506 upload 'Content-Type 'multipart/form-data; boundary=6501480e24c86c9304a4ed865c0ca6e803a0ca0ca8b3d34e166dcbed8cb8' not implemented, error status:  (params: map[agent:1 args: boot: cores:2 cpu:kvm64 description:Packer ephemeral build VM hotplug: ide2:local:iso/alpine-virt-3.17.1-x86_64.iso,media=cdrom kvm:true machine: memory:2048 name:alpine-upload-test net0:virtio=A6:77:6D:2C:8C:FE,bridge=vmbr0,firewall=false onboot:false ostype:l26 scsihw:virtio-scsi-single sockets:1 startup: tags: vmid:101])
```
Fix this by cloning `Client.session.Headers` instead of overwriting.

Fixes https://github.com/hashicorp/packer-plugin-proxmox/issues/146