### PR TITLE
Refactor: Snapshots

### DIFF
--- a/cli/command/create/create-snapshot.go
+++ b/cli/command/create/create-snapshot.go
@@ -23,7 +23,13 @@ var (
 				VmState:     memory,
 			}
 			memory = false
-			err = config.CreateSnapshot(cli.NewClient(), uint(id))
+			client := cli.NewClient()
+			vmr := proxmox.NewVmRef(id)
+			_, err = client.GetVmInfo(vmr)
+			if err != nil {
+				return
+			}
+			err = config.CreateSnapshot(client, vmr)
 			if err != nil {
 				return
 			}

--- a/proxmox/snapshot.go
+++ b/proxmox/snapshot.go
@@ -12,7 +12,7 @@ type ConfigSnapshot struct {
 	VmState     bool   `json:"ram,omitempty"`
 }
 
-func (config *ConfigSnapshot) mapToApiValues() map[string]interface{} {
+func (config ConfigSnapshot) mapToApiValues() map[string]interface{} {
 	return map[string]interface{}{
 		"snapname":    config.Name,
 		"description": config.Description,
@@ -20,7 +20,7 @@ func (config *ConfigSnapshot) mapToApiValues() map[string]interface{} {
 	}
 }
 
-func (config *ConfigSnapshot) CreateSnapshot(c *Client, vmr *VmRef) (err error) {
+func (config ConfigSnapshot) CreateSnapshot(c *Client, vmr *VmRef) (err error) {
 	params := config.mapToApiValues()
 	err = c.CheckVmRef(vmr)
 	if err != nil {

--- a/proxmox/snapshot.go
+++ b/proxmox/snapshot.go
@@ -20,10 +20,9 @@ func (config *ConfigSnapshot) mapToApiValues() map[string]interface{} {
 	}
 }
 
-func (config *ConfigSnapshot) CreateSnapshot(c *Client, guestId uint) (err error) {
+func (config *ConfigSnapshot) CreateSnapshot(c *Client, vmr *VmRef) (err error) {
 	params := config.mapToApiValues()
-	vmr := NewVmRef(int(guestId))
-	_, err = c.GetVmInfo(vmr)
+	err = c.CheckVmRef(vmr)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
Noticed that `CreateSnapshot()` was the only function in [snapshot.go](https://github.com/Telmate/proxmox-api-go/blob/694b457efb6e309cb3d53c1a853c371cba7bbf29/proxmox/snapshot.go) that did not use `VmRef` as input and would create its own `VmRef`.

Also changed `(config *ConfigSnapshot) CreateSnapshot()` to `(config ConfigSnapshot) CreateSnapshot()` as there is no benefit for having the pointer there, since it never needs to be mutated by multiple functions and its too small to be worth the overhead of creating a pointer. 
