### PR TITLE
Fix POST /nodes/{node}/lxc/{id}/template (#260)

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -380,7 +380,9 @@ func (c *Client) CreateTemplate(vmr *VmRef) error {
 		return err
 	}
 
-	if exitStatus != "OK" {
+	// Specifically ignore empty exit status for LXCs, since they don't return a task ID
+	// when creating templates in the first place (but still successfully create them).
+	if exitStatus != "OK" && vmr.vmType != "lxc" {
 		return errors.New("Can't convert Vm to template:" + exitStatus)
 	}
 

--- a/test/api/Lxc/lxc_create_update_delete_test.go
+++ b/test/api/Lxc/lxc_create_update_delete_test.go
@@ -54,3 +54,16 @@ func Test_Remove_Lxc_Container(t *testing.T) {
 
 	require.NoError(t, err)
 }
+
+func Test_Create_Template_Lxc_Container(t *testing.T) {
+	Test := api_test.Test{}
+	_ = Test.CreateTest()
+	config := _create_lxc_spec(true)
+
+	vmRef := _create_vmref()
+	err := config.CreateLxc(vmRef, Test.GetClient())
+	require.NoError(t, err)
+
+	err = Test.GetClient().CreateTemplate(vmRef)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Fixes #260 by ignoring empty exit statuses in CreateTemplate if the vmType == "lxc". 

This should be safe to ignore given that the API specifically returns null in the success case: https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/lxc/{vmid}/template

See issue for example request/response.