### PR TITLE
Include ConfigQemu.Agent when creating params struct even when 0

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -182,14 +182,13 @@ func (config ConfigQemu) mapToApiValues(currentConfig ConfigQemu) (rebootRequire
 
 	params = map[string]interface{}{}
 
+	params["agent"] = config.Agent
+
 	if config.VmID != 0 {
 		params["vmid"] = config.VmID
 	}
 	if config.Args != "" {
 		params["args"] = config.Args
-	}
-	if config.Agent != 0 {
-		params["agent"] = config.Agent
 	}
 	if config.Balloon >= 1 {
 		params["balloon"] = config.Balloon


### PR DESCRIPTION
The current code does not set `params["agent"]` to `0` when set to `0` in `ConfigQemu.Agent`, erroneously identifying `0` as "no value", making it never possible to e.g. update from agent `1` to `0`. I believe this is an error, let me know if not. 😬 