### PR TITLE
[FIX] cloudinit disk not set fix

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -852,6 +852,10 @@ func (newConfig ConfigQemu) setAdvanced(currentConfig *ConfigQemu, rebootIfNeede
 	var exitStatus string
 
 	if currentConfig != nil {
+		// Ugly hack to update config if we clone a template with CloudInit drive and we don't have it in our configuration
+		if currentConfig.Disks.Ide.Disk_2.CloudInit != nil && newConfig.Disks.Ide.Disk_2.CloudInit == nil {
+			newConfig.Disks.Ide.Disk_2 = currentConfig.Disks.Ide.Disk_2
+		}
 		// Update
 		if newConfig.Disks != nil && currentConfig.Disks != nil {
 			markedDisks := newConfig.Disks.markDiskChanges(*currentConfig.Disks)


### PR DESCRIPTION
This should fix the issue described in https://github.com/Telmate/terraform-provider-proxmox/issues/901

There is certainly a case that can be not managed by this code, for example when you define a cloudint disk and you remove it but in the remote config is still present and it will be overwritten. But I cannot see a case where one would do this, cloudinit disks are a special thing in Proxmox

looking forward for test and suggestions