### PR TITLE
fixes: `cloud-init` can't be created bug

### DIFF
--- a/proxmox/config_guest.go
+++ b/proxmox/config_guest.go
@@ -177,10 +177,23 @@ func GuestHasPendingChanges(vmr *VmRef, client *Client) (bool, error) {
 
 // Reboot the specified guest
 func GuestReboot(vmr *VmRef, client *Client) (err error) {
-	_, err = client.ShutdownVm(vmr)
-	if err != nil {
+	_, err = client.RebootVm(vmr)
+	return
+}
+
+func GuestShutdown(vmr *VmRef, client *Client, force bool) (err error) {
+	if err = client.CheckVmRef(vmr); err != nil {
 		return
 	}
+	var params map[string]interface{}
+	if force {
+		params = map[string]interface{}{"forceStop": force}
+	}
+	_, err = client.PostWithTask(params, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/status/shutdown")
+	return
+}
+
+func GuestStart(vmr *VmRef, client *Client) (err error) {
 	_, err = client.StartVm(vmr)
 	return
 }

--- a/proxmox/config_guest.go
+++ b/proxmox/config_guest.go
@@ -172,7 +172,7 @@ func GuestHasPendingChanges(vmr *VmRef, client *Client) (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	return keyExists(params, "pending"), nil
+	return keyExists(params, "pending") || keyExists(params, "delete"), nil
 }
 
 // Reboot the specified guest

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -858,8 +858,7 @@ func (newConfig ConfigQemu) setAdvanced(currentConfig *ConfigQemu, rebootIfNeede
 	var params map[string]interface{}
 	var exitStatus string
 
-	if currentConfig != nil {
-		// Update
+	if currentConfig != nil { // Update
 		url := "/nodes/" + vmr.node + "/" + vmr.vmType + "/" + strconv.Itoa(vmr.vmId) + "/config"
 		var itemsToDeleteBeforeUpdate string // this is for items that should be removed before they can be created again e.g. cloud-init disks. (convert to array when needed)
 		stopped := false
@@ -867,15 +866,13 @@ func (newConfig ConfigQemu) setAdvanced(currentConfig *ConfigQemu, rebootIfNeede
 		var markedDisks qemuUpdateChanges
 		if newConfig.Disks != nil && currentConfig.Disks != nil {
 			markedDisks = *newConfig.Disks.markDiskChanges(*currentConfig.Disks)
-			// move disk to different storage or change disk format
-			for _, e := range markedDisks.Move {
+			for _, e := range markedDisks.Move { // move disk to different storage or change disk format
 				_, err = e.move(true, vmr, client)
 				if err != nil {
 					return
 				}
 			}
-			// increase Disks in size
-			for _, e := range markedDisks.Resize {
+			for _, e := range markedDisks.Resize { // increase Disks in size
 				_, err = e.resize(vmr, client)
 				if err != nil {
 					return false, err
@@ -908,16 +905,14 @@ func (newConfig ConfigQemu) setAdvanced(currentConfig *ConfigQemu, rebootIfNeede
 		}
 
 		// TODO GuestHasPendingChanges() has the current vm config technically. We can use this to avoid an extra API call.
-		// Moving disks changes the disk id. we need to get the config again if any disk was moved.
-		if len(markedDisks.Move) != 0 {
+		if len(markedDisks.Move) != 0 { // Moving disks changes the disk id. we need to get the config again if any disk was moved.
 			currentConfig, err = NewConfigQemuFromApi(vmr, client)
 			if err != nil {
 				return
 			}
 		}
 
-		// Migrate VM
-		if newConfig.Node != currentConfig.Node {
+		if newConfig.Node != currentConfig.Node { // Migrate VM
 			vmr.SetNode(currentConfig.Node)
 			_, err = client.MigrateNode(vmr, newConfig.Node, true)
 			if err != nil {
@@ -963,9 +958,7 @@ func (newConfig ConfigQemu) setAdvanced(currentConfig *ConfigQemu, rebootIfNeede
 				return rebootRequired, nil
 			}
 		}
-	} else {
-		// Create
-
+	} else { // Create
 		_, params, err = newConfig.mapToApiValues(ConfigQemu{})
 		if err != nil {
 			return

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -90,6 +90,10 @@ type ConfigQemu struct {
 	VmID            int           `json:"vmid,omitempty"` // TODO should be a custom type as there are limitations
 }
 
+const (
+	ConfigQemu_Error_UnableToUpdateWithoutReboot string = "unable to update vm without rebooting"
+)
+
 // Create - Tell Proxmox API to make the VM
 func (config ConfigQemu) Create(vmr *VmRef, client *Client) (err error) {
 	_, err = config.setAdvanced(nil, false, vmr, client)
@@ -856,8 +860,13 @@ func (newConfig ConfigQemu) setAdvanced(currentConfig *ConfigQemu, rebootIfNeede
 
 	if currentConfig != nil {
 		// Update
+		url := "/nodes/" + vmr.node + "/" + vmr.vmType + "/" + strconv.Itoa(vmr.vmId) + "/config"
+		var itemsToDeleteBeforeUpdate string // this is for items that should be removed before they can be created again e.g. cloud-init disks. (convert to array when needed)
+		stopped := false
+
+		var markedDisks qemuUpdateChanges
 		if newConfig.Disks != nil && currentConfig.Disks != nil {
-			markedDisks := newConfig.Disks.markDiskChanges(*currentConfig.Disks)
+			markedDisks = *newConfig.Disks.markDiskChanges(*currentConfig.Disks)
 			// move disk to different storage or change disk format
 			for _, e := range markedDisks.Move {
 				_, err = e.move(true, vmr, client)
@@ -869,15 +878,41 @@ func (newConfig ConfigQemu) setAdvanced(currentConfig *ConfigQemu, rebootIfNeede
 			for _, e := range markedDisks.Resize {
 				_, err = e.resize(vmr, client)
 				if err != nil {
-					return
+					return false, err
 				}
 			}
-			// Moving disks changes the disk id. we need to get the config again if any disk was moved
-			if len(markedDisks.Move) != 0 {
-				currentConfig, err = NewConfigQemuFromApi(vmr, client)
-				if err != nil {
-					return
+			itemsToDeleteBeforeUpdate = newConfig.Disks.cloudInitRemove(*currentConfig.Disks)
+		}
+
+		if itemsToDeleteBeforeUpdate != "" {
+			err = client.Put(map[string]interface{}{"delete": itemsToDeleteBeforeUpdate}, url)
+			if err != nil {
+				return false, fmt.Errorf("error updating VM: %v", err)
+			}
+			// Deleteing these items can create pending changes
+			rebootRequired, err = GuestHasPendingChanges(vmr, client)
+			if err != nil {
+				return
+			}
+			if rebootRequired { // shutdown vm if reboot is required
+				if rebootIfNeeded {
+					if err = GuestShutdown(vmr, client, true); err != nil {
+						return
+					}
+					stopped = true
+					rebootRequired = false
+				} else {
+					return rebootRequired, errors.New(ConfigQemu_Error_UnableToUpdateWithoutReboot)
 				}
+			}
+		}
+
+		// TODO GuestHasPendingChanges() has the current vm config technically. We can use this to avoid an extra API call.
+		// Moving disks changes the disk id. we need to get the config again if any disk was moved.
+		if len(markedDisks.Move) != 0 {
+			currentConfig, err = NewConfigQemuFromApi(vmr, client)
+			if err != nil {
+				return
 			}
 		}
 
@@ -896,23 +931,37 @@ func (newConfig ConfigQemu) setAdvanced(currentConfig *ConfigQemu, rebootIfNeede
 		if err != nil {
 			return
 		}
-		exitStatus, err = client.PutWithTask(params, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/config")
+		exitStatus, err = client.PutWithTask(params, url)
 		if err != nil {
 			return false, fmt.Errorf("error updating VM: %v, error status: %s (params: %v)", err, exitStatus, params)
 		}
 
-		if !rebootRequired {
+		if !rebootRequired && !stopped { // only check if reboot is required if the vm is not already stopped
 			rebootRequired, err = GuestHasPendingChanges(vmr, client)
 			if err != nil {
 				return
 			}
 		}
 
-		if rebootRequired && rebootIfNeeded {
-			if err = GuestReboot(vmr, client); err != nil {
-				return
+		if stopped { // start vm if it was stopped
+			if rebootIfNeeded {
+				if err = GuestStart(vmr, client); err != nil {
+					return
+				}
+				stopped = false
+				rebootRequired = false
+			} else {
+				return true, nil
 			}
-			rebootRequired = false
+		} else if rebootRequired { // reboot vm if it is running
+			if rebootIfNeeded {
+				if err = GuestReboot(vmr, client); err != nil {
+					return
+				}
+				rebootRequired = false
+			} else {
+				return rebootRequired, nil
+			}
 		}
 	} else {
 		// Create

--- a/proxmox/config_qemu_disk.go
+++ b/proxmox/config_qemu_disk.go
@@ -1002,6 +1002,40 @@ type QemuStorages struct {
 	VirtIO *QemuVirtIODisks `json:"virtio,omitempty"`
 }
 
+// Return the cloud init disk that should be removed.
+func (newStorages QemuStorages) cloudInitRemove(currentStorages QemuStorages) string {
+	newCloudInit := newStorages.listCloudInitDisk()
+	currentCloudInit := currentStorages.listCloudInitDisk()
+	if newCloudInit != "" && currentCloudInit != "" && newCloudInit != currentCloudInit {
+		return currentCloudInit
+	}
+	return ""
+}
+
+func (q QemuStorages) listCloudInitDisk() string {
+	if q.Ide != nil {
+		if disk := q.Ide.listCloudInitDisk(); disk != "" {
+			return disk
+		}
+	}
+	if q.Sata != nil {
+		if disk := q.Sata.listCloudInitDisk(); disk != "" {
+			return disk
+		}
+	}
+	if q.Scsi != nil {
+		if disk := q.Scsi.listCloudInitDisk(); disk != "" {
+			return disk
+		}
+	}
+	if q.VirtIO != nil {
+		if disk := q.VirtIO.listCloudInitDisk(); disk != "" {
+			return disk
+		}
+	}
+	return ""
+}
+
 func (storages QemuStorages) mapToApiValues(currentStorages QemuStorages, vmID, linkedVmId uint, params map[string]interface{}) (delete string) {
 	if storages.Ide != nil {
 		delete = storages.Ide.mapToApiValues(currentStorages.Ide, vmID, linkedVmId, params, delete)

--- a/proxmox/config_qemu_disk_ide.go
+++ b/proxmox/config_qemu_disk_ide.go
@@ -56,6 +56,16 @@ type QemuIdeDisks struct {
 	Disk_3 *QemuIdeStorage `json:"3,omitempty"`
 }
 
+func (q QemuIdeDisks) listCloudInitDisk() string {
+	diskMap := q.mapToIntMap()
+	for i := range diskMap {
+		if diskMap[i] != nil && diskMap[i].CloudInit != nil {
+			return "ide" + strconv.Itoa(int(i))
+		}
+	}
+	return ""
+}
+
 func (disks QemuIdeDisks) mapToApiValues(currentDisks *QemuIdeDisks, vmID, LinkedVmId uint, params map[string]interface{}, delete string) string {
 	tmpCurrentDisks := QemuIdeDisks{}
 	if currentDisks != nil {

--- a/proxmox/config_qemu_disk_sata.go
+++ b/proxmox/config_qemu_disk_sata.go
@@ -58,6 +58,16 @@ type QemuSataDisks struct {
 	Disk_5 *QemuSataStorage `json:"5,omitempty"`
 }
 
+func (q QemuSataDisks) listCloudInitDisk() string {
+	diskMap := q.mapToIntMap()
+	for i := range diskMap {
+		if diskMap[i] != nil && diskMap[i].CloudInit != nil {
+			return "sata" + strconv.Itoa(int(i))
+		}
+	}
+	return ""
+}
+
 func (disks QemuSataDisks) mapToApiValues(currentDisks *QemuSataDisks, vmID, LinkedVmId uint, params map[string]interface{}, delete string) string {
 	tmpCurrentDisks := QemuSataDisks{}
 	if currentDisks != nil {

--- a/proxmox/config_qemu_disk_scsi.go
+++ b/proxmox/config_qemu_disk_scsi.go
@@ -87,6 +87,16 @@ type QemuScsiDisks struct {
 	Disk_30 *QemuScsiStorage `json:"30,omitempty"`
 }
 
+func (q QemuScsiDisks) listCloudInitDisk() string {
+	diskMap := q.mapToIntMap()
+	for i := range diskMap {
+		if diskMap[i] != nil && diskMap[i].CloudInit != nil {
+			return "scsi" + strconv.Itoa(int(i))
+		}
+	}
+	return ""
+}
+
 func (disks QemuScsiDisks) mapToApiValues(currentDisks *QemuScsiDisks, vmID, linkedVmId uint, params map[string]interface{}, delete string) string {
 	tmpCurrentDisks := QemuScsiDisks{}
 	if currentDisks != nil {

--- a/proxmox/config_qemu_disk_virtio.go
+++ b/proxmox/config_qemu_disk_virtio.go
@@ -70,6 +70,16 @@ type QemuVirtIODisks struct {
 	Disk_15 *QemuVirtIOStorage `json:"15,omitempty"`
 }
 
+func (q QemuVirtIODisks) listCloudInitDisk() string {
+	diskMap := q.mapToIntMap()
+	for i := range diskMap {
+		if diskMap[i] != nil && diskMap[i].CloudInit != nil {
+			return "virtio" + strconv.Itoa(int(i))
+		}
+	}
+	return ""
+}
+
 func (disks QemuVirtIODisks) mapToApiValues(currentDisks *QemuVirtIODisks, vmID, linkedVmId uint, params map[string]interface{}, delete string) string {
 	tmpCurrentDisks := QemuVirtIODisks{}
 	if currentDisks != nil {


### PR DESCRIPTION
This PR fixes #299

Work done:
- Added func `GuestStart()`.
- Added func `GuestShutdown()` with force shutdown option.
- Created procedure for deleting items before the primary update step.
