### PR TITLE
feat: add support for unlinking disks from VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ export PM_HTTP_HEADERS=Key,Value,Key1,Value1 (only if required)
 
 ./proxmox-api-go node shutdown proxmox-node-name
 
+./proxmox-api-go unlink 123 proxmox-node-name "virtio1,virtio2,virtioN" [false|true]
+
 ```
 
 ## Proxy server support

--- a/main.go
+++ b/main.go
@@ -921,6 +921,34 @@ func main() {
 		failError(err)
 		fmt.Println(string(dnsList))
 
+	case "unlink":
+		if len(flag.Args()) < 4 {
+			failError(fmt.Errorf("error: invoke with <vmID> <node> <diskID [<forceRemoval: false|true>]"))
+		}
+
+		vmIdUnparsed := flag.Args()[1]
+		node := flag.Args()[2]
+		vmId, err := strconv.Atoi(vmIdUnparsed)
+		if err != nil {
+			failError(fmt.Errorf("Failed to convert vmId: %s to a string, error: %+v", vmIdUnparsed, err))
+		}
+
+		disks := flag.Args()[3]
+		forceRemoval := false
+		if len(flag.Args()) > 4 {
+			forceRemovalUnparsed := flag.Args()[4]
+			forceRemoval, err = strconv.ParseBool(forceRemovalUnparsed)
+			if err != nil {
+				failError(fmt.Errorf("Failed to convert <forceRemoval>: %s to a bool, error: %+v", forceRemovalUnparsed, err))
+			}
+		}
+
+		exitStatus, err := c.Unlink(node, vmId, disks, forceRemoval)
+		if err != nil {
+			failError(fmt.Errorf("error: %+v\n api error: %s", err, exitStatus))
+		}
+		log.Printf("Unlinked disks: %s from vmId: %d. Disks removed: %t", disks, vmId, forceRemoval)
+
 	default:
 		fmt.Printf("unknown action, try start|stop vmid\n")
 	}

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -842,6 +842,25 @@ func (c *Client) MoveQemuDiskToVM(vmrSource *VmRef, disk string, vmrTarget *VmRe
 	return
 }
 
+// Unlink - Unlink (detach) a set of disks from a VM.
+// Reference: https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/qemu/{vmid}/unlink
+func (c *Client) Unlink(node string, vmId int, diskIds string, forceRemoval bool) (exitStatus string, err error) {
+	url := fmt.Sprintf("/nodes/%s/qemu/%d/unlink", node, vmId)
+	data := ParamsToBody(map[string]interface{}{
+		"idlist": diskIds,
+		"force":  forceRemoval,
+	})
+	resp, err := c.session.Put(url, nil, nil, &data)
+	if err != nil {
+		return c.HandleTaskError(resp), err
+	}
+	json, err := ResponseJSON(resp)
+	if err != nil {
+		return "", err
+	}
+	return c.WaitForCompletion(json)
+}
+
 // GetNextID - Get next free VMID
 func (c *Client) GetNextID(currentID int) (nextID int, err error) {
 	var data map[string]interface{}


### PR DESCRIPTION
Added support for unlinking a disk from a VM with optional force-removal. This is the first step to fix an issue
in the Proxmox Terraform provider where the disks are not removed correctly if removed from the HCL as part
of a cloud-init based VM.

## Testing

I have tested the changes on a local Proxmox install, version `8.0.4` with the following modified example JSON for creating the Qemu VM:

`qemu1.json` (supply name of iso-file uploaded to Proxmox node):
```json
{
  "name": "golang1.test.com",
  "desc": "Test proxmox-api-go",
  "memory": 512,
  "os": "l26",
  "cores": 2,
  "sockets": 1,
  "iso": {
    "file": "iso/<some-iso>.iso",
    "storage": "local"
  },
  "disk": {
    "0": {
      "type": "virtio",
      "storage": "local",
      "storage_type": "dir",
      "size": "5G",
      "backup": true
    },
    "1": {
      "type": "virtio",
      "storage": "local",
      "storage_type": "dir",
      "size": "1G",
      "backup": true
    },
    "2": {
      "type": "virtio",
      "storage": "local",
      "storage_type": "dir",
      "size": "1G",
      "backup": true
    }
  },
  "network": {
    "0": {
      "model": "virtio",
      "bridge": "nat"
    }
  }
}
```

```bash
./proxmox-api-go --insecure createQemu 100 <proxmox-node-name> < qemu1.json
```

### Scenarios

#### Unlink disk, but don't delete it
Should unlink the disk `virtio1` and leave it as `Unused Disk 0` in tab `Hardware` of VM

```bash
./proxmox-api-go unlink 100 <proxmox-node-name> virtio1
```

#### Unlink disk, and delete it
Should unlink the disk `virtio2` and remove it from tab `Hardware` of VM

```bash
./proxmox-api-go unlink 100 <proxmox-node-name> virtio2 true
```

#### Unlink and delete multiple disks
Should unlink the disks `virtio1` and `virtio2` and remove both from tab `Hardware` of VM
```bash
./proxmox-api-go unlink 100 <proxmox-node-name> "virtio1,virtio2" true
```