### PR TITLE
Fix empty cloud init ipconfig

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -226,7 +226,7 @@ func (config ConfigQemu) CreateVm(vmr *VmRef, client *Client) (err error) {
 // HasCloudInit - are there cloud-init options?
 func (config ConfigQemu) HasCloudInit() bool {
 	for _, config := range config.Ipconfig {
-		if config != nil {
+		if config != nil && config != "" {
 			return true
 		}
 	}


### PR DESCRIPTION
For the life of me I cannot figure out what is happening... but empty (non-existent) `config.Ipconfig` entries are being unmarshaled as empty strings instead of `nil` which causes the insurmountable error below:

```
proxmox_vm_qemu.docker-test: Creating...
╷
│ Error: cloud-init parameters only supported on clones or updates
│
│   with proxmox_vm_qemu.docker-test,
│   on docker-test.tf line 1, in resource "proxmox_vm_qemu" "docker-test":
│    1: resource "proxmox_vm_qemu" "docker-test" {
│
╵
```

Below is the `docker-test` terraform config:
```
resource "proxmox_vm_qemu" "docker-test" {
  name        = "docker-test"
  target_node = "node1"
  boot        = "order=ide2;scsi0;net0"
  pxe         = true
  cores       = 4
  memory      = 8192
  network {
    bridge   = "vmbr0"
    firewall = true
    model    = "virtio"
    macaddr  = "<redacted>"
  }
  disk {
    type    = "scsi"
    storage = "local-lvm"
    size    = "8G"
  }
}
```

I have tried bisecting the issue and cannot pin down where it was introduced or why it is happening. But the included fix makes it work for me.

P.S. I was able to determine that, in my case, *none* of the Ipconfig entries were unmarshaled as anything except an empty string (no `nil`, and no actual definitions).