### PR TITLE
CI parallel

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,39 +6,88 @@ on:
   pull_request:
     branches: [master]
 
-jobs:
+env:
+  GO_VERSION: '1.21'
 
-  audit:
+jobs:
+  verify-dependencies:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+      - name: Verify dependencies
+        run: go mod verify
 
-    - name: Set up Go
-      uses: actions/setup-go@v2
-      with:
-        go-version: '1.21'
-        check-latest: true
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+      - name: Build
+        run: go build -v ./...
 
-    - name: Verify dependencies
-      run: go mod verify
+  vet:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+      - name: Run go vet
+        run: go vet ./...
 
-    - name: Build
-      run: go build -v ./...
+  staticcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+      - name: Install staticcheck
+        run: go install honnef.co/go/tools/cmd/staticcheck@latest
+      - name: Run staticcheck
+        run: staticcheck ./...
 
-    - name: Run go vet
-      run: go vet ./...
+  golint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+      - name: Install golint
+        run: go install golang.org/x/lint/golint@latest
+      - name: Run golint
+        run: golint ./...
 
-    - name: Install staticcheck
-      run: go install honnef.co/go/tools/cmd/staticcheck@latest
-
-    # - name: Run staticcheck
-    #   run: staticcheck ./...
-
-    - name: Install golint
-      run: go install golang.org/x/lint/golint@latest
-
-    - name: Run golint
-      run: golint ./...
-
-    - name: Run proxmox unit tests
-      run: go test -race -vet=off ./proxmox/... ./internal/...
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          check-latest: true
+      - name: Run proxmox unit tests
+        run: go test -race -vet=off ./proxmox/... ./internal/...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -64,21 +64,6 @@ jobs:
       - name: Run staticcheck
         run: staticcheck ./...
 
-  golint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: Set up Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          check-latest: true
-      - name: Install golint
-        run: go install golang.org/x/lint/golint@latest
-      - name: Run golint
-        run: golint ./...
-
   test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Make separate jobs from all the tasks.
This allows for getting feedback on all jobs even if another CI job failed.
Removed `golint` as the project is archived and no longer maintained (never look at the errors anyways).