### PR TITLE
Feature: guest features

### DIFF
--- a/cli/command/commands/commands.go
+++ b/cli/command/commands/commands.go
@@ -9,6 +9,7 @@ import (
 	_ "github.com/Telmate/proxmox-api-go/cli/command/delete"
 	_ "github.com/Telmate/proxmox-api-go/cli/command/example"
 	_ "github.com/Telmate/proxmox-api-go/cli/command/get"
+	_ "github.com/Telmate/proxmox-api-go/cli/command/get/guest"
 	_ "github.com/Telmate/proxmox-api-go/cli/command/get/id"
 	_ "github.com/Telmate/proxmox-api-go/cli/command/guest"
 	_ "github.com/Telmate/proxmox-api-go/cli/command/guest/qemu"

--- a/cli/command/get/guest/get-guest-config.go
+++ b/cli/command/get/guest/get-guest-config.go
@@ -1,4 +1,4 @@
-package get
+package guest
 
 import (
 	"github.com/Telmate/proxmox-api-go/cli"
@@ -6,8 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var get_guestCmd = &cobra.Command{
-	Use:   "guest GUESTID",
+var configCmd = &cobra.Command{
+	Use:   "config GUESTID",
 	Short: "Gets the configuration of the specified guest",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
@@ -29,11 +29,11 @@ var get_guestCmd = &cobra.Command{
 		if err != nil {
 			return
 		}
-		cli.PrintFormattedJson(GetCmd.OutOrStdout(), config)
+		cli.PrintFormattedJson(guestCmd.OutOrStdout(), config)
 		return
 	},
 }
 
 func init() {
-	GetCmd.AddCommand(get_guestCmd)
+	guestCmd.AddCommand(configCmd)
 }

--- a/cli/command/get/guest/get-guest-feature.go
+++ b/cli/command/get/guest/get-guest-feature.go
@@ -1,0 +1,32 @@
+package guest
+
+import (
+	"github.com/Telmate/proxmox-api-go/cli"
+	"github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/spf13/cobra"
+)
+
+var featureCmd = &cobra.Command{
+	Use:   "feature GUESTID",
+	Short: "Gets the available features of the specified guest",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		id := cli.ValidateIntIDset(args, "GuestID")
+		vmr := proxmox.NewVmRef(id)
+		c := cli.NewClient()
+		err = c.CheckVmRef(vmr)
+		if err != nil {
+			return
+		}
+		features, err := proxmox.ListGuestFeatures(vmr, c)
+		if err != nil {
+			return
+		}
+		cli.PrintFormattedJson(guestCmd.OutOrStdout(), features)
+		return
+	},
+}
+
+func init() {
+	guestCmd.AddCommand(featureCmd)
+}

--- a/cli/command/get/guest/get-guest.go
+++ b/cli/command/get/guest/get-guest.go
@@ -1,0 +1,15 @@
+package guest
+
+import (
+	"github.com/Telmate/proxmox-api-go/cli/command/get"
+	"github.com/spf13/cobra"
+)
+
+var guestCmd = &cobra.Command{
+	Use:   "guest",
+	Short: "Commands to get information of guests on Proxmox",
+}
+
+func init() {
+	get.GetCmd.AddCommand(guestCmd)
+}

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -34,6 +34,10 @@ type Client struct {
 	TaskTimeout int
 }
 
+const (
+	VmRef_Error_Nil string = "vm reference may not be nil"
+)
+
 // VmRef - virtual machine ref parts
 // map[type:qemu node:proxmox1-xx id:qemu/132 diskread:5.57424738e+08 disk:0 netin:5.9297450593e+10 mem:3.3235968e+09 uptime:1.4567097e+07 vmid:132 template:0 maxcpu:2 netout:6.053310416e+09 maxdisk:3.4359738368e+10 maxmem:8.592031744e+09 diskwrite:1.49663619584e+12 status:running cpu:0.00386980694947209 name:appt-app1-dev.xxx.xx]
 type VmRef struct {
@@ -177,6 +181,9 @@ func (c *Client) GetVmList() (map[string]interface{}, error) {
 }
 
 func (c *Client) CheckVmRef(vmr *VmRef) (err error) {
+	if vmr == nil {
+		return errors.New(VmRef_Error_Nil)
+	}
 	if vmr.node == "" || vmr.vmType == "" {
 		_, err = c.GetVmInfo(vmr)
 	}

--- a/proxmox/config_guest.go
+++ b/proxmox/config_guest.go
@@ -138,11 +138,7 @@ func ListGuests(client *Client) ([]GuestResource, error) {
 }
 
 func pendingGuestConfigFromApi(vmr *VmRef, client *Client) ([]interface{}, error) {
-	err := vmr.nilCheck()
-	if err != nil {
-		return nil, err
-	}
-	if err = client.CheckVmRef(vmr); err != nil {
+	if err := client.CheckVmRef(vmr); err != nil {
 		return nil, err
 	}
 	return client.GetItemConfigInterfaceArray("/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/pending", "Guest", "PENDING CONFIG")

--- a/proxmox/config_guest.go
+++ b/proxmox/config_guest.go
@@ -146,7 +146,11 @@ const (
 
 // check if the guest has the specified feature.
 func GuestHasFeature(vmr *VmRef, client *Client, feature GuestFeature) (bool, error) {
-	err := client.CheckVmRef(vmr)
+	err := feature.Validate()
+	if err != nil {
+		return false, err
+	}
+	err = client.CheckVmRef(vmr)
 	if err != nil {
 		return false, err
 	}

--- a/proxmox/config_guest_test.go
+++ b/proxmox/config_guest_test.go
@@ -237,3 +237,62 @@ func Test_GuestResource_mapToStruct(t *testing.T) {
 		})
 	}
 }
+
+func Test_GuestFeature_mapToStruct(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  map[string]interface{}
+		output bool
+	}{
+		{name: "false",
+			input:  map[string]interface{}{"hasFeature": float64(0)},
+			output: false,
+		},
+		{name: "not set",
+			input:  map[string]interface{}{},
+			output: false,
+		},
+		{name: "true",
+			input:  map[string]interface{}{"hasFeature": float64(1)},
+			output: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(*testing.T) {
+			require.Equal(t, test.output, GuestFeature("").mapToStruct(test.input), test.name)
+		})
+	}
+}
+
+func Test_GuestFeature_Validate(t *testing.T) {
+	tests := []struct {
+		name  string
+		input GuestFeature
+		err   error
+	}{
+		// Invalid
+		{name: "Invalid empty",
+			input: "",
+			err:   GuestFeature("").Error(),
+		},
+		{name: "Invalid not enum",
+			input: "invalid",
+			err:   GuestFeature("").Error(),
+		},
+		// Valid
+		{name: "Valid GuestFeature_Clone",
+			input: GuestFeature_Clone,
+		},
+		{name: "Valid GuestFeature_Copy",
+			input: GuestFeature_Copy,
+		},
+		{name: "Valid GuestFeature_Snapshot",
+			input: GuestFeature_Snapshot,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(*testing.T) {
+			require.Equal(t, test.err, test.input.Validate(), test.name)
+		})
+	}
+}

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -48,7 +48,6 @@ type ConfigQemu struct {
 	Description     string        `json:"description,omitempty"`
 	Disks           *QemuStorages `json:"disks,omitempty"`
 	EFIDisk         QemuDevice    `json:"efidisk,omitempty"`   // TODO should be a struct
-	RNGDrive        QemuDevice    `json:"rng0,omitempty"`      // TODO should be a struct
 	FullClone       *int          `json:"fullclone,omitempty"` // TODO should probably be a bool
 	HaGroup         string        `json:"hagroup,omitempty"`
 	HaState         string        `json:"hastate,omitempty"` // TODO should be custom type with enum
@@ -80,6 +79,7 @@ type ConfigQemu struct {
 	QemuUsbs        QemuDevices   `json:"usb,omitempty"`          // TODO should be a struct
 	QemuVcpus       int           `json:"vcpus,omitempty"`        // TODO should be uint
 	QemuVga         QemuDevice    `json:"vga,omitempty"`          // TODO should be a struct
+	RNGDrive        QemuDevice    `json:"rng0,omitempty"`         // TODO should be a struct
 	Scsihw          string        `json:"scsihw,omitempty"`       // TODO should be custom type with enum
 	Searchdomain    string        `json:"searchdomain,omitempty"` // TODO should be part of a cloud-init struct (cloud-init option)
 	Smbios1         string        `json:"smbios1,omitempty"`      // TODO should be custom type with enum?


### PR DESCRIPTION
Add functionality to check which features are enable for a guest system.

Work done:
- Moved nil check into `*Client.CheckVmRef()` bd6f10d241dedbbd8aa98b8e74a1a5b946b37866 7c6d46ce75b54afe7dc0854460704df06573a423
- Changed `get guest` command to `get guest config` d5a6ce30b8c2ff636318d726aab2573ea65c618a
- Added the `get guest feature` command ca58b91dcca44ff40c3ad92d8c91944b825b6d2c
- Added unit tests 11feae1f09a04483dcd94bcbadad72a4a3fc1550
- Added function `GuestHasFeature()` to check if the guest has a specific feature 11feae1f09a04483dcd94bcbadad72a4a3fc1550
- Added function `ListGuestFeatures()` to check all the features a guest has enabled 11feae1f09a04483dcd94bcbadad72a4a3fc1550
- Put value in alphabetical order 938fbc2900f310bc69dd1614ae7c8e37738665b1

The reason `GuestHasFeature()` and `ListGuestFeatures()` exist is because only one feature can be checked at the time resulting in multiple API calls. For this reason I didn't incorporate it into `ConfigQemu` and `ConfigLxc`.
