### PR TITLE
fix: disk id enumeration overwrite

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -722,7 +722,7 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 
 	// Add disks.
 	diskNames := []string{}
-	diskTypes := []string{"ide", "scsi", "virtio", "sata"}
+	diskTypes := []string{"scsi", "virtio", "sata", "ide"}
 
 	// Search for disks in a predictable order
 	for _, t := range diskTypes {


### PR DESCRIPTION
this fixes a regression where disk ids get overwritten when you for example have a `ide0` and `scsi0` disk device. 