### PR TITLE
tags - allow uppercase

### DIFF
--- a/proxmox/type_tag.go
+++ b/proxmox/type_tag.go
@@ -9,11 +9,11 @@ import (
 type Tag string
 
 var (
-	regexTag = regexp.MustCompile(`^[a-z0-9_][a-z0-9_-]*$`)
+	regexTag = regexp.MustCompile(`^[a-zA-Z0-9_][a-zA-Z0-9_-]*$`)
 )
 
 const (
-	Tag_Error_Invalid   string = "tag may not start with - and may only include the following characters: abcdefghijklmnopqrstuvwxyz0123456789_-"
+	Tag_Error_Invalid   string = "tag may not start with - and may only include the following characters: abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
 	Tag_Error_Duplicate string = "duplicate tag found"
 	Tag_Error_MaxLength string = "tag may only be 124 characters"
 	Tag_Error_Empty     string = "tag may not be empty"

--- a/test/data/test_data_tag/type_Tag.go
+++ b/test/data/test_data_tag/type_Tag.go
@@ -10,7 +10,6 @@ func Tag_Character_Illegal() []string {
 		`Tag with space`,
 		`Tag&`,
 		`Tag*Name`,
-		`Tag-Name`,
 		`Tag#Name`,
 		`Tag(Name)`,
 		`Tag/Name`,
@@ -65,5 +64,6 @@ func Tag_Legal() []string {
 		`python`,
 		`72d1109e_97f6_41e7_96cc_18a8b7dc19dc`,
 		`dash-tag`,
+		`TagName`,
 	}, Tag_Max_Legal())
 }


### PR DESCRIPTION
Tags should be allowed to have uppercase letters.
There is an option in the Datacenter > Options > Tag Style Override to enforce case-sensitivity. When this is enabled, existing tags with capital letters cannot be assigned via this api.
I originally encountered this issue using [Telmate/terraform-provider-proxmox](https://github.com/Telmate/terraform-provider-proxmox), however it appears the root issue is in this repo which does tag validation:
https://github.com/Telmate/proxmox-api-go/blob/25d65daa0b88491c88653dbf897d87ff116c7f52/proxmox/type_tag.go#L11-L16
I think this should be a relatively simple fix, I've added A-Z to the regex, updated the error message, and moved a previously Illegal tag in the tests to the Legal list.
I've tested this change on my fork with `createQemu`, and it seems to be functioning as expected, I no longer receive an error trying to assign tags with uppercase characters. 