### PR TITLE
Fix GetTaskExitStatus success criteria

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -444,6 +444,7 @@ func (c *Client) WaitForCompletion(taskResponse map[string]interface{}) (waitExi
 }
 
 var rxTaskNode = regexp.MustCompile("UPID:(.*?):")
+var rxExitStatusSuccess = regexp.MustCompile(`^(OK|WARNINGS)`)
 
 func (c *Client) GetTaskExitstatus(taskUpid string) (exitStatus interface{}, err error) {
 	node := rxTaskNode.FindStringSubmatch(taskUpid)[1]
@@ -453,7 +454,7 @@ func (c *Client) GetTaskExitstatus(taskUpid string) (exitStatus interface{}, err
 	if err == nil {
 		exitStatus = data["data"].(map[string]interface{})["exitstatus"]
 	}
-	if exitStatus != nil && exitStatus != exitStatusSuccess {
+	if exitStatus != nil && rxExitStatusSuccess.FindString(exitStatus.(string)) == "" {
 		err = fmt.Errorf(exitStatus.(string))
 	}
 	return


### PR DESCRIPTION
GetTaskExitStatus considers any exitstatus other than "OK" as an error. But the Proxmox API can return "WARNINGS: XXX" in the some cases.  This should be considered a success as well.

This bug causes the Terraform provider to try to start the VM three times, and then to return an error because all attempts apparently "fail" (but the VM is actually correctly started).

Example output when starting a VM:

    POST /api2/json/nodes/dahu-2/qemu/100/status/start
    GET /api2/json/nodes/dahu-2/tasks/UPID:dahu-2:00007323:001036A5:6419CAF8:qmstart:100:root@pam:/status
    {"data":{"id":"100","pid":29475,"status":"stopped","type":"qmstart","pstart":1062565,"exitstatus":"WARNINGS: 1","upid":"UPID:dahu-2:00007323:001036A5:6419CAF8:qmstart:100:root@pam:","starttime":1679411960,"user":"root@pam","node":"dahu-2"}}

The exit status is "WARNINGS: 1", not "OK", but the operation still worked.

The corresponding warning in the web interface is:

    WARN: no efidisk configured! Using temporary efivars disk.
    TASK WARNINGS: 1