### PR TITLE
Fix: Create QEMU VMs directly in a configured Pool

### DIFF
--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -187,6 +187,9 @@ func (config ConfigQemu) mapToAPI(currentConfig ConfigQemu, version Version) (re
 	if config.Onboot != nil {
 		params["onboot"] = *config.Onboot
 	}
+	if config.Pool != nil {
+		params["pool"] = *config.Pool
+	}
 	if config.Protection != nil {
 		params["protection"] = *config.Protection
 	}
@@ -723,11 +726,6 @@ func (newConfig ConfigQemu) setAdvanced(currentConfig *ConfigQemu, rebootIfNeede
 		}
 		if err = resizeNewDisks(vmr, client, newConfig.Disks, nil); err != nil {
 			return
-		}
-		if newConfig.Pool != nil && *newConfig.Pool != "" { // add guest to pool
-			if err = newConfig.Pool.addGuests_Unsafe(client, []uint{uint(vmr.vmId)}, nil, version); err != nil {
-				return
-			}
 		}
 		if err = client.insertCachedPermission(permissionPath(permissionCategory_GuestPath) + "/" + permissionPath(strconv.Itoa(vmr.vmId))); err != nil {
 			return

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -187,9 +187,6 @@ func (config ConfigQemu) mapToAPI(currentConfig ConfigQemu, version Version) (re
 	if config.Onboot != nil {
 		params["onboot"] = *config.Onboot
 	}
-	if config.Pool != nil {
-		params["pool"] = *config.Pool
-	}
 	if config.Protection != nil {
 		params["protection"] = *config.Protection
 	}
@@ -719,6 +716,11 @@ func (newConfig ConfigQemu) setAdvanced(currentConfig *ConfigQemu, rebootIfNeede
 		_, params, err = newConfig.mapToAPI(ConfigQemu{}, version)
 		if err != nil {
 			return
+		}
+		// pool field unsupported by /nodes/%s/vms/%d/config used by update (currentConfig != nil).
+		// To be able to create directly in a configured pool, add pool to mapped params from ConfigQemu, before creating VM
+		if newConfig.Pool != nil && *newConfig.Pool != "" {
+			params["pool"] = *newConfig.Pool
 		}
 		exitStatus, err = client.CreateQemuVm(vmr.node, params)
 		if err != nil {

--- a/proxmox/config_qemu_test.go
+++ b/proxmox/config_qemu_test.go
@@ -3485,6 +3485,21 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					config:        &ConfigQemu{Memory: &QemuMemory{Shares: util.Pointer(QemuMemoryShares(0))}},
 					currentConfig: ConfigQemu{Memory: &QemuMemory{Shares: util.Pointer(QemuMemoryShares(20000))}},
 					output:        map[string]interface{}{"delete": "shares"}}}},
+		{category: `Pool`,
+			create: []test{
+				{name: `Pool personal`,
+					config: &ConfigQemu{Pool: util.Pointer(PoolName("personal"))},
+					output: map[string]interface{}{"pool": PoolName("personal")}}},
+			createUpdate: []test{
+				{name: `Pool shared`,
+					config:        &ConfigQemu{Pool: util.Pointer(PoolName("shared"))},
+					currentConfig: ConfigQemu{Pool: util.Pointer(PoolName("personal"))},
+					output:        map[string]interface{}{"pool": PoolName("shared")}}},
+			update: []test{
+				{name: `Pool shared`,
+					config:        &ConfigQemu{Pool: util.Pointer(PoolName("shared"))},
+					currentConfig: ConfigQemu{Pool: util.Pointer(PoolName("personal"))},
+					output:        map[string]interface{}{"pool": PoolName("shared")}}}},
 		{category: `Serials`,
 			createUpdate: []test{
 				{name: `delete non existing`,

--- a/proxmox/config_qemu_test.go
+++ b/proxmox/config_qemu_test.go
@@ -3485,21 +3485,6 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					config:        &ConfigQemu{Memory: &QemuMemory{Shares: util.Pointer(QemuMemoryShares(0))}},
 					currentConfig: ConfigQemu{Memory: &QemuMemory{Shares: util.Pointer(QemuMemoryShares(20000))}},
 					output:        map[string]interface{}{"delete": "shares"}}}},
-		{category: `Pool`,
-			create: []test{
-				{name: `Pool personal`,
-					config: &ConfigQemu{Pool: util.Pointer(PoolName("personal"))},
-					output: map[string]interface{}{"pool": PoolName("personal")}}},
-			createUpdate: []test{
-				{name: `Pool shared`,
-					config:        &ConfigQemu{Pool: util.Pointer(PoolName("shared"))},
-					currentConfig: ConfigQemu{Pool: util.Pointer(PoolName("personal"))},
-					output:        map[string]interface{}{"pool": PoolName("shared")}}},
-			update: []test{
-				{name: `Pool shared`,
-					config:        &ConfigQemu{Pool: util.Pointer(PoolName("shared"))},
-					currentConfig: ConfigQemu{Pool: util.Pointer(PoolName("personal"))},
-					output:        map[string]interface{}{"pool": PoolName("shared")}}}},
 		{category: `Serials`,
 			createUpdate: []test{
 				{name: `delete non existing`,


### PR DESCRIPTION
- Reintroduced Pool for maptoAPI (required for creating a VM within a Pool)
- Removed step to add to Pool after creating of a VM (errors `500 already a member of pool` when Pool added to maptoAPI)
- Added tests for maptoAPI for Pool

Closes #366 