### PR TITLE
Support smbios1 VM configuration

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -73,6 +73,7 @@ type ConfigQemu struct {
 	HaState         string      `json:"hastate,omitempty"`
 	HaGroup         string      `json:"hagroup,omitempty"`
 	Tags            string      `json:"tags,omitempty"`
+	Smbios1         string      `json:"smbios1,omitempty"`
 	Args            string      `json:"args,omitempty"`
 
 	// cloud-init options
@@ -697,6 +698,9 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 	}
 	if _, isSet := vmConfig["sshkeys"]; isSet {
 		config.Sshkeys, _ = url.PathUnescape(vmConfig["sshkeys"].(string))
+	}
+	if _, isSet := vmConfig["smbios1"]; isSet {
+		config.Smbios1 = vmConfig["smbios1"].(string)
 	}
 
 	ipconfigNames := []string{}


### PR DESCRIPTION
This PR adds support for smbios VM configuration settings. It's handy when to inject stuff into VM. One example could be override cloud-init NoCloud configuration. Read more about the API here https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/qemu/{vmid}/config 