### PR TITLE
Feature: Optional HA settings

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -1584,6 +1584,7 @@ func (c *Client) UpdateVMPool(vmr *VmRef, pool string) (exitStatus interface{}, 
 	return
 }
 
+// deprecated use NewGuestHAFromApi() instead
 func (c *Client) ReadVMHA(vmr *VmRef) (err error) {
 	var list map[string]interface{}
 	url := fmt.Sprintf("/cluster/ha/resources/%d", vmr.vmId)
@@ -1602,6 +1603,7 @@ func (c *Client) ReadVMHA(vmr *VmRef) (err error) {
 	return
 }
 
+// deprecated use GuestHA.Set() instead
 func (c *Client) UpdateVMHA(vmr *VmRef, haState HaState, haGroup HaGroupName) (exitStatus interface{}, err error) {
 	// Same hastate & hagroup
 	if vmr.haState == haState && vmr.haGroup == haGroup {

--- a/proxmox/config_ha.go
+++ b/proxmox/config_ha.go
@@ -1,0 +1,211 @@
+package proxmox
+
+import (
+	"errors"
+	"strconv"
+	"strings"
+)
+
+type GuestHA struct {
+	Comment     string      `json:"comment"`          // Description.
+	Delete      bool        `json:"remove,omitempty"` // When true, remove HA settings for the Guest.
+	Group       HaGroupName `json:"group"`            // May be empty, in which case the guest is not part of a group.
+	Reallocates HaRelocate  `json:"reallocates"`
+	Restarts    HaRestart   `json:"restarts"`
+	State       *HaState    `json:"state"`
+}
+
+// TODO change type when we have a custom type for guestID
+func (g GuestHA) mapToApi(guestID int) map[string]interface{} {
+	params := map[string]interface{}{
+		"max_restart":  int(g.Restarts),
+		"max_relocate": int(g.Reallocates),
+	}
+	if g.State != nil {
+		params["state"] = string(*g.State)
+	}
+	if guestID > 0 { // Update
+		params["comment"] = g.Comment
+		params["sid"] = guestID
+		if g.Group != "" {
+			params["group"] = string(g.Group)
+		} else {
+			params["delete"] = "group"
+		}
+	} else { // Create
+		if g.Comment != "" {
+			params["comment"] = g.Comment
+		}
+		if g.Group != "" {
+			params["group"] = string(g.Group)
+		}
+	}
+	return params
+}
+
+func (GuestHA) mapToSDK(params map[string]interface{}) (config GuestHA) {
+	if itemValue, isSet := params["comment"]; isSet {
+		config.Comment = itemValue.(string)
+	}
+	if itemValue, isSet := params["group"]; isSet {
+		config.Group = HaGroupName(itemValue.(string))
+	}
+	if itemValue, isSet := params["max_relocate"]; isSet {
+		config.Reallocates = HaRelocate(itemValue.(float64))
+	}
+	if itemValue, isSet := params["max_restart"]; isSet {
+		config.Restarts = HaRestart(itemValue.(float64))
+	}
+	if itemValue, isSet := params["state"]; isSet {
+		state := HaState(itemValue.(string))
+		config.State = &state
+	}
+	return
+}
+
+func (g GuestHA) Set(vmr *VmRef, client *Client) (err error) {
+	if err = g.Validate(); err != nil {
+		return
+	}
+	ha, err := NewGuestHAFromApi(vmr, client)
+	if err != nil {
+		return
+	}
+	return g.Set_Unsafe(ha, vmr, client)
+}
+
+func (g GuestHA) Set_Unsafe(current *GuestHA, vmr *VmRef, client *Client) (err error) {
+	if current == nil { // create
+		if err = client.Post(g.mapToApi(vmr.vmId), "/cluster/ha/resources"); err != nil {
+			return
+		}
+		if g.State != nil {
+			vmr.haState = *g.State
+		}
+		vmr.haGroup = g.Group
+		return
+	}
+	if g.Delete { // delete
+		if err = client.Delete("/cluster/ha/resources/" + strconv.FormatInt(int64(vmr.vmId), 10)); err != nil {
+			return
+		}
+		vmr.haState = ""
+		vmr.haGroup = ""
+		return
+	}
+	// update
+	if err = client.Put(g.mapToApi(0), "/cluster/ha/resources/"+strconv.FormatInt(int64(vmr.vmId), 10)); err != nil {
+		return
+	}
+	if g.State != nil {
+		vmr.haState = *g.State
+	}
+	vmr.haGroup = g.Group
+	return
+}
+
+func (g GuestHA) Validate() (err error) {
+	if g.Group != "" {
+		if err = g.Group.Validate(); err != nil {
+			return
+		}
+	}
+	if g.State != nil {
+		return g.State.Validate()
+	}
+	if err = g.Reallocates.Validate(); err != nil {
+		return
+	}
+	return g.Restarts.Validate()
+}
+
+type HaGroupName string
+
+const (
+	HaGroupName_Error_Length              string = "HaGroupName should be at least 2 characters long"
+	HaGroupName_Error_Illegal_Start       string = "HaGroupName may only start with the following characters:" + haGroupName_Characters_Legal_Starting
+	HaGroupName_Error_Illegal_End         string = "HaGroupName may only end with the following characters:" + haGroupName_Characters_Legal_Ending
+	HaGroupName_Error_Illegal             string = "HaGroupName may only contain the following characters:" + haGroupName_Characters_Legal
+	haGroupName_Characters_Legal_Starting string = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	haGroupName_Characters_Legal_Ending   string = haGroupName_Characters_Legal_Starting + "12345678890"
+	haGroupName_Characters_Legal          string = haGroupName_Characters_Legal_Starting + ".-_" + haGroupName_Characters_Legal_Ending
+)
+
+func (g HaGroupName) Validate() error {
+	if len(g) < 2 {
+		return errors.New(HaGroupName_Error_Length)
+	}
+	if !strings.Contains(haGroupName_Characters_Legal_Starting, string(g[0])) {
+		return errors.New(HaGroupName_Error_Illegal_Start)
+	}
+	if !strings.Contains(haGroupName_Characters_Legal_Ending, string(g[len(g)-1])) {
+		return errors.New(HaGroupName_Error_Illegal_End)
+	}
+	for _, c := range g {
+		if !strings.Contains(haGroupName_Characters_Legal, string(c)) {
+			return errors.New(HaGroupName_Error_Illegal)
+		}
+	}
+	return nil
+}
+
+type HaRelocate uint8
+
+const HaRelocate_Error_UpperBound string = "HaRelocate should be less or equal to 10"
+
+func (r HaRelocate) Validate() error {
+	if r > 10 {
+		return errors.New(HaRelocate_Error_UpperBound)
+	}
+	return nil
+}
+
+type HaRestart uint8
+
+const HaRestart_Error_UpperBound string = "HaRestart should be less or equal to 10"
+
+func (r HaRestart) Validate() error {
+	if r > 10 {
+		return errors.New(HaRestart_Error_UpperBound)
+	}
+	return nil
+}
+
+type HaState string // enum
+
+const (
+	HaState_Disabled      HaState = "disabled"
+	HaState_Ignored       HaState = "ignored"
+	HaState_Started       HaState = "started"
+	HaState_Stopped       HaState = "stopped"
+	HaState_Error_Invalid string  = string("HaState should be one of: " + HaState_Disabled + "," + HaState_Ignored + "," + HaState_Started + "," + HaState_Stopped)
+)
+
+func (s HaState) Validate() error {
+	switch s {
+	case HaState_Disabled, HaState_Ignored, HaState_Started, HaState_Stopped:
+		return nil
+	}
+	return errors.New(HaState_Error_Invalid)
+}
+
+func NewGuestHAFromApi(vmr *VmRef, client *Client) (*GuestHA, error) {
+	if err := vmr.nilCheck(); err != nil {
+		return nil, err
+	}
+	if client == nil {
+		return nil, errors.New(Client_Error_Nil)
+	}
+	guestID := strconv.FormatInt(int64(vmr.vmId), 10)
+	params, err := client.GetItemConfigMapStringInterface("/cluster/ha/resources/"+guestID, "", "")
+	if err != nil {
+		if err.Error() == noSuchResource+" 'vm:"+guestID+"'" || err.Error() == noSuchResource+" 'ct:"+guestID+"'" {
+			return nil, nil
+		}
+		return nil, err
+	}
+	ha := GuestHA{}.mapToSDK(params)
+	vmr.haState = *ha.State
+	vmr.haGroup = ha.Group
+	return &ha, nil
+}

--- a/proxmox/config_ha_test.go
+++ b/proxmox/config_ha_test.go
@@ -1,0 +1,315 @@
+package proxmox
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_GuestHA_mapToApi(t *testing.T) {
+	PointerHaState := func(i HaState) *HaState { return &i } // TODO remove when we have a generic pointer function
+	type testInput struct {
+		vmID   int
+		config GuestHA
+	}
+	tests := []struct {
+		name   string
+		input  testInput
+		output map[string]interface{}
+	}{
+		{name: "Test Comment Create",
+			input: testInput{config: GuestHA{Comment: "abc"}},
+			output: map[string]interface{}{
+				"comment":      "abc",
+				"max_relocate": 0,
+				"max_restart":  0}},
+		{name: "Test Comment Update",
+			input: testInput{vmID: 100, config: GuestHA{Comment: "abc"}},
+			output: map[string]interface{}{
+				"comment":      "abc",
+				"delete":       "group",
+				"max_relocate": 0,
+				"max_restart":  0,
+				"sid":          100}},
+		{name: "Test Full Create",
+			input: testInput{
+				config: GuestHA{
+					Comment:     "test",
+					Delete:      true,
+					Group:       "test-group",
+					Reallocates: 1,
+					Restarts:    10,
+					State:       PointerHaState(HaState_Started)}},
+			output: map[string]interface{}{
+				"comment":      "test",
+				"group":        "test-group",
+				"max_relocate": 1,
+				"max_restart":  10,
+				"state":        "started"}},
+		{name: "Test Full Update",
+			input: testInput{vmID: 100, config: GuestHA{
+				Comment:     "test",
+				Delete:      true,
+				Group:       "test-group",
+				Reallocates: 10,
+				Restarts:    1,
+				State:       PointerHaState(HaState_Stopped)}},
+			output: map[string]interface{}{
+				"comment":      "test",
+				"group":        "test-group",
+				"max_relocate": 10,
+				"max_restart":  1,
+				"sid":          100,
+				"state":        "stopped"}},
+		{name: "Test Group Create",
+			input: testInput{config: GuestHA{Group: "test-group"}},
+			output: map[string]interface{}{
+				"group":        "test-group",
+				"max_relocate": 0,
+				"max_restart":  0}},
+		{name: "Test Group Update",
+			input: testInput{vmID: 100, config: GuestHA{Group: "test-group"}},
+			output: map[string]interface{}{
+				"comment":      "",
+				"group":        "test-group",
+				"max_relocate": 0,
+				"max_restart":  0,
+				"sid":          100}},
+		{name: "Test Reallocates Create",
+			input: testInput{config: GuestHA{Reallocates: 10}},
+			output: map[string]interface{}{
+				"max_relocate": 10,
+				"max_restart":  0}},
+		{name: "Test Reallocates Update",
+			input: testInput{vmID: 100, config: GuestHA{Reallocates: 10}},
+			output: map[string]interface{}{
+				"comment":      "",
+				"delete":       "group",
+				"max_relocate": 10,
+				"max_restart":  0,
+				"sid":          100}},
+		{name: "Test Restarts Create",
+			input: testInput{config: GuestHA{Restarts: 10}},
+			output: map[string]interface{}{
+				"max_relocate": 0,
+				"max_restart":  10}},
+		{name: "Test Restarts Update",
+			input: testInput{vmID: 100, config: GuestHA{Restarts: 10}},
+			output: map[string]interface{}{
+				"comment":      "",
+				"delete":       "group",
+				"max_relocate": 0,
+				"max_restart":  10,
+				"sid":          100}},
+		{name: "Test State Create",
+			input: testInput{config: GuestHA{State: PointerHaState(HaState_Started)}},
+			output: map[string]interface{}{
+				"max_relocate": 0,
+				"max_restart":  0,
+				"state":        "started"}},
+		{name: "Test State Create nil",
+			input: testInput{config: GuestHA{State: nil}},
+			output: map[string]interface{}{
+				"max_relocate": 0,
+				"max_restart":  0}},
+		{name: "Test State Update",
+			input: testInput{vmID: 100, config: GuestHA{State: PointerHaState(HaState_Started)}},
+			output: map[string]interface{}{
+				"comment":      "",
+				"delete":       "group",
+				"max_relocate": 0,
+				"max_restart":  0,
+				"sid":          100,
+				"state":        "started"}},
+		{name: "Test State Update nil",
+			input: testInput{vmID: 100, config: GuestHA{State: nil}},
+			output: map[string]interface{}{
+				"comment":      "",
+				"delete":       "group",
+				"max_relocate": 0,
+				"max_restart":  0,
+				"sid":          100}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.output, test.input.config.mapToApi(test.input.vmID), test.name)
+		})
+	}
+}
+
+func Test_GuestHA_mapToSDK(t *testing.T) {
+	PointerHaState := func(i HaState) *HaState { return &i } // TODO remove when we have a generic pointer function
+	tests := []struct {
+		name   string
+		input  map[string]interface{}
+		output GuestHA
+	}{
+		{name: "Test Comment",
+			input:  map[string]interface{}{"comment": "abc"},
+			output: GuestHA{Comment: "abc"}},
+		{name: "Test Full",
+			input: map[string]interface{}{
+				"comment":      "test",
+				"group":        "test-group",
+				"max_relocate": float64(10),
+				"max_restart":  float64(1),
+				"state":        "stopped"},
+			output: GuestHA{
+				Comment:     "test",
+				Group:       HaGroupName("test-group"),
+				Reallocates: 10,
+				Restarts:    1,
+				State:       PointerHaState(HaState_Stopped)}},
+		{name: "Test Group",
+			input:  map[string]interface{}{"group": "test-group"},
+			output: GuestHA{Group: "test-group"}},
+		{name: "Test Reallocates",
+			input:  map[string]interface{}{"max_relocate": float64(10)},
+			output: GuestHA{Reallocates: 10}},
+		{name: "Test Restarts",
+			input:  map[string]interface{}{"max_restart": float64(10)},
+			output: GuestHA{Restarts: 10}},
+		{name: "Test State",
+			input:  map[string]interface{}{"state": "started"},
+			output: GuestHA{State: PointerHaState(HaState_Started)}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.output, GuestHA{}.mapToSDK(test.input), test.name)
+		})
+	}
+}
+
+func Test_GuestHA_Set(t *testing.T) {
+	type testInput struct {
+		vmr *VmRef
+		c   *Client
+	}
+	tests := []struct {
+		name  string
+		input testInput
+	}{
+		{name: "* nil", input: testInput{vmr: &VmRef{}}},
+		{name: "nil *", input: testInput{c: &Client{}}},
+		{name: "nil nil", input: testInput{}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.NotPanics(t, func() { GuestHA{}.Set(test.input.vmr, test.input.c) }, test.name)
+		})
+	}
+}
+
+func Test_GuestHA_Validate(t *testing.T) {
+	PointerHaState := func(i HaState) *HaState { return &i } // TODO remove when we have a generic pointer function
+	tests := []struct {
+		name   string
+		input  GuestHA
+		output error
+	}{
+		{name: "Invalid Group", input: GuestHA{Group: "inv&lid"}, output: errors.New(HaGroupName_Error_Illegal)},
+		{name: "Invalid Reallocates", input: GuestHA{Reallocates: 11}, output: errors.New(HaRelocate_Error_UpperBound)},
+		{name: "Invalid Restarts", input: GuestHA{Restarts: 11}, output: errors.New(HaRestart_Error_UpperBound)},
+		{name: "Invalid State", input: GuestHA{State: PointerHaState("invalid")}, output: errors.New(HaState_Error_Invalid)},
+		{name: "Valid", input: GuestHA{}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.output, test.input.Validate(), test.name)
+		})
+	}
+}
+
+func Test_HaGroupName_Validate(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  HaGroupName
+		output error
+	}{
+		{name: "Invalid Length", input: "i", output: errors.New(HaGroupName_Error_Length)},
+		{name: "Invalid Illegal", input: "inv&^%lid", output: errors.New(HaGroupName_Error_Illegal)},
+		{name: "Invalid Illegal_End", input: "invalid&", output: errors.New(HaGroupName_Error_Illegal_End)},
+		{name: "Invalid Illegal_Start", input: "0invalid", output: errors.New(HaGroupName_Error_Illegal_Start)},
+		{name: "Valid", input: "valid"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.output, test.input.Validate(), test.name)
+		})
+	}
+}
+
+func Test_HaRelocate_Validate(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  HaRelocate
+		output error
+	}{
+		{name: "Invalid Upper Bound", input: 11, output: errors.New(HaRelocate_Error_UpperBound)},
+		{name: "Valid Lower Bound", input: 0},
+		{name: "Valid Upper Bound", input: 10},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.output, test.input.Validate(), test.name)
+		})
+	}
+}
+
+func Test_HaRestart_Validate(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  HaRestart
+		output error
+	}{
+		{name: "Invalid Upper Bound", input: 11, output: errors.New(HaRestart_Error_UpperBound)},
+		{name: "Valid Lower Bound", input: 0},
+		{name: "Valid Upper Bound", input: 10},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.output, test.input.Validate(), test.name)
+		})
+	}
+}
+
+func Test_HaState_Validate(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  HaState
+		output error
+	}{
+		{name: "Invalid", input: "invalid", output: errors.New(HaState_Error_Invalid)},
+		{name: "Valid Disabled", input: HaState_Disabled},
+		{name: "Valid Ignored", input: HaState_Ignored},
+		{name: "Valid Started", input: HaState_Started},
+		{name: "Valid Stopped", input: HaState_Stopped},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.output, test.input.Validate(), test.name)
+		})
+	}
+}
+
+func Test_NewGuestHAFromApi(t *testing.T) {
+	type testInput struct {
+		vmr *VmRef
+		c   *Client
+	}
+	tests := []struct {
+		name   string
+		input  testInput
+		output GuestHA
+	}{
+		{name: "* nil", input: testInput{vmr: &VmRef{}}, output: GuestHA{}},
+		{name: "nil *", input: testInput{c: &Client{}}, output: GuestHA{}},
+		{name: "nil nil", input: testInput{}, output: GuestHA{}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.NotPanics(t, func() { NewGuestHAFromApi(test.input.vmr, test.input.c) }, test.name)
+		})
+	}
+}

