### PR TITLE
Feature: TPM State

### DIFF
--- a/proxmox/config_qemu_tpm.go
+++ b/proxmox/config_qemu_tpm.go
@@ -1,0 +1,94 @@
+package proxmox
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/Telmate/proxmox-api-go/internal/util"
+)
+
+type TpmState struct {
+	Delete  bool        `json:"remove,omitempty"`  // If true, the tpmstate will be deleted.
+	Storage string      `json:"storage"`           // TODO change to proper type once the type is added.
+	Version *TpmVersion `json:"version,omitempty"` // Changing version will delete the current tpmstate and create a new one. Optional during update, required during create.
+}
+
+const TmpState_Error_VersionRequired string = "version is required"
+
+func (t TpmState) mapToApi(params map[string]interface{}, currentTpm *TpmState) string {
+	if t.Delete {
+		return "tpmstate0"
+	}
+	if currentTpm == nil { // create
+		params["tpmstate0"] = t.Storage + ":1,version=" + t.Version.mapToApi()
+	}
+	return ""
+}
+
+func (TpmState) mapToSDK(param string) *TpmState {
+	setting := splitStringOfSettings(param)
+	splitString := strings.Split(param, ":")
+	tmp := TpmState{}
+	if len(splitString) > 1 {
+		tmp.Storage = splitString[0]
+	}
+	if itemValue, isSet := setting["version"]; isSet {
+		tmp.Version = util.Pointer(TpmVersion(itemValue.(string)))
+	}
+	return &tmp
+
+}
+
+func (t TpmState) markChanges(currentTpm TpmState) (delete string, disk *qemuDiskMove) {
+	if t.Delete {
+		return "", nil
+	}
+	if t.Version != nil && t.Version.mapToApi() != string(*currentTpm.Version) {
+		return "tpmstate0", nil
+	}
+	if t.Storage != currentTpm.Storage {
+		return "", &qemuDiskMove{Storage: t.Storage, Id: "tpmstate0"}
+	}
+	return "", nil
+}
+
+func (t TpmState) Validate(current *TpmState) error {
+	if t.Storage == "" {
+		return errors.New("storage is required")
+	}
+	if t.Version == nil {
+		if current == nil { // create
+			return errors.New(TmpState_Error_VersionRequired)
+		}
+	} else {
+		if err := t.Version.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+type TpmVersion string // enum
+
+const (
+	TpmVersion_1_2           TpmVersion = "v1.2"
+	TpmVersion_2_0           TpmVersion = "v2.0"
+	TpmVersion_Error_Invalid string     = "enum TmpVersion should be one of: " + string(TpmVersion_1_2) + ", " + string(TpmVersion_2_0)
+)
+
+func (t TpmVersion) mapToApi() string {
+	switch t {
+	case TpmVersion_1_2, "1.2":
+		return string(t)
+	case TpmVersion_2_0, "v2", "2.0", "2":
+		return string(TpmVersion_2_0)
+	}
+	return ""
+}
+
+func (t TpmVersion) Validate() error {
+	if t.mapToApi() == "" {
+		return errors.New(TpmVersion_Error_Invalid)
+	}
+	return nil
+}

--- a/proxmox/config_qemu_tpm_test.go
+++ b/proxmox/config_qemu_tpm_test.go
@@ -1,0 +1,65 @@
+package proxmox
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Telmate/proxmox-api-go/internal/util"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_TpmState_Validate(t *testing.T) {
+	type testInput struct {
+		config  TpmState
+		current *TpmState
+	}
+	tests := []struct {
+		name   string
+		input  testInput
+		output error
+	}{
+		{name: `Invalid Storage Create`, input: testInput{
+			config: TpmState{Storage: ""}},
+			output: errors.New("storage is required")},
+		{name: `Invalid Storage Update`, input: testInput{
+			config:  TpmState{Storage: ""},
+			current: &TpmState{Storage: "local-lvm"}},
+			output: errors.New("storage is required")},
+		{name: `Invalid Version=nil Create`, input: testInput{
+			config: TpmState{Storage: "local-lvm"}},
+			output: errors.New(TmpState_Error_VersionRequired)},
+		{name: `Invalid Version="" Create`, input: testInput{
+			config: TpmState{Storage: "local-lvm", Version: util.Pointer(TpmVersion(""))}},
+			output: errors.New(TpmVersion_Error_Invalid)},
+		{name: `Invalid Version="" Update`, input: testInput{
+			config:  TpmState{Storage: "local-lvm", Version: util.Pointer(TpmVersion(""))},
+			current: &TpmState{Storage: "local-lvm", Version: util.Pointer(TpmVersion("v2.0"))}},
+			output: errors.New(TpmVersion_Error_Invalid)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.output, test.input.config.Validate(test.input.current))
+		})
+	}
+}
+
+func Test_TpmVersion_Validate(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  TpmVersion
+		output error
+	}{
+		{name: "Valid v1.2", input: TpmVersion_1_2},
+		{name: "Valid v2.0", input: TpmVersion_2_0},
+		{name: "Valid 1.2", input: "1.2"},
+		{name: "Valid 2", input: "2"},
+		{name: "Valid 2.0", input: "2.0"},
+		{name: "Valid v2", input: "v2"},
+		{name: `Invalid ""`, output: errors.New(TpmVersion_Error_Invalid)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.output, test.input.Validate())
+		})
+	}
+}


### PR DESCRIPTION
Adding support for `tpmstate0`

During testing of  #321
I came to the conclusion that there isn't a way of updating the TPM state in proxmox, it has to be recreated.
The TPM state also acts like a Disk in the sense that it can be migrated to a different storage.

Closes #241

P.S. at some point I'll restructure the test in `proxmox/config_qemu_test.go` as it is becoming quite unwieldy. 