### PR TITLE
Add Support for Loading Environment Variables from .env Files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+PM_API_URL="https://xxxx.com:8006/api2/json"
+PM_USER=user@pam
+PM_PASS=password
+PM_OTP=otpcode (only if required)
+PM_HTTP_HEADERS=Key,Value,Key1,Value1 (only if required)

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 proxmox-api-go
 .vagrant/
 .vscode
+.env

--- a/README.md
+++ b/README.md
@@ -16,13 +16,21 @@ go build -o proxmox-api-go
 
 ## Run
 
-```sh
-export PM_API_URL="https://xxxx.com:8006/api2/json"
-export PM_USER=user@pam
-export PM_PASS=password
-export PM_OTP=otpcode (only if required)
-export PM_HTTP_HEADERS=Key,Value,Key1,Value1 (only if required)
+Create a local `.env` file in the root directory of the project and add the following environment variables:
 
+```sh
+PM_API_URL="https://xxxx.com:8006/api2/json"
+PM_USER=user@pam
+PM_PASS=password
+PM_OTP=otpcode (only if required)
+PM_HTTP_HEADERS=Key,Value,Key1,Value1 (only if required)
+```
+
+**Note**: Do not commit your local `.env` file to version control to keep your credentials secure.
+
+Run commands (examples, not a complete list):
+
+```sh
 ./proxmox-api-go installQemu proxmox-node-name < qemu1.json
 
 ./proxmox-api-go createQemu 123 proxmox-node-name < qemu1.json

--- a/README.md
+++ b/README.md
@@ -28,6 +28,16 @@ PM_HTTP_HEADERS=Key,Value,Key1,Value1 (only if required)
 
 **Note**: Do not commit your local `.env` file to version control to keep your credentials secure.
 
