### PR TITLE
Fix DiskSize regex to accept decimals

### DIFF
--- a/proxmox/util.go
+++ b/proxmox/util.go
@@ -121,7 +121,7 @@ func DiskSizeGB(dcSize interface{}) float64 {
 	switch dcSize := dcSize.(type) {
 	case string:
 		diskString := strings.ToUpper(dcSize)
-		re := regexp.MustCompile("([0-9]+)([A-Z]*)")
+		re := regexp.MustCompile("([0-9]+(?:\.[0-9]+)?)([TGMK]B?)?")
 		diskArray := re.FindStringSubmatch(diskString)
 
 		diskSize, _ = strconv.ParseFloat(diskArray[1], 64)


### PR DESCRIPTION
Size should accept decimal but the regex only accept whole numbers. This changes the regex to also detect decimal numbers like 0.2G.