### PR TITLE
feat: implement ability to clone Qemu VM to different storage

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -40,7 +40,7 @@ type ConfigQemu struct {
 	Description     *string         `json:"description,omitempty"`
 	Disks           *QemuStorages   `json:"disks,omitempty"`
 	EFIDisk         QemuDevice      `json:"efidisk,omitempty"`   // TODO should be a struct
-	Storage         string          `json:"storage,omitempty"`   // for clone
+	Storage         string          `json:"storage,omitempty"`   // this value is only used when doing a full clone and is never returned
 	FullClone       *int            `json:"fullclone,omitempty"` // TODO should probably be a bool
 	HaGroup         string          `json:"hagroup,omitempty"`
 	HaState         string          `json:"hastate,omitempty"` // TODO should be custom type with enum

--- a/test/api/Qemu/qemu_clone_test.go
+++ b/test/api/Qemu/qemu_clone_test.go
@@ -35,6 +35,27 @@ func Test_Clone_Qemu_VM(t *testing.T) {
 
 }
 
+func Test_Clone_Qemu_VM_To_Different_Storage(t *testing.T) {
+	Test := api_test.Test{}
+	_ = Test.CreateTest()
+	config := _create_vm_spec(false)
+
+	config.Create(_create_vmref(), Test.GetClient())
+
+	cloneConfig := _create_vm_spec(false)
+
+	fullClone := 1
+
+	cloneConfig.Name = "test-qemu02"
+	cloneConfig.FullClone = &fullClone
+	cloneConfig.Storage = "other-storage"
+
+	err := cloneConfig.CloneVm(_create_vmref(), _create_clone_vmref(), Test.GetClient())
+
+	require.NoError(t, err)
+
+}
+
 func Test_Qemu_VM_Is_Cloned(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()


### PR DESCRIPTION
Hi,

I want to create a clone to a different storage as it is possible through the Web UI and I noticed that this option is already documented in the README.md, but not yet implemented.

The changes in this PR will allow cloning a Qemu VM to a different storage location without changing the original configuration.

I also added a unit test, but I could not run and verify the unit test with `make test`. I did not found out how to setup the unit test so the new storage `other-storage` will exist when the unit test runs. Should I keep the new unit test, or should I remove it?

Nevertheless I testet the change on my Proxmox 8 and it worked.

If there is anything I can improve in this PR, please let me know :wink:.