+Or export the environment variables:
+
+```sh
+export PM_API_URL="https://xxxx.com:8006/api2/json"
+export PM_USER=user@pam
+export PM_PASS=password
+export PM_OTP=otpcode (only if required)
+export PM_HTTP_HEADERS=Key,Value,Key1,Value1 (only if required)
+```
+
 Run commands (examples, not a complete list):
 
 ```sh

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
+github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/main.go
+++ b/main.go
@@ -15,9 +15,17 @@ import (
 	"github.com/Telmate/proxmox-api-go/cli"
 	_ "github.com/Telmate/proxmox-api-go/cli/command/commands"
 	"github.com/Telmate/proxmox-api-go/proxmox"
+
+	"github.com/joho/godotenv"
 )
 
 func main() {
+
+    err := godotenv.Load()
+    if err != nil {
+        log.Fatalf("Error loading .env file: %v", err)
+    }
+
 	if os.Getenv("NEW_CLI") == "true" {
 		err := cli.Execute()
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -19,56 +19,94 @@ import (
 	"github.com/joho/godotenv"
 )
 
-func main() {
+type AppConfig struct {
+    APIURL       string
+    HTTPHeaders  string
+    User         string
+    Password     string
+    OTP          string
+    NewCLI       bool
+}
 
-    err := godotenv.Load()
-    if err != nil {
-        log.Fatalf("Error loading .env file: %v", err)
+func loadAppConfig() AppConfig {
+    newCLI := os.Getenv("NEW_CLI") == "true"
+
+    if err := godotenv.Load(); err != nil {
+        log.Printf("Warning: Failed to load .env file: %v", err)
     }
 
-	if os.Getenv("NEW_CLI") == "true" {
-		err := cli.Execute()
-		if err != nil {
-			failError(err)
-		}
-		os.Exit(0)
-	}
-	insecure := flag.Bool("insecure", false, "TLS insecure mode")
-	proxmox.Debug = flag.Bool("debug", false, "debug mode")
-	fConfigFile := flag.String("file", "", "file to get the config from")
-	taskTimeout := flag.Int("timeout", 300, "api task timeout in seconds")
-	proxyURL := flag.String("proxy", "", "proxy url to connect to")
-	fvmid := flag.Int("vmid", -1, "custom vmid (instead of auto)")
-	flag.Parse()
-	tlsconf := &tls.Config{InsecureSkipVerify: true}
-	if !*insecure {
-		tlsconf = nil
-	}
-	c, err := proxmox.NewClient(os.Getenv("PM_API_URL"), nil, os.Getenv("PM_HTTP_HEADERS"), tlsconf, *proxyURL, *taskTimeout)
-	failError(err)
-	if userRequiresAPIToken(os.Getenv("PM_USER")) {
-		c.SetAPIToken(os.Getenv("PM_USER"), os.Getenv("PM_PASS"))
-		// As test, get the version of the server
-		_, err := c.GetVersion()
-		if err != nil {
-			log.Fatalf("login error: %s", err)
-		}
-	} else {
-		err = c.Login(os.Getenv("PM_USER"), os.Getenv("PM_PASS"), os.Getenv("PM_OTP"))
-		failError(err)
-	}
+    return AppConfig{
+        APIURL:      os.Getenv("PM_API_URL"),
+        HTTPHeaders: os.Getenv("PM_HTTP_HEADERS"),
+        User:        os.Getenv("PM_USER"),
+        Password:    os.Getenv("PM_PASS"),
+        OTP:         os.Getenv("PM_OTP"),
+        NewCLI:      newCLI,
+    }
+}
 
-	vmid := *fvmid
-	if vmid < 0 {
-		if len(flag.Args()) > 1 {
-			vmid, err = strconv.Atoi(flag.Args()[1])
-			if err != nil {
+func initializeProxmoxClient(config AppConfig, insecure bool, proxyURL string, taskTimeout int) (*proxmox.Client, error) {
+    tlsconf := &tls.Config{InsecureSkipVerify: insecure}
+    if !insecure {
+        tlsconf = nil
+    }
+    
+    client, err := proxmox.NewClient(config.APIURL, nil, config.HTTPHeaders, tlsconf, proxyURL, taskTimeout)
+    if err != nil {
+        return nil, err
+    }
+    
+    if userRequiresAPIToken(config.User) {
+        client.SetAPIToken(config.User, config.Password)
+        _, err := client.GetVersion()
+        if err != nil {
+            return nil, err
+        }
+    } else {
+        err = client.Login(config.User, config.Password, config.OTP)
+        if err != nil {
+            return nil, err
+        }
+    }
+    
+    return client, nil
+}
+
+func main() {
+
+    config := loadAppConfig()
+
+    if config.NewCLI {
+        err := cli.Execute()
+        if err != nil {
+            failError(err)
+        }
+        os.Exit(0)
+    }
+
+    // Command-line flags
+    insecure := flag.Bool("insecure", false, "TLS insecure mode")
+    proxmox.Debug = flag.Bool("debug", false, "debug mode")
+    fConfigFile := flag.String("file", "", "file to get the config from")
+    taskTimeout := flag.Int("timeout", 300, "API task timeout in seconds")
+    proxyURL := flag.String("proxy", "", "proxy URL to connect to")
+    fvmid := flag.Int("vmid", -1, "custom VMID (instead of auto)")
+    flag.Parse()
+
+    // Initialize Proxmox client
+	c, err := initializeProxmoxClient(config, *insecure, *proxyURL, *taskTimeout)
+
+    vmid := *fvmid
+    if vmid < 0 {
+                if len(flag.Args()) > 1 {
+            vmid, err = strconv.Atoi(flag.Args()[1])
+            if err != nil {
 				vmid = 0
 			}
-		} else if len(flag.Args()) == 0 || (flag.Args()[0] == "idstatus") {
-			vmid = 0
-		}
-	}
+        } else if len(flag.Args()) == 0 || (flag.Args()[0] == "idstatus") {
+            vmid = 0
+        }
+    }
 
 	var jbody interface{}
 	var vmr *proxmox.VmRef


### PR DESCRIPTION
Hello `Telmate/proxmox-api-go` maintainers,

I am just starting to contribute to the Proxmox ecosystem. I want to see a nice and useful terraform provider and do my part to it. As I learned now the `Telmate/proxmox-api-go` is the first crucial thing and I cloned the repo to play around with it to get started.

**My Motivation:**
When it came to exporting environment variables to setup the configuration, I thought `.env` files would be a nice thing to have. I usually have multiple small projects ongoing at the same time and always having to type `export KEY=value` is error prone and as it is part of the bash history also insecure.

**Implementation:**
To address this, I have integrated the `godotenv` package, which allows the application to automatically load environment variables from a `.env` file at runtime. This means users can now store their sensitive credentials safely in `.env` files, significantly reducing the risk of accidental exposure, mixing up things etc. I also added `.env` to the gitignore file, everybody should know that this is a sensitive file which must not be shared.

**Changes Made:**

- Added `godotenv` as a dependency in `go.mod`.
- Implemented `.env` file loading logic in the main initialization section of the application.
- Updated the README.md to include instructions on how to use `.env` files with the Proxmox API Go client.

Thank you for considering my PR.
