### PR TITLE
client/CreateQemuVM: only read body if existing

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -561,12 +561,18 @@ func (c *Client) CreateQemuVm(node string, vmParams map[string]interface{}) (exi
 	var resp *http.Response
 	resp, err = c.session.Post(url, nil, nil, &reqbody)
 	if err != nil {
-		defer resp.Body.Close()
-		// This might not work if we never got a body. We'll ignore errors in trying to read,
-		// but extract the body if possible to give any error information back in the exitStatus
-		b, _ := io.ReadAll(resp.Body)
-		exitStatus = string(b)
-		return exitStatus, err
+		// Only attempt to read the body if it is available.
+		if resp != nil && resp.Body != nil {
+			defer resp.Body.Close()
+			// This might not work if we never got a body. We'll ignore errors in trying to read,
+			// but extract the body if possible to give any error information back in the exitStatus
+			b, _ := io.ReadAll(resp.Body)
+			exitStatus = string(b)
+
+			return exitStatus, err
+		}
+
+		return "", err
 	}
 
 	taskResponse, err := ResponseJSON(resp)


### PR DESCRIPTION
Working on Packer, we noticed that on many occasions the plugin crashes because the call to `resp.Body.Close()` panics with a null pointer dereference.

Unsure if this is because the `resp` object is null, or if the `resp.Body` is, but to avoid this problem, we only read and defer closing the body when it is available.

See for example the following issues:

* https://github.com/hashicorp/packer-plugin-proxmox/issues/134
* https://github.com/hashicorp/packer-plugin-proxmox/issues/137
* https://github.com/hashicorp/packer-plugin-proxmox/issues/162

Please let me know if there's anything I can do to help test this, I don't have a Proxmox installation to test it on, and am mostly going with the stack traces provided in the aforementioned issues.