### PR TITLE
refactor: use generics for `Pointer` func

### DIFF
--- a/internal/util/util.go
+++ b/internal/util/util.go
@@ -1,0 +1,5 @@
+package util
+
+func Pointer[T any](item T) *T {
+	return &item
+}

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -13,6 +13,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/Telmate/proxmox-api-go/internal/util"
 )
 
 // Currently ZFS local, LVM, Ceph RBD, CephFS, Directory and virtio-scsi-pci are considered.
@@ -237,7 +239,7 @@ func (config *ConfigQemu) defaults() {
 		config.EFIDisk = QemuDevice{}
 	}
 	if config.Onboot == nil {
-		config.Onboot = PointerBool(true)
+		config.Onboot = util.Pointer(true)
 	}
 	if config.Hotplug == "" {
 		config.Hotplug = "network,disk,usb"
@@ -255,7 +257,7 @@ func (config *ConfigQemu) defaults() {
 		config.QemuDisks = QemuDevices{}
 	}
 	if config.QemuKVM == nil {
-		config.QemuKVM = PointerBool(true)
+		config.QemuKVM = util.Pointer(true)
 	}
 	if config.QemuNetworks == nil {
 		config.QemuNetworks = QemuDevices{}
@@ -285,7 +287,7 @@ func (config *ConfigQemu) defaults() {
 		config.Scsihw = "lsi"
 	}
 	if config.Tablet == nil {
-		config.Tablet = PointerBool(true)
+		config.Tablet = util.Pointer(true)
 	}
 
 }
@@ -541,7 +543,7 @@ func (ConfigQemu) mapToStruct(vmr *VmRef, params map[string]interface{}) (*Confi
 		config.Nameserver = params["nameserver"].(string)
 	}
 	if _, isSet := params["onboot"]; isSet {
-		config.Onboot = PointerBool(Itob(int(params["onboot"].(float64))))
+		config.Onboot = util.Pointer(Itob(int(params["onboot"].(float64))))
 	}
 	if _, isSet := params["cores"]; isSet {
 		config.QemuCores = int(params["cores"].(float64))
@@ -550,10 +552,10 @@ func (ConfigQemu) mapToStruct(vmr *VmRef, params map[string]interface{}) (*Confi
 		config.QemuCpu = params["cpu"].(string)
 	}
 	if _, isSet := params["kvm"]; isSet {
-		config.QemuKVM = PointerBool(Itob(int(params["kvm"].(float64))))
+		config.QemuKVM = util.Pointer(Itob(int(params["kvm"].(float64))))
 	}
 	if _, isSet := params["numa"]; isSet {
-		config.QemuNuma = PointerBool(Itob(int(params["numa"].(float64))))
+		config.QemuNuma = util.Pointer(Itob(int(params["numa"].(float64))))
 	}
 	if _, isSet := params["ostype"]; isSet {
 		config.QemuOs = params["ostype"].(string)
@@ -580,7 +582,7 @@ func (ConfigQemu) mapToStruct(vmr *VmRef, params map[string]interface{}) (*Confi
 		config.Startup = params["startup"].(string)
 	}
 	if _, isSet := params["tablet"]; isSet {
-		config.Tablet = PointerBool(Itob(int(params["tablet"].(float64))))
+		config.Tablet = util.Pointer(Itob(int(params["tablet"].(float64))))
 	}
 	if _, isSet := params["tags"]; isSet {
 		config.Tags = strings.TrimSpace(params["tags"].(string))

--- a/proxmox/config_storage.go
+++ b/proxmox/config_storage.go
@@ -6,6 +6,8 @@ import (
 	"log"
 	"strconv"
 	"strings"
+
+	"github.com/Telmate/proxmox-api-go/internal/util"
 )
 
 // matrix of storage types and which content types they support.
@@ -129,7 +131,7 @@ type ConfigStorageDirectory struct {
 
 func (directory *ConfigStorageDirectory) SetDefaults() {
 	if directory.Preallocation == nil {
-		directory.Preallocation = PointerString("metadata")
+		directory.Preallocation = util.Pointer("metadata")
 	}
 }
 
@@ -152,7 +154,7 @@ type ConfigStorageNFS struct {
 
 func (nfs *ConfigStorageNFS) SetDefaults() {
 	if nfs.Preallocation == nil {
-		nfs.Preallocation = PointerString("metadata")
+		nfs.Preallocation = util.Pointer("metadata")
 	}
 }
 
@@ -168,7 +170,7 @@ type ConfigStorageSMB struct {
 
 func (smb *ConfigStorageSMB) SetDefaults() {
 	if smb.Preallocation == nil {
-		smb.Preallocation = PointerString("metadata")
+		smb.Preallocation = util.Pointer("metadata")
 	}
 }
 
@@ -181,7 +183,7 @@ type ConfigStorageGlusterFS struct {
 
 func (glusterfs *ConfigStorageGlusterFS) SetDefaults() {
 	if glusterfs.Preallocation == nil {
-		glusterfs.Preallocation = PointerString("metadata")
+		glusterfs.Preallocation = util.Pointer("metadata")
 	}
 }
 
@@ -220,7 +222,7 @@ type ConfigStorageZFSoverISCSI struct {
 
 func (zfsoveriscsi *ConfigStorageZFSoverISCSI) SetDefaults() {
 	if zfsoveriscsi.Blocksize == nil {
-		zfsoveriscsi.Blocksize = PointerString("4k")
+		zfsoveriscsi.Blocksize = util.Pointer("4k")
 	}
 }
 
@@ -256,7 +258,7 @@ type ConfigStorageZFS struct {
 
 func (zfs *ConfigStorageZFS) SetDefaults() {
 	if zfs.Blocksize == nil {
-		zfs.Blocksize = PointerString("8k")
+		zfs.Blocksize = util.Pointer("8k")
 	}
 }
 
@@ -272,7 +274,7 @@ type ConfigStoragePBS struct {
 
 func (pbs *ConfigStoragePBS) SetDefaults() {
 	if pbs.Port == nil {
-		pbs.Port = PointerInt(8007)
+		pbs.Port = util.Pointer(8007)
 	}
 }
 
@@ -883,7 +885,7 @@ func (config *ConfigStorage) mapToApiValues(create bool) (params map[string]inte
 			}
 		}
 		config.Content = &ConfigStorageContent{
-			DiskImage: PointerBool(true),
+			DiskImage: util.Pointer(true),
 		}
 	case "zfs":
 		if config.ZFS != nil {
@@ -918,7 +920,7 @@ func (config *ConfigStorage) mapToApiValues(create bool) (params map[string]inte
 			}
 		}
 		config.Content = &ConfigStorageContent{
-			Backup: PointerBool(true),
+			Backup: util.Pointer(true),
 		}
 	}
 
@@ -1017,7 +1019,7 @@ func NewConfigStorageFromApi(storageid string, client *Client) (config *ConfigSt
 		config.Directory.Path = rawConfig["path"].(string)
 		config.Directory.Shared = Itob(int(rawConfig["shared"].(float64)))
 		if _, isSet := rawConfig["preallocation"]; isSet {
-			config.Directory.Preallocation = PointerString(rawConfig["preallocation"].(string))
+			config.Directory.Preallocation = util.Pointer(rawConfig["preallocation"].(string))
 		}
 	case "lvm":
 		config.LVM = new(ConfigStorageLVM)
@@ -1033,10 +1035,10 @@ func NewConfigStorageFromApi(storageid string, client *Client) (config *ConfigSt
 		config.NFS.Export = rawConfig["export"].(string)
 		if _, isSet := rawConfig["options"]; isSet {
 			version := strings.Split(rawConfig["options"].(string), "=")
-			config.NFS.Version = PointerString(version[1])
+			config.NFS.Version = util.Pointer(version[1])
 		}
 		if _, isSet := rawConfig["preallocation"]; isSet {
-			config.NFS.Preallocation = PointerString(rawConfig["preallocation"].(string))
+			config.NFS.Preallocation = util.Pointer(rawConfig["preallocation"].(string))
 		}
 	case "smb":
 		config.SMB = new(ConfigStorageSMB)
@@ -1047,7 +1049,7 @@ func NewConfigStorageFromApi(storageid string, client *Client) (config *ConfigSt
 			if smbVersion == "default" {
 				config.SMB.Version = nil
 			} else {
-				config.SMB.Version = PointerString(smbVersion)
+				config.SMB.Version = util.Pointer(smbVersion)
 			}
 		}
 		if _, isSet := rawConfig["domain"]; isSet {
@@ -1057,7 +1059,7 @@ func NewConfigStorageFromApi(storageid string, client *Client) (config *ConfigSt
 			config.SMB.Username = rawConfig["username"].(string)
 		}
 		if _, isSet := rawConfig["preallocation"]; isSet {
-			config.SMB.Preallocation = PointerString(rawConfig["preallocation"].(string))
+			config.SMB.Preallocation = util.Pointer(rawConfig["preallocation"].(string))
 		}
 	case "glusterfs":
 		config.GlusterFS = new(ConfigStorageGlusterFS)
@@ -1067,7 +1069,7 @@ func NewConfigStorageFromApi(storageid string, client *Client) (config *ConfigSt
 			config.GlusterFS.Server2 = rawConfig["server2"].(string)
 		}
 		if _, isSet := rawConfig["preallocation"]; isSet {
-			config.GlusterFS.Preallocation = PointerString(rawConfig["preallocation"].(string))
+			config.GlusterFS.Preallocation = util.Pointer(rawConfig["preallocation"].(string))
 		}
 	case "iscsi":
 		config.ISCSI = new(ConfigStorageISCSI)
@@ -1095,7 +1097,7 @@ func NewConfigStorageFromApi(storageid string, client *Client) (config *ConfigSt
 		}
 	case "zfs-over-iscsi":
 		config.ZFSoverISCSI = new(ConfigStorageZFSoverISCSI)
-		config.ZFSoverISCSI.Blocksize = PointerString(rawConfig["blocksize"].(string))
+		config.ZFSoverISCSI.Blocksize = util.Pointer(rawConfig["blocksize"].(string))
 		config.ZFSoverISCSI.ISCSIprovider = rawConfig["iscsiprovider"].(string)
 		config.ZFSoverISCSI.RemapFromAPI()
 		switch config.ZFSoverISCSI.ISCSIprovider {
@@ -1128,7 +1130,7 @@ func NewConfigStorageFromApi(storageid string, client *Client) (config *ConfigSt
 		config.ZFS.Pool = rawConfig["pool"].(string)
 		config.ZFS.Thinprovision = Itob(int(rawConfig["sparse"].(float64)))
 		if _, isSet := rawConfig["blocksize"]; isSet {
-			config.ZFS.Blocksize = PointerString(rawConfig["blocksize"].(string))
+			config.ZFS.Blocksize = util.Pointer(rawConfig["blocksize"].(string))
 		}
 	case "pbs":
 		config.PBS = new(ConfigStoragePBS)
@@ -1136,7 +1138,7 @@ func NewConfigStorageFromApi(storageid string, client *Client) (config *ConfigSt
 		config.PBS.Server = rawConfig["server"].(string)
 		config.PBS.Username = rawConfig["username"].(string)
 		if _, isSet := rawConfig["port"]; isSet {
-			config.PBS.Port = PointerInt(int(rawConfig["port"].(float64)))
+			config.PBS.Port = util.Pointer(int(rawConfig["port"].(float64)))
 		}
 		if _, isSet := rawConfig["fingerprint"]; isSet {
 			config.PBS.Fingerprint = rawConfig["fingerprint"].(string)
@@ -1152,28 +1154,28 @@ func NewConfigStorageFromApi(storageid string, client *Client) (config *ConfigSt
 			contentArray := CSVtoArray(content)
 			config.Content = new(ConfigStorageContent)
 			if storageContentTypes[config.Type].([]bool)[0] {
-				config.Content.Backup = PointerBool(inArray(contentArray, storageContentTypesAPI[0]))
+				config.Content.Backup = util.Pointer(inArray(contentArray, storageContentTypesAPI[0]))
 			}
 			if storageContentTypes[config.Type].([]bool)[1] {
-				config.Content.Container = PointerBool(inArray(contentArray, storageContentTypesAPI[1]))
+				config.Content.Container = util.Pointer(inArray(contentArray, storageContentTypesAPI[1]))
 			}
 			if storageContentTypes[config.Type].([]bool)[2] {
-				config.Content.DiskImage = PointerBool(inArray(contentArray, storageContentTypesAPI[2]))
+				config.Content.DiskImage = util.Pointer(inArray(contentArray, storageContentTypesAPI[2]))
 			}
 			if storageContentTypes[config.Type].([]bool)[3] {
-				config.Content.Iso = PointerBool(inArray(contentArray, storageContentTypesAPI[3]))
+				config.Content.Iso = util.Pointer(inArray(contentArray, storageContentTypesAPI[3]))
 			}
 			if storageContentTypes[config.Type].([]bool)[4] {
-				config.Content.Snippets = PointerBool(inArray(contentArray, storageContentTypesAPI[4]))
+				config.Content.Snippets = util.Pointer(inArray(contentArray, storageContentTypesAPI[4]))
 			}
 			if storageContentTypes[config.Type].([]bool)[5] {
-				config.Content.Template = PointerBool(inArray(contentArray, storageContentTypesAPI[5]))
+				config.Content.Template = util.Pointer(inArray(contentArray, storageContentTypesAPI[5]))
 			}
 		} else {
 			// Edge cases
 			if config.Type == "iscsi" {
 				config.Content = new(ConfigStorageContent)
-				config.Content.DiskImage = PointerBool(false)
+				config.Content.DiskImage = util.Pointer(false)
 			}
 		}
 	}
@@ -1186,12 +1188,12 @@ func NewConfigStorageFromApi(storageid string, client *Client) (config *ConfigSt
 				retentionSettings[a[0]], _ = strconv.Atoi(a[1])
 			}
 			config.BackupRetention = new(ConfigStorageBackupRetention)
-			config.BackupRetention.Daily = PointerInt(retentionSettings["keep-daily"])
-			config.BackupRetention.Hourly = PointerInt(retentionSettings["keep-hourly"])
-			config.BackupRetention.Last = PointerInt(retentionSettings["keep-last"])
-			config.BackupRetention.Monthly = PointerInt(retentionSettings["keep-monthly"])
-			config.BackupRetention.Weekly = PointerInt(retentionSettings["keep-weekly"])
-			config.BackupRetention.Yearly = PointerInt(retentionSettings["keep-yearly"])
+			config.BackupRetention.Daily = util.Pointer(retentionSettings["keep-daily"])
+			config.BackupRetention.Hourly = util.Pointer(retentionSettings["keep-hourly"])
+			config.BackupRetention.Last = util.Pointer(retentionSettings["keep-last"])
+			config.BackupRetention.Monthly = util.Pointer(retentionSettings["keep-monthly"])
+			config.BackupRetention.Weekly = util.Pointer(retentionSettings["keep-weekly"])
+			config.BackupRetention.Yearly = util.Pointer(retentionSettings["keep-yearly"])
 		}
 	}
 	return

--- a/proxmox/util.go
+++ b/proxmox/util.go
@@ -177,21 +177,6 @@ func ArrayToStringType(inputarray []interface{}) (array []string) {
 	return
 }
 
-// Creates a pointer to a string
-func PointerString(text string) *string {
-	return &text
-}
-
-// Creates a pointer to an int
-func PointerInt(number int) *int {
-	return &number
-}
-
-// Creates a pointer to a bool
-func PointerBool(boolean bool) *bool {
-	return &boolean
-}
-
 func failError(err error) {
 	if err != nil {
 		log.Fatal(err)

--- a/test/api/CloudInit/shared_test.go
+++ b/test/api/CloudInit/shared_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	pxapi "github.com/Telmate/proxmox-api-go/proxmox"
 )
 
@@ -28,14 +29,14 @@ func _create_vm_spec(network bool) pxapi.ConfigQemu {
 	config := pxapi.ConfigQemu{
 		Name:         "test-qemu01",
 		Bios:         "seabios",
-		Tablet:       pxapi.PointerBool(true),
+		Tablet:       util.Pointer(true),
 		Memory:       2048,
 		QemuOs:       "l26",
 		QemuCores:    1,
 		QemuSockets:  1,
 		QemuCpu:      "kvm64",
-		QemuNuma:     pxapi.PointerBool(false),
-		QemuKVM:      pxapi.PointerBool(true),
+		QemuNuma:     util.Pointer(false),
+		QemuKVM:      util.Pointer(true),
 		Hotplug:      "network,disk,usb",
 		QemuNetworks: networks,
 		QemuIso:      "none",

--- a/test/api/Qemu/shared_test.go
+++ b/test/api/Qemu/shared_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	pxapi "github.com/Telmate/proxmox-api-go/proxmox"
 )
 
@@ -32,14 +33,14 @@ func _create_vm_spec(network bool) pxapi.ConfigQemu {
 	config := pxapi.ConfigQemu{
 		Name:         "test-qemu01",
 		Bios:         "seabios",
-		Tablet:       pxapi.PointerBool(true),
+		Tablet:       util.Pointer(true),
 		Memory:       128,
 		QemuOs:       "l26",
 		QemuCores:    1,
 		QemuSockets:  1,
 		QemuCpu:      "kvm64",
-		QemuNuma:     pxapi.PointerBool(false),
-		QemuKVM:      pxapi.PointerBool(true),
+		QemuNuma:     util.Pointer(false),
+		QemuKVM:      util.Pointer(true),
 		Hotplug:      "network,disk,usb",
 		QemuNetworks: networks,
 		QemuIso:      "none",

--- a/test/cli/Storage/Storage_PBS_0_test.go
+++ b/test/cli/Storage/Storage_PBS_0_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	_ "github.com/Telmate/proxmox-api-go/cli/command/commands"
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 	storagesubtests "github.com/Telmate/proxmox-api-go/test/cli/Storage/storage-sub-tests"
 )
@@ -14,7 +15,7 @@ func Test_Storage_PBS_0_Cleanup(t *testing.T) {
 
 func Test_Storage_PBS_0_Create_Full(t *testing.T) {
 	s := storagesubtests.CloneJson(storagesubtests.PBSFull)
-	s.PBS.Password = proxmox.PointerString("Enter123!")
+	s.PBS.Password = util.Pointer("Enter123!")
 	s.PBS.Namespace = "test"
 	storagesubtests.Create(s, "pbs-test-0", t)
 }
@@ -36,10 +37,10 @@ func Test_Storage_PBS_0_Update_Empty(t *testing.T) {
 func Test_Storage_PBS_0_Get_Empty(t *testing.T) {
 	s := storagesubtests.CloneJson(storagesubtests.PBSEmpty)
 	s.ID = "pbs-test-0"
-	s.PBS.Port = proxmox.PointerInt(8007)
+	s.PBS.Port = util.Pointer(8007)
 	s.PBS.Namespace = "test"
 	s.Content = &proxmox.ConfigStorageContent{
-		Backup: proxmox.PointerBool(true),
+		Backup: util.Pointer(true),
 	}
 	storagesubtests.Get(s, s.ID, t)
 }

--- a/test/cli/Storage/Storage_PBS_1_test.go
+++ b/test/cli/Storage/Storage_PBS_1_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	_ "github.com/Telmate/proxmox-api-go/cli/command/commands"
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 	storagesubtests "github.com/Telmate/proxmox-api-go/test/cli/Storage/storage-sub-tests"
 )
@@ -14,7 +15,7 @@ func Test_Storage_PBS_1_Cleanup(t *testing.T) {
 
 func Test_Storage_PBS_1_Create_Empty(t *testing.T) {
 	s := storagesubtests.CloneJson(storagesubtests.PBSEmpty)
-	s.PBS.Password = proxmox.PointerString("Enter123!")
+	s.PBS.Password = util.Pointer("Enter123!")
 	s.BackupRetention = &proxmox.ConfigStorageBackupRetention{}
 	storagesubtests.Create(s, "pbs-test-1", t)
 }
@@ -22,9 +23,9 @@ func Test_Storage_PBS_1_Create_Empty(t *testing.T) {
 func Test_Storage_PBS_1_Get_Empty(t *testing.T) {
 	s := storagesubtests.CloneJson(storagesubtests.PBSEmpty)
 	s.ID = "pbs-test-1"
-	s.PBS.Port = proxmox.PointerInt(8007)
+	s.PBS.Port = util.Pointer(8007)
 	s.Content = &proxmox.ConfigStorageContent{
-		Backup: proxmox.PointerBool(true),
+		Backup: util.Pointer(true),
 	}
 	storagesubtests.Get(s, s.ID, t)
 }

--- a/test/cli/Storage/Storage_RBD_0_test.go
+++ b/test/cli/Storage/Storage_RBD_0_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	_ "github.com/Telmate/proxmox-api-go/cli/command/commands"
-	"github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	storagesubtests "github.com/Telmate/proxmox-api-go/test/cli/Storage/storage-sub-tests"
 )
 
@@ -14,7 +14,7 @@ func Test_Storage_RBD_0_Cleanup(t *testing.T) {
 
 func Test_Storage_RBD_0_Create_Full(t *testing.T) {
 	s := storagesubtests.CloneJson(storagesubtests.RBDFull)
-	s.RBD.Keyring = proxmox.PointerString("keyringplaceholder")
+	s.RBD.Keyring = util.Pointer("keyringplaceholder")
 	storagesubtests.Create(s, "rbd-test-0", t)
 }
 

--- a/test/cli/Storage/Storage_RBD_1_test.go
+++ b/test/cli/Storage/Storage_RBD_1_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	_ "github.com/Telmate/proxmox-api-go/cli/command/commands"
-	"github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	storagesubtests "github.com/Telmate/proxmox-api-go/test/cli/Storage/storage-sub-tests"
 )
 
@@ -14,7 +14,7 @@ func Test_Storage_RBD_1_Cleanup(t *testing.T) {
 
 func Test_Storage_RBD_1_Create_Empty(t *testing.T) {
 	s := storagesubtests.CloneJson(storagesubtests.RBDEmpty)
-	s.RBD.Keyring = proxmox.PointerString("keyringplaceholder")
+	s.RBD.Keyring = util.Pointer("keyringplaceholder")
 	storagesubtests.Create(s, "rbd-test-1", t)
 }
 

--- a/test/cli/Storage/Storage_SMB_0_test.go
+++ b/test/cli/Storage/Storage_SMB_0_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	_ "github.com/Telmate/proxmox-api-go/cli/command/commands"
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 	cliTest "github.com/Telmate/proxmox-api-go/test/cli"
 	storagesubtests "github.com/Telmate/proxmox-api-go/test/cli/Storage/storage-sub-tests"
@@ -15,7 +16,7 @@ func Test_Storage_SMB_0_Cleanup(t *testing.T) {
 
 func Test_Storage_SMB_0_Create_Full(t *testing.T) {
 	s := storagesubtests.CloneJson(storagesubtests.SMBFull)
-	s.SMB.Password = proxmox.PointerString("Enter123!")
+	s.SMB.Password = util.Pointer("Enter123!")
 	storagesubtests.Create(s, "smb-test-0", t)
 }
 

--- a/test/cli/Storage/Storage_SMB_1_test.go
+++ b/test/cli/Storage/Storage_SMB_1_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	_ "github.com/Telmate/proxmox-api-go/cli/command/commands"
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 	storagesubtests "github.com/Telmate/proxmox-api-go/test/cli/Storage/storage-sub-tests"
 )
@@ -24,7 +25,7 @@ func Test_Storage_SMB_1_Get_Empty(t *testing.T) {
 
 func Test_Storage_SMB_1_Update_Full(t *testing.T) {
 	s := storagesubtests.CloneJson(storagesubtests.SMBFull)
-	s.SMB.Password = proxmox.PointerString("Enter123!")
+	s.SMB.Password = util.Pointer("Enter123!")
 	storagesubtests.Update(s, "smb-test-1", t)
 }
 

--- a/test/cli/Storage/Storage_ZFS-over-ISCSI_0_test.go
+++ b/test/cli/Storage/Storage_ZFS-over-ISCSI_0_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	_ "github.com/Telmate/proxmox-api-go/cli/command/commands"
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 	storagesubtests "github.com/Telmate/proxmox-api-go/test/cli/Storage/storage-sub-tests"
 )
@@ -20,7 +21,7 @@ func Test_Storage_ZFSoverISCSI_0_Create_Full(t *testing.T) {
 func Test_Storage_ZFSoverISCSI_0_Get_Full(t *testing.T) {
 	s := storagesubtests.CloneJson(storagesubtests.ZFSoverISCSIFull)
 	s.ID = "zfs-over-iscsi-test-0"
-	s.ZFSoverISCSI.Blocksize = proxmox.PointerString("8k")
+	s.ZFSoverISCSI.Blocksize = util.Pointer("8k")
 	storagesubtests.Get(s, s.ID, t)
 }
 
@@ -32,9 +33,9 @@ func Test_Storage_ZFSoverISCSI_0_Update_Empty(t *testing.T) {
 func Test_Storage_ZFSoverISCSI_0_Get_Empty(t *testing.T) {
 	s := storagesubtests.CloneJson(storagesubtests.ZFSoverISCSIEmpty)
 	s.ID = "zfs-over-iscsi-test-0"
-	s.ZFSoverISCSI.Blocksize = proxmox.PointerString("8k")
+	s.ZFSoverISCSI.Blocksize = util.Pointer("8k")
 	s.Content = &proxmox.ConfigStorageContent{
-		DiskImage: proxmox.PointerBool(true),
+		DiskImage: util.Pointer(true),
 	}
 	storagesubtests.Get(s, s.ID, t)
 }

--- a/test/cli/Storage/Storage_ZFS-over-ISCSI_1_test.go
+++ b/test/cli/Storage/Storage_ZFS-over-ISCSI_1_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	_ "github.com/Telmate/proxmox-api-go/cli/command/commands"
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 	storagesubtests "github.com/Telmate/proxmox-api-go/test/cli/Storage/storage-sub-tests"
 )
@@ -20,9 +21,9 @@ func Test_Storage_ZFSoverISCSI_1_Create_Empty(t *testing.T) {
 func Test_Storage_ZFSoverISCSI_1_Get_Empty(t *testing.T) {
 	s := storagesubtests.CloneJson(storagesubtests.ZFSoverISCSIEmpty)
 	s.ID = "zfs-over-iscsi-test-1"
-	s.ZFSoverISCSI.Blocksize = proxmox.PointerString("4k")
+	s.ZFSoverISCSI.Blocksize = util.Pointer("4k")
 	s.Content = &proxmox.ConfigStorageContent{
-		DiskImage: proxmox.PointerBool(true),
+		DiskImage: util.Pointer(true),
 	}
 	storagesubtests.Get(s, s.ID, t)
 }
@@ -35,7 +36,7 @@ func Test_Storage_ZFSoverISCSI_1_Update_Full(t *testing.T) {
 func Test_Storage_ZFSoverISCSI_1_Get_Full(t *testing.T) {
 	s := storagesubtests.CloneJson(storagesubtests.ZFSoverISCSIFull)
 	s.ID = "zfs-over-iscsi-test-1"
-	s.ZFSoverISCSI.Blocksize = proxmox.PointerString("4k")
+	s.ZFSoverISCSI.Blocksize = util.Pointer("4k")
 	storagesubtests.Get(s, s.ID, t)
 }
 

--- a/test/cli/Storage/Storage_ZFS-over-ISCSI_Comstar_0_test.go
+++ b/test/cli/Storage/Storage_ZFS-over-ISCSI_Comstar_0_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	_ "github.com/Telmate/proxmox-api-go/cli/command/commands"
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 	storagesubtests "github.com/Telmate/proxmox-api-go/test/cli/Storage/storage-sub-tests"
 )
@@ -33,14 +34,14 @@ func Test_Storage_ZFSoverISCSI_Comstar_0_Update_Empty(t *testing.T) {
 func Test_Storage_ZFSoverISCSI_Comstar_0_Get_Empty(t *testing.T) {
 	s := storagesubtests.CloneJson(storagesubtests.ZFSoverISCSI_ComstarEmpty)
 	s.ID = "zfs-over-iscsi_comstar-test-0"
-	s.ZFSoverISCSI.Blocksize = proxmox.PointerString("8k")
+	s.ZFSoverISCSI.Blocksize = util.Pointer("8k")
 	s.ZFSoverISCSI.Comstar = &proxmox.ConfigStorageZFSoverISCSI_Comstar{
 		TargetGroup: "t-group",
 		HostGroup:   "h-group",
 		Writecache:  false,
 	}
 	s.Content = &proxmox.ConfigStorageContent{
-		DiskImage: proxmox.PointerBool(true),
+		DiskImage: util.Pointer(true),
 	}
 	storagesubtests.Get(s, s.ID, t)
 }

--- a/test/cli/Storage/Storage_ZFS-over-ISCSI_Comstar_1_test.go
+++ b/test/cli/Storage/Storage_ZFS-over-ISCSI_Comstar_1_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	_ "github.com/Telmate/proxmox-api-go/cli/command/commands"
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 	storagesubtests "github.com/Telmate/proxmox-api-go/test/cli/Storage/storage-sub-tests"
 )
@@ -21,14 +22,14 @@ func Test_Storage_ZFSoverISCSI_Comstar_1_Create_Empty(t *testing.T) {
 func Test_Storage_ZFSoverISCSI_Comstar_1_Get_Empty(t *testing.T) {
 	s := storagesubtests.CloneJson(storagesubtests.ZFSoverISCSI_ComstarEmpty)
 	s.ID = "zfs-over-iscsi_comstar-test-1"
-	s.ZFSoverISCSI.Blocksize = proxmox.PointerString("4k")
+	s.ZFSoverISCSI.Blocksize = util.Pointer("4k")
 	s.ZFSoverISCSI.Comstar = &proxmox.ConfigStorageZFSoverISCSI_Comstar{
 		TargetGroup: "",
 		HostGroup:   "",
 		Writecache:  true,
 	}
 	s.Content = &proxmox.ConfigStorageContent{
-		DiskImage: proxmox.PointerBool(true),
+		DiskImage: util.Pointer(true),
 	}
 	storagesubtests.Get(s, s.ID, t)
 }
@@ -43,7 +44,7 @@ func Test_Storage_ZFSoverISCSI_Comstar_1_Update_Full(t *testing.T) {
 func Test_Storage_ZFSoverISCSI_Comstar_1_Get_Full(t *testing.T) {
 	s := storagesubtests.CloneJson(storagesubtests.ZFSoverISCSI_ComstarFull)
 	s.ID = "zfs-over-iscsi_comstar-test-1"
-	s.ZFSoverISCSI.Blocksize = proxmox.PointerString("4k")
+	s.ZFSoverISCSI.Blocksize = util.Pointer("4k")
 	s.ZFSoverISCSI.Comstar.HostGroup = ""
 	s.ZFSoverISCSI.Comstar.TargetGroup = ""
 	storagesubtests.Get(s, s.ID, t)

--- a/test/cli/Storage/Storage_ZFS-over-ISCSI_Istgt_0_test.go
+++ b/test/cli/Storage/Storage_ZFS-over-ISCSI_Istgt_0_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	_ "github.com/Telmate/proxmox-api-go/cli/command/commands"
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 	storagesubtests "github.com/Telmate/proxmox-api-go/test/cli/Storage/storage-sub-tests"
 )
@@ -31,9 +32,9 @@ func Test_Storage_ZFSoverISCSI_Istgt_0_Update_Empty(t *testing.T) {
 func Test_Storage_ZFSoverISCSI_Istgt_0_Get_Empty(t *testing.T) {
 	s := storagesubtests.CloneJson(storagesubtests.ZFSoverISCSI_IstgtEmpty)
 	s.ID = "zfs-over-iscsi_istgt-test-0"
-	s.ZFSoverISCSI.Blocksize = proxmox.PointerString("8k")
+	s.ZFSoverISCSI.Blocksize = util.Pointer("8k")
 	s.Content = &proxmox.ConfigStorageContent{
-		DiskImage: proxmox.PointerBool(true),
+		DiskImage: util.Pointer(true),
 	}
 	storagesubtests.Get(s, s.ID, t)
 }

--- a/test/cli/Storage/Storage_ZFS-over-ISCSI_Istgt_1_test.go
+++ b/test/cli/Storage/Storage_ZFS-over-ISCSI_Istgt_1_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	_ "github.com/Telmate/proxmox-api-go/cli/command/commands"
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 	storagesubtests "github.com/Telmate/proxmox-api-go/test/cli/Storage/storage-sub-tests"
 )
@@ -21,9 +22,9 @@ func Test_Storage_ZFSoverISCSI_Istgt_1_Create_Empty(t *testing.T) {
 func Test_Storage_ZFSoverISCSI_Istgt_1_Get_Empty(t *testing.T) {
 	s := storagesubtests.CloneJson(storagesubtests.ZFSoverISCSI_IstgtEmpty)
 	s.ID = "zfs-over-iscsi_istgt-test-1"
-	s.ZFSoverISCSI.Blocksize = proxmox.PointerString("4k")
+	s.ZFSoverISCSI.Blocksize = util.Pointer("4k")
 	s.Content = &proxmox.ConfigStorageContent{
-		DiskImage: proxmox.PointerBool(true),
+		DiskImage: util.Pointer(true),
 	}
 	storagesubtests.Get(s, s.ID, t)
 }
@@ -36,7 +37,7 @@ func Test_Storage_ZFSoverISCSI_Istgt_1_Update_Full(t *testing.T) {
 func Test_Storage_ZFSoverISCSI_Istgt_1_Get_Full(t *testing.T) {
 	s := storagesubtests.CloneJson(storagesubtests.ZFSoverISCSI_IstgtFull)
 	s.ID = "zfs-over-iscsi_istgt-test-1"
-	s.ZFSoverISCSI.Blocksize = proxmox.PointerString("4k")
+	s.ZFSoverISCSI.Blocksize = util.Pointer("4k")
 	storagesubtests.Get(s, s.ID, t)
 }
 

--- a/test/cli/Storage/Storage_ZFS-over-ISCSI_LIO_0_test.go
+++ b/test/cli/Storage/Storage_ZFS-over-ISCSI_LIO_0_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	_ "github.com/Telmate/proxmox-api-go/cli/command/commands"
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 	storagesubtests "github.com/Telmate/proxmox-api-go/test/cli/Storage/storage-sub-tests"
 )
@@ -31,9 +32,9 @@ func Test_Storage_ZFSoverISCSI_Lio_0_Update_Empty(t *testing.T) {
 func Test_Storage_ZFSoverISCSI_Lio_0_Get_Empty(t *testing.T) {
 	s := storagesubtests.CloneJson(storagesubtests.ZFSoverISCSI_LioEmpty)
 	s.ID = "zfs-over-iscsi_lio-test-0"
-	s.ZFSoverISCSI.Blocksize = proxmox.PointerString("8k")
+	s.ZFSoverISCSI.Blocksize = util.Pointer("8k")
 	s.Content = &proxmox.ConfigStorageContent{
-		DiskImage: proxmox.PointerBool(true),
+		DiskImage: util.Pointer(true),
 	}
 	storagesubtests.Get(s, s.ID, t)
 }

--- a/test/cli/Storage/Storage_ZFS-over-ISCSI_LIO_1_test.go
+++ b/test/cli/Storage/Storage_ZFS-over-ISCSI_LIO_1_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	_ "github.com/Telmate/proxmox-api-go/cli/command/commands"
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 	storagesubtests "github.com/Telmate/proxmox-api-go/test/cli/Storage/storage-sub-tests"
 )
@@ -21,9 +22,9 @@ func Test_Storage_ZFSoverISCSI_Lio_1_Create_Empty(t *testing.T) {
 func Test_Storage_ZFSoverISCSI_Lio_1_Get_Empty(t *testing.T) {
 	s := storagesubtests.CloneJson(storagesubtests.ZFSoverISCSI_LioEmpty)
 	s.ID = "zfs-over-iscsi_lio-test-1"
-	s.ZFSoverISCSI.Blocksize = proxmox.PointerString("4k")
+	s.ZFSoverISCSI.Blocksize = util.Pointer("4k")
 	s.Content = &proxmox.ConfigStorageContent{
-		DiskImage: proxmox.PointerBool(true),
+		DiskImage: util.Pointer(true),
 	}
 	storagesubtests.Get(s, s.ID, t)
 }
@@ -36,7 +37,7 @@ func Test_Storage_ZFSoverISCSI_Lio_1_Update_Full(t *testing.T) {
 func Test_Storage_ZFSoverISCSI_Lio_1_Get_Full(t *testing.T) {
 	s := storagesubtests.CloneJson(storagesubtests.ZFSoverISCSI_LioFull)
 	s.ID = "zfs-over-iscsi_lio-test-1"
-	s.ZFSoverISCSI.Blocksize = proxmox.PointerString("4k")
+	s.ZFSoverISCSI.Blocksize = util.Pointer("4k")
 	storagesubtests.Get(s, s.ID, t)
 }
 

--- a/test/cli/Storage/storage-sub-tests/cephfs.go
+++ b/test/cli/Storage/storage-sub-tests/cephfs.go
@@ -3,6 +3,7 @@ package storagesubtests
 import (
 	"testing"
 
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 )
 
@@ -16,18 +17,18 @@ var CephfsFull = proxmox.ConfigStorage{
 		FSname:   "test-fs-name",
 	},
 	Content: &proxmox.ConfigStorageContent{
-		Backup:   proxmox.PointerBool(true),
-		Iso:      proxmox.PointerBool(true),
-		Snippets: proxmox.PointerBool(true),
-		Template: proxmox.PointerBool(true),
+		Backup:   util.Pointer(true),
+		Iso:      util.Pointer(true),
+		Snippets: util.Pointer(true),
+		Template: util.Pointer(true),
 	},
 	BackupRetention: &proxmox.ConfigStorageBackupRetention{
-		Last:    proxmox.PointerInt(6),
-		Hourly:  proxmox.PointerInt(5),
-		Daily:   proxmox.PointerInt(4),
-		Monthly: proxmox.PointerInt(3),
-		Weekly:  proxmox.PointerInt(2),
-		Yearly:  proxmox.PointerInt(1),
+		Last:    util.Pointer(6),
+		Hourly:  util.Pointer(5),
+		Daily:   util.Pointer(4),
+		Monthly: util.Pointer(3),
+		Weekly:  util.Pointer(2),
+		Yearly:  util.Pointer(1),
 	},
 }
 
@@ -39,7 +40,7 @@ var CephfsEmpty = proxmox.ConfigStorage{
 		FSname:   "test-fs-name",
 	},
 	Content: &proxmox.ConfigStorageContent{
-		Iso: proxmox.PointerBool(true),
+		Iso: util.Pointer(true),
 	},
 }
 
@@ -52,8 +53,8 @@ func CephfsGetFull(name string, t *testing.T) {
 func CephfsGetEmpty(name string, t *testing.T) {
 	s := CloneJson(CephfsEmpty)
 	s.ID = name
-	s.Content.Backup = proxmox.PointerBool(false)
-	s.Content.Snippets = proxmox.PointerBool(false)
-	s.Content.Template = proxmox.PointerBool(false)
+	s.Content.Backup = util.Pointer(false)
+	s.Content.Snippets = util.Pointer(false)
+	s.Content.Template = util.Pointer(false)
 	Get(s, name, t)
 }

--- a/test/cli/Storage/storage-sub-tests/directory.go
+++ b/test/cli/Storage/storage-sub-tests/directory.go
@@ -3,6 +3,7 @@ package storagesubtests
 import (
 	"testing"
 
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 )
 
@@ -12,24 +13,24 @@ var DirectoryFull = proxmox.ConfigStorage{
 	Type:   "directory",
 	Directory: &proxmox.ConfigStorageDirectory{
 		Path:          "/test",
-		Preallocation: proxmox.PointerString("full"),
+		Preallocation: util.Pointer("full"),
 		Shared:        true,
 	},
 	Content: &proxmox.ConfigStorageContent{
-		Backup:    proxmox.PointerBool(true),
-		Container: proxmox.PointerBool(true),
-		DiskImage: proxmox.PointerBool(true),
-		Iso:       proxmox.PointerBool(true),
-		Snippets:  proxmox.PointerBool(true),
-		Template:  proxmox.PointerBool(true),
+		Backup:    util.Pointer(true),
+		Container: util.Pointer(true),
+		DiskImage: util.Pointer(true),
+		Iso:       util.Pointer(true),
+		Snippets:  util.Pointer(true),
+		Template:  util.Pointer(true),
 	},
 	BackupRetention: &proxmox.ConfigStorageBackupRetention{
-		Last:    proxmox.PointerInt(6),
-		Hourly:  proxmox.PointerInt(5),
-		Daily:   proxmox.PointerInt(4),
-		Monthly: proxmox.PointerInt(3),
-		Weekly:  proxmox.PointerInt(2),
-		Yearly:  proxmox.PointerInt(1),
+		Last:    util.Pointer(6),
+		Hourly:  util.Pointer(5),
+		Daily:   util.Pointer(4),
+		Monthly: util.Pointer(3),
+		Weekly:  util.Pointer(2),
+		Yearly:  util.Pointer(1),
 	},
 }
 
@@ -39,7 +40,7 @@ var DirectoryEmpty = proxmox.ConfigStorage{
 		Path: "/test",
 	},
 	Content: &proxmox.ConfigStorageContent{
-		Iso: proxmox.PointerBool(true),
+		Iso: util.Pointer(true),
 	},
 }
 
@@ -52,11 +53,11 @@ func DirectoryGetFull(name string, t *testing.T) {
 func DirectoryGetEmpty(name string, t *testing.T) {
 	s := CloneJson(DirectoryEmpty)
 	s.ID = name
-	s.Directory.Preallocation = proxmox.PointerString("metadata")
-	s.Content.Backup = proxmox.PointerBool(false)
-	s.Content.Container = proxmox.PointerBool(false)
-	s.Content.DiskImage = proxmox.PointerBool(false)
-	s.Content.Snippets = proxmox.PointerBool(false)
-	s.Content.Template = proxmox.PointerBool(false)
+	s.Directory.Preallocation = util.Pointer("metadata")
+	s.Content.Backup = util.Pointer(false)
+	s.Content.Container = util.Pointer(false)
+	s.Content.DiskImage = util.Pointer(false)
+	s.Content.Snippets = util.Pointer(false)
+	s.Content.Template = util.Pointer(false)
 	Get(s, name, t)
 }

--- a/test/cli/Storage/storage-sub-tests/glusterfs.go
+++ b/test/cli/Storage/storage-sub-tests/glusterfs.go
@@ -3,6 +3,7 @@ package storagesubtests
 import (
 	"testing"
 
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 )
 
@@ -13,23 +14,23 @@ var GlusterfsFull = proxmox.ConfigStorage{
 	GlusterFS: &proxmox.ConfigStorageGlusterFS{
 		Server1:       "10.20.1.1",
 		Server2:       "10.20.1.2",
-		Preallocation: proxmox.PointerString("full"),
+		Preallocation: util.Pointer("full"),
 		Volume:        "test",
 	},
 	Content: &proxmox.ConfigStorageContent{
-		Backup:    proxmox.PointerBool(true),
-		DiskImage: proxmox.PointerBool(true),
-		Iso:       proxmox.PointerBool(true),
-		Snippets:  proxmox.PointerBool(true),
-		Template:  proxmox.PointerBool(true),
+		Backup:    util.Pointer(true),
+		DiskImage: util.Pointer(true),
+		Iso:       util.Pointer(true),
+		Snippets:  util.Pointer(true),
+		Template:  util.Pointer(true),
 	},
 	BackupRetention: &proxmox.ConfigStorageBackupRetention{
-		Last:    proxmox.PointerInt(6),
-		Hourly:  proxmox.PointerInt(5),
-		Daily:   proxmox.PointerInt(4),
-		Monthly: proxmox.PointerInt(3),
-		Weekly:  proxmox.PointerInt(2),
-		Yearly:  proxmox.PointerInt(1),
+		Last:    util.Pointer(6),
+		Hourly:  util.Pointer(5),
+		Daily:   util.Pointer(4),
+		Monthly: util.Pointer(3),
+		Weekly:  util.Pointer(2),
+		Yearly:  util.Pointer(1),
 	},
 }
 
@@ -40,7 +41,7 @@ var GlusterfsEmpty = proxmox.ConfigStorage{
 		Volume:  "test",
 	},
 	Content: &proxmox.ConfigStorageContent{
-		Iso: proxmox.PointerBool(true),
+		Iso: util.Pointer(true),
 	},
 }
 
@@ -53,10 +54,10 @@ func GlusterfsGetFull(name string, t *testing.T) {
 func GlusterfsGetEmpty(name string, t *testing.T) {
 	s := CloneJson(GlusterfsEmpty)
 	s.ID = name
-	s.GlusterFS.Preallocation = proxmox.PointerString("metadata")
-	s.Content.Backup = proxmox.PointerBool(false)
-	s.Content.DiskImage = proxmox.PointerBool(false)
-	s.Content.Snippets = proxmox.PointerBool(false)
-	s.Content.Template = proxmox.PointerBool(false)
+	s.GlusterFS.Preallocation = util.Pointer("metadata")
+	s.Content.Backup = util.Pointer(false)
+	s.Content.DiskImage = util.Pointer(false)
+	s.Content.Snippets = util.Pointer(false)
+	s.Content.Template = util.Pointer(false)
 	Get(s, name, t)
 }

--- a/test/cli/Storage/storage-sub-tests/iscsi.go
+++ b/test/cli/Storage/storage-sub-tests/iscsi.go
@@ -3,6 +3,7 @@ package storagesubtests
 import (
 	"testing"
 
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 )
 
@@ -15,7 +16,7 @@ var IscsiFull = proxmox.ConfigStorage{
 		Target: "target-volume",
 	},
 	Content: &proxmox.ConfigStorageContent{
-		DiskImage: proxmox.PointerBool(true),
+		DiskImage: util.Pointer(true),
 	},
 }
 
@@ -37,6 +38,6 @@ func IscsiGetFull(name string, t *testing.T) {
 func IscsiGetEmpty(name string, t *testing.T) {
 	s := CloneJson(IscsiEmpty)
 	s.ID = name
-	s.Content.DiskImage = proxmox.PointerBool(false)
+	s.Content.DiskImage = util.Pointer(false)
 	Get(s, name, t)
 }

--- a/test/cli/Storage/storage-sub-tests/lvm-thin.go
+++ b/test/cli/Storage/storage-sub-tests/lvm-thin.go
@@ -3,6 +3,7 @@ package storagesubtests
 import (
 	"testing"
 
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 )
 
@@ -15,8 +16,8 @@ var LVMThinFull = proxmox.ConfigStorage{
 		Thinpool: "data",
 	},
 	Content: &proxmox.ConfigStorageContent{
-		Container: proxmox.PointerBool(true),
-		DiskImage: proxmox.PointerBool(true),
+		Container: util.Pointer(true),
+		DiskImage: util.Pointer(true),
 	},
 }
 
@@ -27,7 +28,7 @@ var LVMThinEmpty = proxmox.ConfigStorage{
 		Thinpool: "data",
 	},
 	Content: &proxmox.ConfigStorageContent{
-		Container: proxmox.PointerBool(true),
+		Container: util.Pointer(true),
 	},
 }
 
@@ -40,6 +41,6 @@ func LVMThinGetFull(name string, t *testing.T) {
 func LVMThinGetEmpty(name string, t *testing.T) {
 	s := CloneJson(LVMThinEmpty)
 	s.ID = name
-	s.Content.DiskImage = proxmox.PointerBool(false)
+	s.Content.DiskImage = util.Pointer(false)
 	Get(s, name, t)
 }

--- a/test/cli/Storage/storage-sub-tests/lvm.go
+++ b/test/cli/Storage/storage-sub-tests/lvm.go
@@ -3,6 +3,7 @@ package storagesubtests
 import (
 	"testing"
 
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 )
 
@@ -15,8 +16,8 @@ var LVMFull = proxmox.ConfigStorage{
 		Shared: true,
 	},
 	Content: &proxmox.ConfigStorageContent{
-		Container: proxmox.PointerBool(true),
-		DiskImage: proxmox.PointerBool(true),
+		Container: util.Pointer(true),
+		DiskImage: util.Pointer(true),
 	},
 }
 
@@ -26,7 +27,7 @@ var LVMEmpty = proxmox.ConfigStorage{
 		VGname: "TestVolumeGroup",
 	},
 	Content: &proxmox.ConfigStorageContent{
-		DiskImage: proxmox.PointerBool(true),
+		DiskImage: util.Pointer(true),
 	},
 }
 
@@ -39,6 +40,6 @@ func LVMGetFull(name string, t *testing.T) {
 func LVMGetEmpty(name string, t *testing.T) {
 	s := CloneJson(LVMEmpty)
 	s.ID = name
-	s.Content.Container = proxmox.PointerBool(false)
+	s.Content.Container = util.Pointer(false)
 	Get(s, name, t)
 }

--- a/test/cli/Storage/storage-sub-tests/nfs.go
+++ b/test/cli/Storage/storage-sub-tests/nfs.go
@@ -3,6 +3,7 @@ package storagesubtests
 import (
 	"testing"
 
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 )
 
@@ -13,24 +14,24 @@ var NFSFull = proxmox.ConfigStorage{
 	NFS: &proxmox.ConfigStorageNFS{
 		Server:        "10.20.1.1",
 		Export:        "/exports",
-		Preallocation: proxmox.PointerString("full"),
-		Version:       proxmox.PointerString("4"),
+		Preallocation: util.Pointer("full"),
+		Version:       util.Pointer("4"),
 	},
 	Content: &proxmox.ConfigStorageContent{
-		Backup:    proxmox.PointerBool(true),
-		Container: proxmox.PointerBool(true),
-		DiskImage: proxmox.PointerBool(true),
-		Iso:       proxmox.PointerBool(true),
-		Snippets:  proxmox.PointerBool(true),
-		Template:  proxmox.PointerBool(true),
+		Backup:    util.Pointer(true),
+		Container: util.Pointer(true),
+		DiskImage: util.Pointer(true),
+		Iso:       util.Pointer(true),
+		Snippets:  util.Pointer(true),
+		Template:  util.Pointer(true),
 	},
 	BackupRetention: &proxmox.ConfigStorageBackupRetention{
-		Last:    proxmox.PointerInt(6),
-		Hourly:  proxmox.PointerInt(5),
-		Daily:   proxmox.PointerInt(4),
-		Monthly: proxmox.PointerInt(3),
-		Weekly:  proxmox.PointerInt(2),
-		Yearly:  proxmox.PointerInt(1),
+		Last:    util.Pointer(6),
+		Hourly:  util.Pointer(5),
+		Daily:   util.Pointer(4),
+		Monthly: util.Pointer(3),
+		Weekly:  util.Pointer(2),
+		Yearly:  util.Pointer(1),
 	},
 }
 
@@ -41,7 +42,7 @@ var NFSEmpty = proxmox.ConfigStorage{
 		Export: "/exports",
 	},
 	Content: &proxmox.ConfigStorageContent{
-		DiskImage: proxmox.PointerBool(true),
+		DiskImage: util.Pointer(true),
 	},
 }
 
@@ -54,11 +55,11 @@ func NFSGetFull(name string, t *testing.T) {
 func NFSGetEmpty(name string, t *testing.T) {
 	s := CloneJson(NFSEmpty)
 	s.ID = name
-	s.NFS.Preallocation = proxmox.PointerString("metadata")
-	s.Content.Backup = proxmox.PointerBool(false)
-	s.Content.Container = proxmox.PointerBool(false)
-	s.Content.Snippets = proxmox.PointerBool(false)
-	s.Content.Iso = proxmox.PointerBool(false)
-	s.Content.Template = proxmox.PointerBool(false)
+	s.NFS.Preallocation = util.Pointer("metadata")
+	s.Content.Backup = util.Pointer(false)
+	s.Content.Container = util.Pointer(false)
+	s.Content.Snippets = util.Pointer(false)
+	s.Content.Iso = util.Pointer(false)
+	s.Content.Template = util.Pointer(false)
 	Get(s, name, t)
 }

--- a/test/cli/Storage/storage-sub-tests/pbs.go
+++ b/test/cli/Storage/storage-sub-tests/pbs.go
@@ -1,6 +1,7 @@
 package storagesubtests
 
 import (
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 )
 
@@ -13,18 +14,18 @@ var PBSFull = proxmox.ConfigStorage{
 		Datastore:   "proxmox",
 		Username:    "root@pam",
 		Fingerprint: "B7:BC:55:10:CC:1C:63:7B:5E:5F:B7:85:81:6A:77:3D:BB:39:4B:68:33:7B:1B:11:7C:A5:AB:43:CC:F7:78:CF",
-		Port:        proxmox.PointerInt(8007),
+		Port:        util.Pointer(8007),
 	},
 	Content: &proxmox.ConfigStorageContent{
-		Backup: proxmox.PointerBool(true),
+		Backup: util.Pointer(true),
 	},
 	BackupRetention: &proxmox.ConfigStorageBackupRetention{
-		Last:    proxmox.PointerInt(6),
-		Hourly:  proxmox.PointerInt(5),
-		Daily:   proxmox.PointerInt(4),
-		Monthly: proxmox.PointerInt(3),
-		Weekly:  proxmox.PointerInt(2),
-		Yearly:  proxmox.PointerInt(1),
+		Last:    util.Pointer(6),
+		Hourly:  util.Pointer(5),
+		Daily:   util.Pointer(4),
+		Monthly: util.Pointer(3),
+		Weekly:  util.Pointer(2),
+		Yearly:  util.Pointer(1),
 	},
 }
 

--- a/test/cli/Storage/storage-sub-tests/rbd.go
+++ b/test/cli/Storage/storage-sub-tests/rbd.go
@@ -3,6 +3,7 @@ package storagesubtests
 import (
 	"testing"
 
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 )
 
@@ -18,8 +19,8 @@ var RBDFull = proxmox.ConfigStorage{
 		KRBD:      true,
 	},
 	Content: &proxmox.ConfigStorageContent{
-		Container: proxmox.PointerBool(true),
-		DiskImage: proxmox.PointerBool(true),
+		Container: util.Pointer(true),
+		DiskImage: util.Pointer(true),
 	},
 }
 
@@ -32,7 +33,7 @@ var RBDEmpty = proxmox.ConfigStorage{
 		Namespace: "ceph-namespace",
 	},
 	Content: &proxmox.ConfigStorageContent{
-		Container: proxmox.PointerBool(true),
+		Container: util.Pointer(true),
 	},
 }
 
@@ -46,6 +47,6 @@ func RBDGetEmpty(name string, t *testing.T) {
 	s := CloneJson(RBDEmpty)
 	s.ID = name
 	s.RBD.KRBD = false
-	s.Content.DiskImage = proxmox.PointerBool(false)
+	s.Content.DiskImage = util.Pointer(false)
 	Get(s, name, t)
 }

--- a/test/cli/Storage/storage-sub-tests/smb.go
+++ b/test/cli/Storage/storage-sub-tests/smb.go
@@ -3,6 +3,7 @@ package storagesubtests
 import (
 	"testing"
 
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 )
 
@@ -13,26 +14,26 @@ var SMBFull = proxmox.ConfigStorage{
 	SMB: &proxmox.ConfigStorageSMB{
 		Username:      "b.wayne",
 		Share:         "NetworkShare",
-		Preallocation: proxmox.PointerString("full"),
+		Preallocation: util.Pointer("full"),
 		Domain:        "organization.pve",
 		Server:        "10.20.1.1",
-		Version:       proxmox.PointerString("3"),
+		Version:       util.Pointer("3"),
 	},
 	Content: &proxmox.ConfigStorageContent{
-		Backup:    proxmox.PointerBool(true),
-		Container: proxmox.PointerBool(true),
-		DiskImage: proxmox.PointerBool(true),
-		Iso:       proxmox.PointerBool(true),
-		Snippets:  proxmox.PointerBool(true),
-		Template:  proxmox.PointerBool(true),
+		Backup:    util.Pointer(true),
+		Container: util.Pointer(true),
+		DiskImage: util.Pointer(true),
+		Iso:       util.Pointer(true),
+		Snippets:  util.Pointer(true),
+		Template:  util.Pointer(true),
 	},
 	BackupRetention: &proxmox.ConfigStorageBackupRetention{
-		Last:    proxmox.PointerInt(6),
-		Hourly:  proxmox.PointerInt(5),
-		Daily:   proxmox.PointerInt(4),
-		Monthly: proxmox.PointerInt(3),
-		Weekly:  proxmox.PointerInt(2),
-		Yearly:  proxmox.PointerInt(1),
+		Last:    util.Pointer(6),
+		Hourly:  util.Pointer(5),
+		Daily:   util.Pointer(4),
+		Monthly: util.Pointer(3),
+		Weekly:  util.Pointer(2),
+		Yearly:  util.Pointer(1),
 	},
 }
 
@@ -45,7 +46,7 @@ var SMBEmpty = proxmox.ConfigStorage{
 		Server:   "10.20.1.1",
 	},
 	Content: &proxmox.ConfigStorageContent{
-		Snippets: proxmox.PointerBool(true),
+		Snippets: util.Pointer(true),
 	},
 }
 
@@ -58,11 +59,11 @@ func SMBGetFull(name string, t *testing.T) {
 func SMBGetEmpty(name string, t *testing.T) {
 	s := CloneJson(SMBEmpty)
 	s.ID = name
-	s.SMB.Preallocation = proxmox.PointerString("metadata")
-	s.Content.Backup = proxmox.PointerBool(false)
-	s.Content.Container = proxmox.PointerBool(false)
-	s.Content.DiskImage = proxmox.PointerBool(false)
-	s.Content.Iso = proxmox.PointerBool(false)
-	s.Content.Template = proxmox.PointerBool(false)
+	s.SMB.Preallocation = util.Pointer("metadata")
+	s.Content.Backup = util.Pointer(false)
+	s.Content.Container = util.Pointer(false)
+	s.Content.DiskImage = util.Pointer(false)
+	s.Content.Iso = util.Pointer(false)
+	s.Content.Template = util.Pointer(false)
 	Get(s, name, t)
 }

--- a/test/cli/Storage/storage-sub-tests/zfs-over-iscsi.go
+++ b/test/cli/Storage/storage-sub-tests/zfs-over-iscsi.go
@@ -1,6 +1,7 @@
 package storagesubtests
 
 import (
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 )
 
@@ -11,13 +12,13 @@ var ZFSoverISCSIFull = proxmox.ConfigStorage{
 	ZFSoverISCSI: &proxmox.ConfigStorageZFSoverISCSI{
 		Portal:        "test-portal",
 		Pool:          "test-pool",
-		Blocksize:     proxmox.PointerString("8k"),
+		Blocksize:     util.Pointer("8k"),
 		Target:        "test-target",
 		Thinprovision: true,
 		ISCSIprovider: "iet",
 	},
 	Content: &proxmox.ConfigStorageContent{
-		DiskImage: proxmox.PointerBool(true),
+		DiskImage: util.Pointer(true),
 	},
 }
 

--- a/test/cli/Storage/storage-sub-tests/zfs-over-iscsi_comstar.go
+++ b/test/cli/Storage/storage-sub-tests/zfs-over-iscsi_comstar.go
@@ -1,6 +1,7 @@
 package storagesubtests
 
 import (
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 )
 
@@ -11,7 +12,7 @@ var ZFSoverISCSI_ComstarFull = proxmox.ConfigStorage{
 	ZFSoverISCSI: &proxmox.ConfigStorageZFSoverISCSI{
 		Portal:        "test-portal",
 		Pool:          "test-pool",
-		Blocksize:     proxmox.PointerString("8k"),
+		Blocksize:     util.Pointer("8k"),
 		Target:        "test-target",
 		Thinprovision: true,
 		ISCSIprovider: "comstar",
@@ -22,7 +23,7 @@ var ZFSoverISCSI_ComstarFull = proxmox.ConfigStorage{
 		},
 	},
 	Content: &proxmox.ConfigStorageContent{
-		DiskImage: proxmox.PointerBool(true),
+		DiskImage: util.Pointer(true),
 	},
 }
 

--- a/test/cli/Storage/storage-sub-tests/zfs-over-iscsi_istgt.go
+++ b/test/cli/Storage/storage-sub-tests/zfs-over-iscsi_istgt.go
@@ -1,6 +1,7 @@
 package storagesubtests
 
 import (
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 )
 
@@ -11,7 +12,7 @@ var ZFSoverISCSI_IstgtFull = proxmox.ConfigStorage{
 	ZFSoverISCSI: &proxmox.ConfigStorageZFSoverISCSI{
 		Portal:        "test-portal",
 		Pool:          "test-pool",
-		Blocksize:     proxmox.PointerString("8k"),
+		Blocksize:     util.Pointer("8k"),
 		Target:        "test-target",
 		Thinprovision: true,
 		ISCSIprovider: "istgt",
@@ -20,7 +21,7 @@ var ZFSoverISCSI_IstgtFull = proxmox.ConfigStorage{
 		},
 	},
 	Content: &proxmox.ConfigStorageContent{
-		DiskImage: proxmox.PointerBool(true),
+		DiskImage: util.Pointer(true),
 	},
 }
 

--- a/test/cli/Storage/storage-sub-tests/zfs-over-iscsi_lio.go
+++ b/test/cli/Storage/storage-sub-tests/zfs-over-iscsi_lio.go
@@ -1,6 +1,7 @@
 package storagesubtests
 
 import (
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 )
 
@@ -11,7 +12,7 @@ var ZFSoverISCSI_LioFull = proxmox.ConfigStorage{
 	ZFSoverISCSI: &proxmox.ConfigStorageZFSoverISCSI{
 		Portal:        "test-portal",
 		Pool:          "test-pool",
-		Blocksize:     proxmox.PointerString("8k"),
+		Blocksize:     util.Pointer("8k"),
 		Target:        "test-target",
 		Thinprovision: true,
 		ISCSIprovider: "lio",
@@ -20,7 +21,7 @@ var ZFSoverISCSI_LioFull = proxmox.ConfigStorage{
 		},
 	},
 	Content: &proxmox.ConfigStorageContent{
-		DiskImage: proxmox.PointerBool(true),
+		DiskImage: util.Pointer(true),
 	},
 }
 

--- a/test/cli/Storage/storage-sub-tests/zfs.go
+++ b/test/cli/Storage/storage-sub-tests/zfs.go
@@ -3,6 +3,7 @@ package storagesubtests
 import (
 	"testing"
 
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/Telmate/proxmox-api-go/proxmox"
 )
 
@@ -12,12 +13,12 @@ var ZFSFull = proxmox.ConfigStorage{
 	Type:   "zfs",
 	ZFS: &proxmox.ConfigStorageZFS{
 		Pool:          "test-pool",
-		Blocksize:     proxmox.PointerString("4k"),
+		Blocksize:     util.Pointer("4k"),
 		Thinprovision: true,
 	},
 	Content: &proxmox.ConfigStorageContent{
-		Container: proxmox.PointerBool(true),
-		DiskImage: proxmox.PointerBool(true),
+		Container: util.Pointer(true),
+		DiskImage: util.Pointer(true),
 	},
 }
 
@@ -27,7 +28,7 @@ var ZFSEmpty = proxmox.ConfigStorage{
 		Pool: "test-pool",
 	},
 	Content: &proxmox.ConfigStorageContent{
-		DiskImage: proxmox.PointerBool(true),
+		DiskImage: util.Pointer(true),
 	},
 }
 
@@ -40,7 +41,7 @@ func ZFSGetFull(name string, t *testing.T) {
 func ZFSGetEmpty(name string, t *testing.T) {
 	s := CloneJson(ZFSEmpty)
 	s.ID = name
-	s.ZFS.Blocksize = proxmox.PointerString("8k")
-	s.Content.Container = proxmox.PointerBool(false)
+	s.ZFS.Blocksize = util.Pointer("8k")
+	s.Content.Container = util.Pointer(false)
 	Get(s, name, t)
 }


### PR DESCRIPTION
Removed the type specific pointer creation functions and replaced it with one that uses generics.
Created the `util` package in the `internal` folder as the integration tests where using the old pointer functions. Putting it in `internal` ensures it can't be imported by a third party project.

Before:
```go
func PointerString(text string) *string {
	return &text
}

// Creates a pointer to an int
func PointerInt(number int) *int {
	return &number
}

// Creates a pointer to a bool
func PointerBool(boolean bool) *bool {
	return &boolean
}
```

After:
```go
func Pointer[T any](item T) *T {
	return &item
}
```