### PR TITLE
refactor: snapshot formatting

### DIFF
--- a/cli/command/list/list-snapshots.go
+++ b/cli/command/list/list-snapshots.go
@@ -16,7 +16,7 @@ var (
 		Args:             cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			id := cli.ValidateExistingGuestID(args, 0)
-			jBody, err := proxmox.ListSnapshots(cli.NewClient(), proxmox.NewVmRef(id))
+			rawSnapshots, err := proxmox.ListSnapshots(cli.NewClient(), proxmox.NewVmRef(id))
 			if err != nil {
 				noTree = false
 				return
@@ -24,9 +24,9 @@ var (
 			var list []*proxmox.Snapshot
 			if noTree {
 				noTree = false
-				list = proxmox.FormatSnapshotsList(jBody)
+				list = rawSnapshots.FormatSnapshotsList()
 			} else {
-				list = proxmox.FormatSnapshotsTree(jBody)
+				list = rawSnapshots.FormatSnapshotsTree()
 			}
 			if len(list) == 0 {
 				listCmd.Printf("Guest with ID (%d) has no snapshots", id)

--- a/proxmox/snapshot_test.go
+++ b/proxmox/snapshot_test.go
@@ -12,7 +12,7 @@ func Test_FormatSnapshotsTree(t *testing.T) {
 	input := test_FormatSnapshots_Input()
 	output := test_FormatSnapshotsTree_Output()
 	for i, e := range input {
-		result, _ := json.Marshal(FormatSnapshotsTree(e))
+		result, _ := json.Marshal(e.FormatSnapshotsTree())
 		require.JSONEq(t, output[i], string(result))
 	}
 }
@@ -22,13 +22,13 @@ func Test_FormatSnapshotsList(t *testing.T) {
 	input := test_FormatSnapshots_Input()
 	output := test_FormatSnapshotsList_Output()
 	for i, e := range input {
-		result, _ := json.Marshal(FormatSnapshotsList(e))
+		result, _ := json.Marshal(e.FormatSnapshotsList())
 		require.JSONEq(t, output[i], string(result))
 	}
 }
 
-func test_FormatSnapshots_Input() [][]interface{} {
-	return [][]interface{}{{map[string]interface{}{
+func test_FormatSnapshots_Input() []rawSnapshots {
+	return []rawSnapshots{{map[string]interface{}{
 		"name":        "aa",
 		"snaptime":    float64(1666361849),
 		"description": "",


### PR DESCRIPTION
Introduced the private type `rawSnapshots` to make it easier for a user to figure out what to do with the output of `ListSnapshots()`. As before you needed to know that the output of the `ListSnapshots()` function was an intermediary step for `FormatSnapshotsList()` and `FormatSnapshotsTree()`. Due to this change the user would be able to figure it out with their IDE's auto-completion.