--- a/proxmox/config_hagroup.go
+++ b/proxmox/config_hagroup.go
@@ -6,12 +6,12 @@ import (
 )
 
 type HAGroup struct {
-	Comment    string   // Description.
-	Group      string   // The HA group identifier.
-	Nodes      []string // List of cluster node names with optional priority. LIKE: <node>[:<pri>]{,<node>[:<pri>]}*
-	NoFailback bool     // The CRM tries to run services on the node with the highest priority. If a node with higher priority comes online, the CRM migrates the service to that node. Enabling nofailback prevents that behavior.
-	Restricted bool     // Resources bound to restricted groups may only run on nodes defined by the group.
-	Type       string   // Group type
+	Comment    string      // Description.
+	Group      HaGroupName // The HA group identifier.
+	Nodes      []string    // List of cluster node names with optional priority. LIKE: <node>[:<pri>]{,<node>[:<pri>]}*
+	NoFailback bool        // The CRM tries to run services on the node with the highest priority. If a node with higher priority comes online, the CRM migrates the service to that node. Enabling nofailback prevents that behavior.
+	Restricted bool        // Resources bound to restricted groups may only run on nodes defined by the group.
+	Type       string      // Group type
 }
 
 func (c *Client) GetHAGroupList() (haGroups []HAGroup, err error) {
@@ -28,7 +28,7 @@ func (c *Client) GetHAGroupList() (haGroups []HAGroup, err error) {
 
 		haGroups = append(haGroups, HAGroup{
 			Comment:    itemMap["comment"].(string),
-			Group:      itemMap["group"].(string),
+			Group:      HaGroupName(itemMap["group"].(string)),
 			Nodes:      strings.Split(itemMap["nodes"].(string), ","),
 			NoFailback: itemMap["nofailback"].(float64) == 1,
 			Restricted: itemMap["restricted"].(float64) == 1,
@@ -39,7 +39,7 @@ func (c *Client) GetHAGroupList() (haGroups []HAGroup, err error) {
 	return haGroups, nil
 }
 
-func (c *Client) GetHAGroupByName(GroupName string) (*HAGroup, error) {
+func (c *Client) GetHAGroupByName(GroupName HaGroupName) (*HAGroup, error) {
 	groups, err := c.GetHAGroupList()
 
 	if err != nil {
@@ -52,5 +52,5 @@ func (c *Client) GetHAGroupByName(GroupName string) (*HAGroup, error) {
 		}
 	}
 
-	return nil, errors.New("cannot find HaGroup by name " + GroupName)
+	return nil, errors.New("cannot find HaGroup by name " + string(GroupName))
 }


### PR DESCRIPTION
Add support for all guest HA options.

These HA settings have been added as an optional substructure to `ConfigQemu` and `ConfigLxc`, not setting this means that the HA settings won't be updated.

The following type changes where made:

Before:
```go 
type VmRef struct {
 haState string
 haGroup string
}
type HAGroup struct {
 Group string // The HA group identifier.
}
```

After:
```go
type VmRef struct {
 haState HaState
 haGroup HaGroupName
}
type HAGroup struct {
 Group HaGroupName // The HA group identifier.
}
```

Marked the following as deprecated `*Client.ReadVMHA()` `*Client.UpdateVMHA()`



Will make a corresponding pr to the Terraform provider as well.

Closes #314