### PR TITLE
Allow the creation of bind mounts for lxc containers

### DIFF
--- a/proxmox/config_lxc.go
+++ b/proxmox/config_lxc.go
@@ -473,6 +473,7 @@ func (config ConfigLxc) mapToApiValues() map[string]interface{} {
 		// add mp to lxc parameters
 		mpID := mpConfMap["slot"]
 		mpName := fmt.Sprintf("mp%v", mpID)
+
 		paramMap[mpName] = FormatDiskParam(mpConfMap)
 	}
 

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -1380,7 +1380,10 @@ func FormatDiskParam(disk QemuDevice) string {
 
 	if volume, ok := disk["volume"]; ok && volume != "" {
 		diskConfParam = append(diskConfParam, volume.(string))
-		diskConfParam = append(diskConfParam, fmt.Sprintf("size=%v", disk["size"]))
+		
+		if size, ok := disk["size"]; ok && size != "" {
+			diskConfParam = append(diskConfParam, fmt.Sprintf("size=%v", disk["size"]))
+		}
 	} else {
 		volumeInit := fmt.Sprintf("%v:%v", disk["storage"], DiskSizeGB(disk["size"]))
 		diskConfParam = append(diskConfParam, volumeInit)


### PR DESCRIPTION
This PR essentially makes size optional for a mount specified by volume. 

I have tested this using `terraform-provider-proxmox` for my use cases and it seems to work well. Is there somewhere I should look to add a test?

### Further reading:
Provider PR: https://github.com/Telmate/terraform-provider-proxmox/pull/806
Provider Issue: https://github.com/Telmate/terraform-provider-proxmox/issues/277
Bind mount docs: https://pve.proxmox.com/pve-docs/pve-admin-guide.html#_bind_mount_points