### PR TITLE
fix: dashes in tags allowed everywhere but at the start of tag

### DIFF
--- a/proxmox/type_tag.go
+++ b/proxmox/type_tag.go
@@ -9,11 +9,11 @@ import (
 type Tag string
 
 var (
-	regexTag = regexp.MustCompile(`^[a-z0-9_]+$`)
+	regexTag = regexp.MustCompile(`^[a-z0-9_][a-z0-9_-]*$`)
 )
 
 const (
-	Tag_Error_Invalid   string = "tag may only include the following characters: abcdefghijklmnopqrstuvwxyz0123456789_"
+	Tag_Error_Invalid   string = "tag may not start with - and may only include the following characters: abcdefghijklmnopqrstuvwxyz0123456789_-"
 	Tag_Error_Duplicate string = "duplicate tag found"
 	Tag_Error_MaxLength string = "tag may only be 124 characters"
 	Tag_Error_Empty     string = "tag may not be empty"

--- a/test/data/test_data_tag/type_Tag.go
+++ b/test/data/test_data_tag/type_Tag.go
@@ -22,7 +22,6 @@ func Tag_Character_Illegal() []string {
 		`Tag'Name`,
 		`Tag~Name`,
 		`Name<Tag`,
-		`dash-first`,
 		`tag.with.dot`,
 		`tag,with,comma`,
 		`tag:name`,
@@ -30,6 +29,7 @@ func Tag_Character_Illegal() []string {
 		`Tag[Bracket]`,
 		`Tag{Name}`,
 		`!InvalidTag`,
+		`-StartWithDashTag`,
 	}, Tag_Illegal())
 }
 
@@ -64,5 +64,6 @@ func Tag_Legal() []string {
 		`programming`,
 		`python`,
 		`72d1109e_97f6_41e7_96cc_18a8b7dc19dc`,
+		`dash-tag`,
 	}, Tag_Max_Legal())
 }


### PR DESCRIPTION
## Issue
https://github.com/Telmate/proxmox-api-go/issues/340

Tags now are allowed to have dash in every, but first character.

## Comment

Kept original invalid formatting error and modifying regex to limit logic branching as much as possible, added red, green example to existing tag tests.