### PR TITLE
Phase out: GetVmList()

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -188,11 +188,7 @@ func (c *Client) GetVmInfo(vmr *VmRef) (vmInfo map[string]interface{}, err error
 	if resp, err = c.GetVmList(); err != nil {
 		return
 	}
-	vms, ok := resp["data"].([]interface{})
-	if !ok {
-		err = fmt.Errorf("failed to cast response to list, resp: %v", resp)
-		return
-	}
+	vms := resp["data"].([]interface{})
 	for vmii := range vms {
 		vm := vms[vmii].(map[string]interface{})
 		if int(vm["vmid"].(float64)) == vmr.vmId {
@@ -1957,7 +1953,11 @@ func (c *Client) GetItemListInterfaceArray(url string) ([]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
-	return list["data"].([]interface{}), nil
+	data, ok := list["data"].([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("failed to cast response to list, resp: %v", list)
+	}
+	return data, nil
 }
 
 func (c *Client) GetItemList(url string) (list map[string]interface{}, err error) {

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -184,11 +184,10 @@ func (c *Client) CheckVmRef(vmr *VmRef) (err error) {
 }
 
 func (c *Client) GetVmInfo(vmr *VmRef) (vmInfo map[string]interface{}, err error) {
-	var resp map[string]interface{}
-	if resp, err = c.GetVmList(); err != nil {
+	vms, err := c.GetResourceList(resourceListGuest)
+	if err != nil {
 		return
 	}
-	vms := resp["data"].([]interface{})
 	for vmii := range vms {
 		vm := vms[vmii].(map[string]interface{})
 		if int(vm["vmid"].(float64)) == vmr.vmId {
@@ -218,11 +217,10 @@ func (c *Client) GetVmRefByName(vmName string) (vmr *VmRef, err error) {
 }
 
 func (c *Client) GetVmRefsByName(vmName string) (vmrs []*VmRef, err error) {
-	resp, err := c.GetVmList()
+	vms, err := c.GetResourceList(resourceListGuest)
 	if err != nil {
 		return
 	}
-	vms := resp["data"].([]interface{})
 	for vmii := range vms {
 		vm := vms[vmii].(map[string]interface{})
 		if vm["name"] != nil && vm["name"].(string) == vmName {
@@ -871,11 +869,10 @@ func (c *Client) GetNextID(currentID int) (nextID int, err error) {
 
 // VMIdExists - If you pass an VMID that exists it will return true, otherwise it wil return false
 func (c *Client) VMIdExists(vmID int) (exists bool, err error) {
-	resp, err := c.GetVmList()
+	vms, err := c.GetResourceList(resourceListGuest)
 	if err != nil {
 		return
 	}
-	vms := resp["data"].([]interface{})
 	for vmii := range vms {
 		vm := vms[vmii].(map[string]interface{})
 		if vmID == int(vm["vmid"].(float64)) {

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -170,7 +170,7 @@ func (c *Client) GetResourceList(resourceType string) (list []interface{}, err e
 	return c.GetItemListInterfaceArray(url)
 }
 
-// TODO deprecate once nothing uses this anymore, use GetResourceList() instead
+// TODO deprecate once nothing uses this anymore, use ListGuests() instead
 func (c *Client) GetVmList() (map[string]interface{}, error) {
 	list, err := c.GetResourceList(resourceListGuest)
 	return map[string]interface{}{"data": list}, err

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -1289,8 +1289,7 @@ func RemoveSshForwardUsernet(vmr *VmRef, client *Client) (err error) {
 }
 
 func MaxVmId(client *Client) (max int, err error) {
-	resp, err := client.GetVmList()
-	vms := resp["data"].([]interface{})
+	vms, err := client.GetResourceList(resourceListGuest)
 	max = 100
 	for vmii := range vms {
 		vm := vms[vmii].(map[string]interface{})


### PR DESCRIPTION
Started phasing out `GetVmList()`

- `GetVmList()` is replaced with `GetResourceList(resourceListGuest)` in all but one instance (its only used in the old cli).
- Added error checking when extracting the array to `GetItemListInterfaceArray()`.
- Minor code optimization due to using `GetResourceList(resourceListGuest)`.