### PR TITLE
Bug fix: `ConfigQemu`. `Node`, `Pool`, `VmID`

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -457,7 +457,7 @@ func (config ConfigQemu) mapToApiValues(currentConfig ConfigQemu) (rebootRequire
 	return
 }
 
-func (ConfigQemu) mapToStruct(params map[string]interface{}) (*ConfigQemu, error) {
+func (ConfigQemu) mapToStruct(vmr *VmRef, params map[string]interface{}) (*ConfigQemu, error) {
 	// vmConfig Sample: map[ cpu:host
 	// net0:virtio=62:DF:XX:XX:XX:XX,bridge=vmbr0
 	// ide2:local:iso/xxx-xx.iso,media=cdrom memory:2048
@@ -468,6 +468,12 @@ func (ConfigQemu) mapToStruct(params map[string]interface{}) (*ConfigQemu, error
 	// cores:2 ostype:l26
 
 	config := ConfigQemu{}
+
+	if vmr != nil {
+		config.Node = vmr.node
+		config.Pool = vmr.pool
+		config.VmID = vmr.vmId
+	}
 
 	if _, isSet := params["agent"]; isSet {
 		switch params["agent"].(type) {
@@ -1223,7 +1229,7 @@ func NewConfigQemuFromApi(vmr *VmRef, client *Client) (config *ConfigQemu, err e
 		return nil, fmt.Errorf("vm locked, could not obtain config")
 	}
 
-	config, err = ConfigQemu{}.mapToStruct(vmConfig)
+	config, err = ConfigQemu{}.mapToStruct(vmr, vmConfig)
 	if err != nil {
 		return
 	}

--- a/proxmox/config_qemu_test.go
+++ b/proxmox/config_qemu_test.go
@@ -2348,6 +2348,7 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 	tests := []struct {
 		name   string
 		input  map[string]interface{}
+		vmr    *VmRef
 		output *ConfigQemu
 		err    error
 	}{
@@ -4514,10 +4515,46 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 				"volume":  "local-lvm:vm-1000-disk-0",
 			}},
 		},
+		// Node
+		{name: "Node vmr nil",
+			output: &ConfigQemu{},
+		},
+		{name: "Node vmr empty",
+			vmr:    &VmRef{node: ""},
+			output: &ConfigQemu{},
+		},
+		{name: "Node vmr populated",
+			vmr:    &VmRef{node: "test"},
+			output: &ConfigQemu{Node: "test"},
+		},
+		// Pool
+		{name: "Pool vmr nil",
+			output: &ConfigQemu{},
+		},
+		{name: "Pool vmr empty",
+			vmr:    &VmRef{pool: ""},
+			output: &ConfigQemu{},
+		},
+		{name: "Pool vmr populated",
+			vmr:    &VmRef{pool: "test"},
+			output: &ConfigQemu{Pool: "test"},
+		},
+		// VmID
+		{name: "VmID vmr nil",
+			output: &ConfigQemu{},
+		},
+		{name: "VmID vmr empty",
+			vmr:    &VmRef{vmId: 0},
+			output: &ConfigQemu{},
+		},
+		{name: "VmID vmr populated",
+			vmr:    &VmRef{vmId: 100},
+			output: &ConfigQemu{VmID: 100},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(*testing.T) {
-			output, err := ConfigQemu{}.mapToStruct(test.input)
+			output, err := ConfigQemu{}.mapToStruct(test.vmr, test.input)
 			if err != nil {
 				require.Equal(t, test.err, err, test.name)
 			} else {


### PR DESCRIPTION
Noticed that #255 broke `ConfigQemu`. `Node`, `Pool`, `VmID`

Work Done:
- Fixed bug
- Added unit test

Rework of #272

