### PR TITLE
Snapshot addons

### DIFF
--- a/cli/command/create/create-snapshot.go
+++ b/cli/command/create/create-snapshot.go
@@ -29,7 +29,7 @@ var (
 			if err != nil {
 				return
 			}
-			err = config.CreateSnapshot(client, vmr)
+			err = config.Create(client, vmr)
 			if err != nil {
 				return
 			}

--- a/cli/command/delete/delete-snapshot.go
+++ b/cli/command/delete/delete-snapshot.go
@@ -14,7 +14,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			id := cli.ValidateIntIDset(args, "GuestID")
 			snapName := cli.RequiredIDset(args, 1, "SnapshotName")
-			_, err = proxmox.DeleteSnapshot(cli.NewClient(), proxmox.NewVmRef(id), proxmox.SnapshotName(snapName))
+			_, err = proxmox.SnapshotName(snapName).Delete(cli.NewClient(), proxmox.NewVmRef(id))
 			if err != nil {
 				return
 			}

--- a/cli/command/guest/guest-rollback.go
+++ b/cli/command/guest/guest-rollback.go
@@ -15,7 +15,7 @@ var guest_rollbackCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		snapName := cli.RequiredIDset(args, 1, "SnapshotName")
-		_, err = proxmox.RollbackSnapshot(cli.NewClient(), vmr, snapName)
+		_, err = proxmox.RollbackSnapshot(cli.NewClient(), vmr, proxmox.SnapshotName(snapName))
 		if err == nil {
 			fmt.Fprintf(GuestCmd.OutOrStdout(), "Guest with id (%d) has been rolled back to snapshot (%s)\n", vmr.VmId(), snapName)
 		}

--- a/cli/command/guest/guest-rollback.go
+++ b/cli/command/guest/guest-rollback.go
@@ -15,7 +15,7 @@ var guest_rollbackCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		snapName := cli.RequiredIDset(args, 1, "SnapshotName")
-		_, err = proxmox.RollbackSnapshot(cli.NewClient(), vmr, proxmox.SnapshotName(snapName))
+		_, err = proxmox.SnapshotName(snapName).Rollback(cli.NewClient(), vmr)
 		if err == nil {
 			fmt.Fprintf(GuestCmd.OutOrStdout(), "Guest with id (%d) has been rolled back to snapshot (%s)\n", vmr.VmId(), snapName)
 		}

--- a/cli/command/update/update-snapshotdescription.go
+++ b/cli/command/update/update-snapshotdescription.go
@@ -14,7 +14,7 @@ var update_snapshotCmd = &cobra.Command{
 		id := cli.ValidateIntIDset(args, "GuestID")
 		snapName := cli.RequiredIDset(args, 1, "SnapshotName")
 		des := cli.OptionalIDset(args, 2)
-		err = proxmox.UpdateSnapshotDescription(cli.NewClient(), proxmox.NewVmRef(id), proxmox.SnapshotName(snapName), des)
+		err = proxmox.SnapshotName(snapName).UpdateDescription(cli.NewClient(), proxmox.NewVmRef(id), des)
 		if err != nil {
 			return
 		}

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -760,7 +760,7 @@ func (c *Client) ListQemuSnapshot(vmr *VmRef) (taskResponse map[string]interface
 
 // DEPRECATED superseded by RollbackSnapshot()
 func (c *Client) RollbackQemuVm(vmr *VmRef, snapshot string) (exitStatus string, err error) {
-	return RollbackSnapshot(c, vmr, snapshot)
+	return RollbackSnapshot(c, vmr, SnapshotName(snapshot))
 }
 
 // DEPRECATED SetVmConfig - send config options

--- a/proxmox/snapshot.go
+++ b/proxmox/snapshot.go
@@ -156,7 +156,7 @@ const (
 	SnapshotName_Error_StartNoLetter     string = "SnapshotName must start with a letter"
 )
 
-// Deletes the specified snapshot
+// Deletes the specified snapshot, validates the input
 func (snap SnapshotName) Delete(c *Client, vmr *VmRef) (exitStatus string, err error) {
 	err = c.CheckVmRef(vmr)
 	if err != nil {
@@ -166,15 +166,25 @@ func (snap SnapshotName) Delete(c *Client, vmr *VmRef) (exitStatus string, err e
 	if err != nil {
 		return
 	}
+	return snap.Delete_Unsafe(c, vmr)
+}
+
+// Deletes the specified snapshot without validating the input, use SnapshotName.Delete() to validate the input.
+func (snap SnapshotName) Delete_Unsafe(c *Client, vmr *VmRef) (exitStatus string, err error) {
 	return c.DeleteWithTask("/nodes/" + vmr.node + "/" + vmr.vmType + "/" + strconv.Itoa(vmr.vmId) + "/snapshot/" + string(snap))
 }
 
-// Rollback to the specified snapshot
+// Rollback to the specified snapshot, validates the input
 func (snap SnapshotName) Rollback(c *Client, vmr *VmRef) (exitStatus string, err error) {
 	err = c.CheckVmRef(vmr)
 	if err != nil {
 		return
 	}
+	return snap.Rollback_Unsafe(c, vmr)
+}
+
+// Rollback to the specified snapshot without validating the input, use SnapshotName.Rollback() to validate the input.
+func (snap SnapshotName) Rollback_Unsafe(c *Client, vmr *VmRef) (exitStatus string, err error) {
 	return c.PostWithTask(nil, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.FormatInt(int64(vmr.vmId), 10)+"/snapshot/"+string(snap)+"/rollback")
 }
 

--- a/proxmox/snapshot.go
+++ b/proxmox/snapshot.go
@@ -23,7 +23,8 @@ func (config ConfigSnapshot) mapToApiValues() map[string]interface{} {
 	}
 }
 
-func (config ConfigSnapshot) CreateSnapshot(c *Client, vmr *VmRef) (err error) {
+// Creates a snapshot and validates the input
+func (config ConfigSnapshot) Create(c *Client, vmr *VmRef) (err error) {
 	err = c.CheckVmRef(vmr)
 	if err != nil {
 		return
@@ -32,13 +33,23 @@ func (config ConfigSnapshot) CreateSnapshot(c *Client, vmr *VmRef) (err error) {
 	if err != nil {
 		return
 	}
+	return config.Create_Unsafe(c, vmr)
+}
+
+// Create a snapshot without validating the input, use ConfigSnapshot.Create() to validate the input.
+func (config ConfigSnapshot) Create_Unsafe(c *Client, vmr *VmRef) error {
 	params := config.mapToApiValues()
-	_, err = c.PostWithTask(params, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/")
+	_, err := c.PostWithTask(params, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/")
 	if err != nil {
 		params, _ := json.Marshal(&params)
 		return fmt.Errorf("error creating Snapshot: %v, (params: %v)", err, string(params))
 	}
-	return
+	return nil
+}
+
+// deprecated use ConfigSnapshot.Create() instead
+func (config ConfigSnapshot) CreateSnapshot(c *Client, vmr *VmRef) error {
+	return config.Create(c, vmr)
 }
 
 func (config ConfigSnapshot) Validate() error {

--- a/proxmox/snapshot.go
+++ b/proxmox/snapshot.go
@@ -73,12 +73,9 @@ func DeleteSnapshot(c *Client, vmr *VmRef, snapshot SnapshotName) (exitStatus st
 	return snapshot.Delete(c, vmr)
 }
 
-func RollbackSnapshot(c *Client, vmr *VmRef, snapshot string) (exitStatus string, err error) {
-	err = c.CheckVmRef(vmr)
-	if err != nil {
-		return
-	}
-	return c.PostWithTask(nil, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/"+snapshot+"/rollback")
+// Rollback to a snapshot, same as SnapshotName.Rollback()
+func RollbackSnapshot(c *Client, vmr *VmRef, snapshot SnapshotName) (exitStatus string, err error) {
+	return snapshot.Rollback(c, vmr)
 }
 
 // Used for formatting the output when retrieving snapshots
@@ -148,6 +145,7 @@ const (
 	SnapshotName_Error_StartNoLetter     string = "SnapshotName must start with a letter"
 )
 
+// Deletes the specified snapshot
 func (snap SnapshotName) Delete(c *Client, vmr *VmRef) (exitStatus string, err error) {
 	err = c.CheckVmRef(vmr)
 	if err != nil {
@@ -158,6 +156,15 @@ func (snap SnapshotName) Delete(c *Client, vmr *VmRef) (exitStatus string, err e
 		return
 	}
 	return c.DeleteWithTask("/nodes/" + vmr.node + "/" + vmr.vmType + "/" + strconv.Itoa(vmr.vmId) + "/snapshot/" + string(snap))
+}
+
+// Rollback to the specified snapshot
+func (snap SnapshotName) Rollback(c *Client, vmr *VmRef) (exitStatus string, err error) {
+	err = c.CheckVmRef(vmr)
+	if err != nil {
+		return
+	}
+	return c.PostWithTask(nil, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.FormatInt(int64(vmr.vmId), 10)+"/snapshot/"+string(snap)+"/rollback")
 }
 
 func (name SnapshotName) Validate() error {

--- a/proxmox/snapshot.go
+++ b/proxmox/snapshot.go
@@ -68,16 +68,9 @@ func UpdateSnapshotDescription(c *Client, vmr *VmRef, snapshot SnapshotName, des
 	return c.Put(map[string]interface{}{"description": description}, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/"+string(snapshot)+"/config")
 }
 
+// Deletes a snapshot, same as SnapshotName.Delete()
 func DeleteSnapshot(c *Client, vmr *VmRef, snapshot SnapshotName) (exitStatus string, err error) {
-	err = c.CheckVmRef(vmr)
-	if err != nil {
-		return
-	}
-	err = snapshot.Validate()
-	if err != nil {
-		return
-	}
-	return c.DeleteWithTask("/nodes/" + vmr.node + "/" + vmr.vmType + "/" + strconv.Itoa(vmr.vmId) + "/snapshot/" + string(snapshot))
+	return snapshot.Delete(c, vmr)
 }
 
 func RollbackSnapshot(c *Client, vmr *VmRef, snapshot string) (exitStatus string, err error) {
@@ -154,6 +147,18 @@ const (
 	SnapshotName_Error_MinLength         string = "SnapshotName must be at least 3 characters long"
 	SnapshotName_Error_StartNoLetter     string = "SnapshotName must start with a letter"
 )
+
+func (snap SnapshotName) Delete(c *Client, vmr *VmRef) (exitStatus string, err error) {
+	err = c.CheckVmRef(vmr)
+	if err != nil {
+		return
+	}
+	err = snap.Validate()
+	if err != nil {
+		return
+	}
+	return c.DeleteWithTask("/nodes/" + vmr.node + "/" + vmr.vmType + "/" + strconv.Itoa(vmr.vmId) + "/snapshot/" + string(snap))
+}
 
 func (name SnapshotName) Validate() error {
 	regex, _ := regexp.Compile(`^([a-zA-Z])([a-z]|[A-Z]|[0-9]|_|-){2,39}$`)

--- a/proxmox/snapshot.go
+++ b/proxmox/snapshot.go
@@ -25,12 +25,10 @@ func (config ConfigSnapshot) mapToApiValues() map[string]interface{} {
 
 // Creates a snapshot and validates the input
 func (config ConfigSnapshot) Create(c *Client, vmr *VmRef) (err error) {
-	err = c.CheckVmRef(vmr)
-	if err != nil {
+	if err = c.CheckVmRef(vmr); err != nil {
 		return
 	}
-	err = config.Validate()
-	if err != nil {
+	if err = config.Validate(); err != nil {
 		return
 	}
 	return config.Create_Unsafe(c, vmr)
@@ -59,8 +57,7 @@ func (config ConfigSnapshot) Validate() error {
 type rawSnapshots []interface{}
 
 func ListSnapshots(c *Client, vmr *VmRef) (rawSnapshots, error) {
-	err := c.CheckVmRef(vmr)
-	if err != nil {
+	if err := c.CheckVmRef(vmr); err != nil {
 		return nil, err
 	}
 	return c.GetItemConfigInterfaceArray("/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/", "Guest", "SNAPSHOTS")
@@ -150,12 +147,10 @@ const (
 
 // Deletes the specified snapshot, validates the input
 func (snap SnapshotName) Delete(c *Client, vmr *VmRef) (exitStatus string, err error) {
-	err = c.CheckVmRef(vmr)
-	if err != nil {
+	if err = c.CheckVmRef(vmr); err != nil {
 		return
 	}
-	err = snap.Validate()
-	if err != nil {
+	if err = snap.Validate(); err != nil {
 		return
 	}
 	// TODO check if snapshot exists
@@ -169,8 +164,7 @@ func (snap SnapshotName) Delete_Unsafe(c *Client, vmr *VmRef) (exitStatus string
 
 // Rollback to the specified snapshot, validates the input
 func (snap SnapshotName) Rollback(c *Client, vmr *VmRef) (exitStatus string, err error) {
-	err = c.CheckVmRef(vmr)
-	if err != nil {
+	if err = c.CheckVmRef(vmr); err != nil {
 		return
 	}
 	if err = snap.Validate(); err != nil {
@@ -187,12 +181,10 @@ func (snap SnapshotName) Rollback_Unsafe(c *Client, vmr *VmRef) (exitStatus stri
 
 // Updates the description of the specified snapshot, validates the input
 func (snap SnapshotName) UpdateDescription(c *Client, vmr *VmRef, description string) (err error) {
-	err = c.CheckVmRef(vmr)
-	if err != nil {
+	if err = c.CheckVmRef(vmr); err != nil {
 		return
 	}
-	err = snap.Validate()
-	if err != nil {
+	if err = snap.Validate(); err != nil {
 		return
 	}
 	// TODO check if snapshot exists

--- a/proxmox/snapshot.go
+++ b/proxmox/snapshot.go
@@ -173,6 +173,9 @@ func (snap SnapshotName) Rollback(c *Client, vmr *VmRef) (exitStatus string, err
 	if err != nil {
 		return
 	}
+	if err = snap.Validate(); err != nil {
+		return
+	}
 	// TODO check if snapshot exists
 	return snap.Rollback_Unsafe(c, vmr)
 }

--- a/proxmox/snapshot.go
+++ b/proxmox/snapshot.go
@@ -66,17 +66,9 @@ func ListSnapshots(c *Client, vmr *VmRef) (rawSnapshots, error) {
 	return c.GetItemConfigInterfaceArray("/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/", "Guest", "SNAPSHOTS")
 }
 
-// Can only be used to update the description of an already existing snapshot
+// Updates the description of the specified snapshot, same as SnapshotName.UpdateDescription()
 func UpdateSnapshotDescription(c *Client, vmr *VmRef, snapshot SnapshotName, description string) (err error) {
-	err = c.CheckVmRef(vmr)
-	if err != nil {
-		return
-	}
-	err = snapshot.Validate()
-	if err != nil {
-		return
-	}
-	return c.Put(map[string]interface{}{"description": description}, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/"+string(snapshot)+"/config")
+	return snapshot.UpdateDescription(c, vmr, description)
 }
 
 // Deletes a snapshot, same as SnapshotName.Delete()
@@ -166,6 +158,7 @@ func (snap SnapshotName) Delete(c *Client, vmr *VmRef) (exitStatus string, err e
 	if err != nil {
 		return
 	}
+	// TODO check if snapshot exists
 	return snap.Delete_Unsafe(c, vmr)
 }
 
@@ -180,12 +173,32 @@ func (snap SnapshotName) Rollback(c *Client, vmr *VmRef) (exitStatus string, err
 	if err != nil {
 		return
 	}
+	// TODO check if snapshot exists
 	return snap.Rollback_Unsafe(c, vmr)
 }
 
 // Rollback to the specified snapshot without validating the input, use SnapshotName.Rollback() to validate the input.
 func (snap SnapshotName) Rollback_Unsafe(c *Client, vmr *VmRef) (exitStatus string, err error) {
 	return c.PostWithTask(nil, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.FormatInt(int64(vmr.vmId), 10)+"/snapshot/"+string(snap)+"/rollback")
+}
+
+// Updates the description of the specified snapshot, validates the input
+func (snap SnapshotName) UpdateDescription(c *Client, vmr *VmRef, description string) (err error) {
+	err = c.CheckVmRef(vmr)
+	if err != nil {
+		return
+	}
+	err = snap.Validate()
+	if err != nil {
+		return
+	}
+	// TODO check if snapshot exists
+	return snap.UpdateDescription_Unsafe(c, vmr, description)
+}
+
+// Updates the description of the specified snapshot without validating the input, use SnapshotName.UpdateDescription() to validate the input.
+func (snap SnapshotName) UpdateDescription_Unsafe(c *Client, vmr *VmRef, description string) error {
+	return c.Put(map[string]interface{}{"description": description}, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/"+string(snap)+"/config")
 }
 
 func (name SnapshotName) Validate() error {


### PR DESCRIPTION
Added some features for working with snapshots.

Moved 3 functions from global to local behaviors, `SnapshotName.Delete()`, `SnapshotName.UpdateDescription()` and `SnapshotName.Rollback()`. Also added their `unsafe` equivalents.
The old functions now call these new ones.

Added `ConfigSnapshot.Create()` and  `ConfigSnapshot.Create_Unsafe()`, and deprecated the old `CreateSnapshot()`.
