### PR TITLE
fix: support array of values for param

### DIFF
--- a/proxmox/session.go
+++ b/proxmox/session.go
@@ -109,6 +109,11 @@ func ParamsToValuesWithAllEmpty(params map[string]interface{}, allowedEmpty []st
 			} else {
 				v = "0"
 			}
+		case []string:
+			for _, v := range intrV {
+				vals.Add(k, fmt.Sprintf("%v", v))
+			}
+			continue
 		default:
 			v = fmt.Sprintf("%v", intrV)
 		}

--- a/proxmox/session_test.go
+++ b/proxmox/session_test.go
@@ -29,6 +29,12 @@ func TestParamsTo(t *testing.T) {
 			"comment": "",
 		},
 		output: []string{"poolid=test"},
+	}, {
+		name: "array",
+		input: map[string]interface{}{
+			"command": []string{"bash", "-c", "echo test"},
+		},
+		output: []string{"command=bash&command=-c&command=echo+test"},
 	}}
 
 	for _, test := range tests {


### PR DESCRIPTION
Proxmox 8 made a [breaking change](https://pve.proxmox.com/wiki/Roadmap#Proxmox_VE_8.0:~:text=Before%20Proxmox%20VE%208,proper%20array%20of%20strings.) to the [API](https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/qemu/{vmid}/agent/exec) for qemu exec.

Add support for sending an array values for a parameter.