### PR TITLE
fix: cloudinit `Format` empty

### DIFF
--- a/proxmox/config_qemu_disk.go
+++ b/proxmox/config_qemu_disk.go
@@ -95,11 +95,11 @@ type qemuCdRom struct {
 }
 
 func (qemuCdRom) mapToStruct(diskData string, settings map[string]interface{}) *qemuCdRom {
-	var isCdRom bool
 	if setting, isSet := settings["media"]; isSet {
-		isCdRom = setting.(string) == "cdrom"
-	}
-	if !isCdRom {
+		if setting.(string) != "cdrom" {
+			return nil
+		}
+	} else {
 		return nil
 	}
 	if _, isSet := settings["none"]; isSet {

--- a/proxmox/config_qemu_disk.go
+++ b/proxmox/config_qemu_disk.go
@@ -111,7 +111,14 @@ func (qemuCdRom) mapToStruct(diskData string, settings map[string]interface{}) *
 	tmpStorage := strings.Split(diskData, ":")
 	if len(tmpStorage) > 1 {
 		tmpFile := strings.Split(diskData, "/")
-		if len(tmpFile) == 2 {
+		switch len(tmpFile) {
+		case 1:
+			return &qemuCdRom{
+				Storage: tmpStorage[0],
+				File:    tmpStorage[1],
+				Format:  QemuDiskFormat_Raw,
+			}
+		case 2:
 			tmpFileType := strings.Split(tmpFile[1], ".")
 			if len(tmpFileType) > 1 {
 				fileType := QemuDiskFormat(tmpFileType[len(tmpFileType)-1])

--- a/proxmox/config_qemu_test.go
+++ b/proxmox/config_qemu_test.go
@@ -3001,8 +3001,8 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 			}}}}},
 		},
 		{name: "Disks Ide CloudInit lvm",
-			input: map[string]interface{}{"ide0": "Test:vm-100-cloudinit,media=cdrom"},
-			output: &ConfigQemu{Disks: &QemuStorages{Ide: &QemuIdeDisks{Disk_0: &QemuIdeStorage{CloudInit: &QemuCloudInitDisk{
+			input: map[string]interface{}{"ide3": "Test:vm-100-cloudinit,media=cdrom"},
+			output: &ConfigQemu{Disks: &QemuStorages{Ide: &QemuIdeDisks{Disk_3: &QemuIdeStorage{CloudInit: &QemuCloudInitDisk{
 				Format:  QemuDiskFormat_Raw,
 				Storage: "Test",
 			}}}}},
@@ -3540,8 +3540,8 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 		},
 		// Disks Sata CloudInit
 		{name: "Disks Sata CloudInit file",
-			input: map[string]interface{}{"sata0": "Test:100/vm-100-cloudinit.raw,media=cdrom"},
-			output: &ConfigQemu{Disks: &QemuStorages{Sata: &QemuSataDisks{Disk_0: &QemuSataStorage{CloudInit: &QemuCloudInitDisk{
+			input: map[string]interface{}{"sata4": "Test:100/vm-100-cloudinit.raw,media=cdrom"},
+			output: &ConfigQemu{Disks: &QemuStorages{Sata: &QemuSataDisks{Disk_4: &QemuSataStorage{CloudInit: &QemuCloudInitDisk{
 				Format:  QemuDiskFormat_Raw,
 				Storage: "Test",
 			}}}}},
@@ -4097,8 +4097,8 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 			}}}}},
 		},
 		{name: "Disks Scsi CloudInit lvm",
-			input: map[string]interface{}{"scsi0": "Test:vm-100-cloudinit,media=cdrom"},
-			output: &ConfigQemu{Disks: &QemuStorages{Scsi: &QemuScsiDisks{Disk_0: &QemuScsiStorage{CloudInit: &QemuCloudInitDisk{
+			input: map[string]interface{}{"scsi23": "Test:vm-100-cloudinit,media=cdrom"},
+			output: &ConfigQemu{Disks: &QemuStorages{Scsi: &QemuScsiDisks{Disk_23: &QemuScsiStorage{CloudInit: &QemuCloudInitDisk{
 				Format:  QemuDiskFormat_Raw,
 				Storage: "Test",
 			}}}}},
@@ -4689,8 +4689,8 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 			}}}}},
 		},
 		{name: "Disks VirtIO CloudInit lvm",
-			input: map[string]interface{}{"virtio0": "Test:vm-100-cloudinit,media=cdrom"},
-			output: &ConfigQemu{Disks: &QemuStorages{VirtIO: &QemuVirtIODisks{Disk_0: &QemuVirtIOStorage{CloudInit: &QemuCloudInitDisk{
+			input: map[string]interface{}{"virtio7": "Test:vm-100-cloudinit,media=cdrom"},
+			output: &ConfigQemu{Disks: &QemuStorages{VirtIO: &QemuVirtIODisks{Disk_7: &QemuVirtIOStorage{CloudInit: &QemuCloudInitDisk{
 				Format:  QemuDiskFormat_Raw,
 				Storage: "Test",
 			}}}}},

--- a/proxmox/config_qemu_test.go
+++ b/proxmox/config_qemu_test.go
@@ -2993,8 +2993,15 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 			}}}}}},
 		},
 		// Disks Ide CloudInit
-		{name: "Disks Ide CloudInit",
+		{name: "Disks Ide CloudInit file",
 			input: map[string]interface{}{"ide0": "Test:100/vm-100-cloudinit.raw,media=cdrom"},
+			output: &ConfigQemu{Disks: &QemuStorages{Ide: &QemuIdeDisks{Disk_0: &QemuIdeStorage{CloudInit: &QemuCloudInitDisk{
+				Format:  QemuDiskFormat_Raw,
+				Storage: "Test",
+			}}}}},
+		},
+		{name: "Disks Ide CloudInit lvm",
+			input: map[string]interface{}{"ide0": "Test:vm-100-cloudinit,media=cdrom"},
 			output: &ConfigQemu{Disks: &QemuStorages{Ide: &QemuIdeDisks{Disk_0: &QemuIdeStorage{CloudInit: &QemuCloudInitDisk{
 				Format:  QemuDiskFormat_Raw,
 				Storage: "Test",
@@ -3532,8 +3539,15 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 			}}}}}},
 		},
 		// Disks Sata CloudInit
-		{name: "Disks Sata CloudInit",
+		{name: "Disks Sata CloudInit file",
 			input: map[string]interface{}{"sata0": "Test:100/vm-100-cloudinit.raw,media=cdrom"},
+			output: &ConfigQemu{Disks: &QemuStorages{Sata: &QemuSataDisks{Disk_0: &QemuSataStorage{CloudInit: &QemuCloudInitDisk{
+				Format:  QemuDiskFormat_Raw,
+				Storage: "Test",
+			}}}}},
+		},
+		{name: "Disks Sata CloudInit lvm",
+			input: map[string]interface{}{"sata0": "Test:vm-100-cloudinit,media=cdrom"},
 			output: &ConfigQemu{Disks: &QemuStorages{Sata: &QemuSataDisks{Disk_0: &QemuSataStorage{CloudInit: &QemuCloudInitDisk{
 				Format:  QemuDiskFormat_Raw,
 				Storage: "Test",
@@ -4075,8 +4089,15 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 			}}}}}},
 		},
 		// Disks Scsi CloudInit
-		{name: "Disks Scsi CloudInit",
+		{name: "Disks Scsi CloudInit file",
 			input: map[string]interface{}{"scsi0": "Test:100/vm-100-cloudinit.raw,media=cdrom"},
+			output: &ConfigQemu{Disks: &QemuStorages{Scsi: &QemuScsiDisks{Disk_0: &QemuScsiStorage{CloudInit: &QemuCloudInitDisk{
+				Format:  QemuDiskFormat_Raw,
+				Storage: "Test",
+			}}}}},
+		},
+		{name: "Disks Scsi CloudInit lvm",
+			input: map[string]interface{}{"scsi0": "Test:vm-100-cloudinit,media=cdrom"},
 			output: &ConfigQemu{Disks: &QemuStorages{Scsi: &QemuScsiDisks{Disk_0: &QemuScsiStorage{CloudInit: &QemuCloudInitDisk{
 				Format:  QemuDiskFormat_Raw,
 				Storage: "Test",
@@ -4660,8 +4681,15 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 			}}}}}},
 		},
 		// Disks VirtIO CloudInit
-		{name: "Disks VirtIO CloudInit",
+		{name: "Disks VirtIO CloudInit file",
 			input: map[string]interface{}{"virtio0": "Test:100/vm-100-cloudinit.raw,media=cdrom"},
+			output: &ConfigQemu{Disks: &QemuStorages{VirtIO: &QemuVirtIODisks{Disk_0: &QemuVirtIOStorage{CloudInit: &QemuCloudInitDisk{
+				Format:  QemuDiskFormat_Raw,
+				Storage: "Test",
+			}}}}},
+		},
+		{name: "Disks VirtIO CloudInit lvm",
+			input: map[string]interface{}{"virtio0": "Test:vm-100-cloudinit,media=cdrom"},
 			output: &ConfigQemu{Disks: &QemuStorages{VirtIO: &QemuVirtIODisks{Disk_0: &QemuVirtIOStorage{CloudInit: &QemuCloudInitDisk{
 				Format:  QemuDiskFormat_Raw,
 				Storage: "Test",


### PR DESCRIPTION
Fixed an issue where cloudinit format would be `""`, now defaults to `"raw"` for lvm storage.