### PR TITLE
feat: `context` for all api related calls

### DIFF
--- a/cli/command/content/iso/download.go
+++ b/cli/command/content/iso/download.go
@@ -24,7 +24,7 @@ var iso_downloadCmd = &cobra.Command{
 		if err != nil {
 			return
 		}
-		err = proxmox.DownloadIsoFromUrl(c, config)
+		err = proxmox.DownloadIsoFromUrl(cli.Context(), c, config)
 		if err != nil {
 			return
 		}

--- a/cli/command/content/template/download.go
+++ b/cli/command/content/template/download.go
@@ -21,7 +21,7 @@ var template_downloadCmd = &cobra.Command{
 		if err != nil {
 			return
 		}
-		err = proxmox.DownloadLxcTemplate(c, config)
+		err = proxmox.DownloadLxcTemplate(cli.Context(), c, config)
 		if err != nil {
 			return
 		}

--- a/cli/command/content/template/list.go
+++ b/cli/command/content/template/list.go
@@ -11,7 +11,7 @@ var template_listCmd = &cobra.Command{
 	Short: "Prints a list of all LXC templates available for download in raw json format",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
-		templates, err := proxmox.ListTemplates(cli.NewClient(), args[0])
+		templates, err := proxmox.ListTemplates(cli.Context(), cli.NewClient(), args[0])
 		if err != nil {
 			return
 		}

--- a/cli/command/create/create-acmeaccount.go
+++ b/cli/command/create/create-acmeaccount.go
@@ -20,7 +20,7 @@ For config examples see "example acmeaccount"`,
 			return
 		}
 		c := cli.NewClient()
-		err = config.CreateAcmeAccount(id, c)
+		err = config.CreateAcmeAccount(cli.Context(), id, c)
 		if err != nil {
 			return
 		}

--- a/cli/command/create/create-pool.go
+++ b/cli/command/create/create-pool.go
@@ -20,7 +20,7 @@ var create_poolCmd = &cobra.Command{
 		err = proxmox.ConfigPool{
 			Name:    proxmox.PoolName(id),
 			Comment: comment,
-		}.Create(c)
+		}.Create(cli.Context(), c)
 		if err != nil {
 			return
 		}

--- a/cli/command/create/create-snapshot.go
+++ b/cli/command/create/create-snapshot.go
@@ -25,11 +25,11 @@ var (
 			memory = false
 			client := cli.NewClient()
 			vmr := proxmox.NewVmRef(id)
-			_, err = client.GetVmInfo(vmr)
+			_, err = client.GetVmInfo(cli.Context(), vmr)
 			if err != nil {
 				return
 			}
-			err = config.Create(client, vmr)
+			err = config.Create(cli.Context(), client, vmr)
 			if err != nil {
 				return
 			}

--- a/cli/command/create/create-storage.go
+++ b/cli/command/create/create-storage.go
@@ -20,7 +20,7 @@ For config examples see "example storage"`,
 			return
 		}
 		c := cli.NewClient()
-		err = config.CreateWithValidate(id, c)
+		err = config.CreateWithValidate(cli.Context(), id, c)
 		if err != nil {
 			return
 		}

--- a/cli/command/create/guest/create-guest-lxc.go
+++ b/cli/command/create/guest/create-guest-lxc.go
@@ -1,6 +1,7 @@
 package guest
 
 import (
+	"github.com/Telmate/proxmox-api-go/cli"
 	"github.com/spf13/cobra"
 )
 
@@ -12,7 +13,7 @@ The config can be set with the --file flag or piped from stdin.
 For config examples see "example guest lxc"`,
 	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
-		return createGuest(args, "LxcGuest")
+		return createGuest(cli.Context(), args, "LxcGuest")
 	},
 }
 

--- a/cli/command/create/guest/create-guest-qemu.go
+++ b/cli/command/create/guest/create-guest-qemu.go
@@ -1,6 +1,7 @@
 package guest
 
 import (
+	"github.com/Telmate/proxmox-api-go/cli"
 	"github.com/spf13/cobra"
 )
 
@@ -12,7 +13,7 @@ var guest_qemuCmd = &cobra.Command{
 	For config examples see "example guest qemu"`,
 	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
-		return createGuest(args, "QemuGuest")
+		return createGuest(cli.Context(), args, "QemuGuest")
 	},
 }
 

--- a/cli/command/create/guest/create-guest.go
+++ b/cli/command/create/guest/create-guest.go
@@ -1,6 +1,7 @@
 package guest
 
 import (
+	"context"
 	"strconv"
 
 	"github.com/Telmate/proxmox-api-go/cli"
@@ -19,7 +20,7 @@ func init() {
 	create.CreateCmd.AddCommand(guestCmd)
 }
 
-func createGuest(args []string, IDtype string) (err error) {
+func createGuest(ctx context.Context, args []string, IDtype string) (err error) {
 	id := cli.ValidateIntIDset(args, IDtype+"ID")
 	node := cli.RequiredIDset(args, 1, "NodeID")
 	vmr := proxmox.NewVmRef(id)
@@ -32,7 +33,7 @@ func createGuest(args []string, IDtype string) (err error) {
 		if err != nil {
 			return
 		}
-		err = config.CreateLxc(vmr, c)
+		err = config.CreateLxc(ctx, vmr, c)
 	case "QemuGuest":
 		// var config *proxmox.ConfigQemu
 		// config, err = proxmox.NewConfigQemuFromJson(cli.NewConfig())
@@ -54,7 +55,7 @@ func createGuest(args []string, IDtype string) (err error) {
 				Units:        util.Pointer(proxmox.CpuUnits(1024)),
 				VirtualCores: util.Pointer(proxmox.CpuVirtualCores(2)),
 			},
-		}.Update(true, vmr, c)
+		}.Update(ctx, true, vmr, c)
 		// err = config.Create(vmr, c)
 	}
 	if err != nil {

--- a/cli/command/delete/delete-acmeaccount.go
+++ b/cli/command/delete/delete-acmeaccount.go
@@ -1,6 +1,7 @@
 package delete
 
 import (
+	"github.com/Telmate/proxmox-api-go/cli"
 	"github.com/spf13/cobra"
 )
 
@@ -9,7 +10,7 @@ var delete_acmeaccountCmd = &cobra.Command{
 	Short: "Deletes the Specified AcmeAccount",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return deleteID(args, "AcmeAccount")
+		return deleteID(cli.Context(), args, "AcmeAccount")
 	},
 }
 

--- a/cli/command/delete/delete-file.go
+++ b/cli/command/delete/delete-file.go
@@ -16,7 +16,7 @@ var delete_fileCmd = &cobra.Command{
 		if Type.Validate() != nil {
 			return
 		}
-		err = proxmox.DeleteFile(c, args[0], proxmox.Content_File{
+		err = proxmox.DeleteFile(cli.Context(), c, args[0], proxmox.Content_File{
 			Storage:     args[1],
 			ContentType: Type,
 			FilePath:    args[3],

--- a/cli/command/delete/delete-group.go
+++ b/cli/command/delete/delete-group.go
@@ -1,6 +1,7 @@
 package delete
 
 import (
+	"github.com/Telmate/proxmox-api-go/cli"
 	"github.com/spf13/cobra"
 )
 
@@ -9,7 +10,7 @@ var delete_groupCmd = &cobra.Command{
 	Short: "Deletes the Specified group",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return deleteID(args, "Group")
+		return deleteID(cli.Context(), args, "Group")
 	},
 }
 

--- a/cli/command/delete/delete-guest.go
+++ b/cli/command/delete/delete-guest.go
@@ -16,11 +16,11 @@ var delete_guestCmd = &cobra.Command{
 		id := cli.ValidateIntIDset(args, "GuestID")
 		vmr := proxmox.NewVmRef(id)
 		c := cli.NewClient()
-		_, err = c.StopVm(vmr)
+		_, err = c.StopVm(cli.Context(), vmr)
 		if err != nil {
 			return
 		}
-		_, err = c.DeleteVm(vmr)
+		_, err = c.DeleteVm(cli.Context(), vmr)
 		if err != nil {
 			return
 		}

--- a/cli/command/delete/delete-metricserver.go
+++ b/cli/command/delete/delete-metricserver.go
@@ -1,6 +1,7 @@
 package delete
 
 import (
+	"github.com/Telmate/proxmox-api-go/cli"
 	"github.com/spf13/cobra"
 )
 
@@ -9,7 +10,7 @@ var delete_metricserverCmd = &cobra.Command{
 	Short: "Deletes the specified MetricServer",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return deleteID(args, "MetricServer")
+		return deleteID(cli.Context(), args, "MetricServer")
 	},
 }
 

--- a/cli/command/delete/delete-pool.go
+++ b/cli/command/delete/delete-pool.go
@@ -1,6 +1,7 @@
 package delete
 
 import (
+	"github.com/Telmate/proxmox-api-go/cli"
 	"github.com/spf13/cobra"
 )
 
@@ -9,7 +10,7 @@ var delete_poolCmd = &cobra.Command{
 	Short: "Deletes the Specified pool",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return deleteID(args, "Pool")
+		return deleteID(cli.Context(), args, "Pool")
 	},
 }
 

--- a/cli/command/delete/delete-snapshot.go
+++ b/cli/command/delete/delete-snapshot.go
@@ -14,7 +14,7 @@ var (
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			id := cli.ValidateIntIDset(args, "GuestID")
 			snapName := cli.RequiredIDset(args, 1, "SnapshotName")
-			_, err = proxmox.SnapshotName(snapName).Delete(cli.NewClient(), proxmox.NewVmRef(id))
+			_, err = proxmox.SnapshotName(snapName).Delete(cli.Context(), cli.NewClient(), proxmox.NewVmRef(id))
 			if err != nil {
 				return
 			}

--- a/cli/command/delete/delete-storage.go
+++ b/cli/command/delete/delete-storage.go
@@ -1,6 +1,7 @@
 package delete
 
 import (
+	"github.com/Telmate/proxmox-api-go/cli"
 	"github.com/spf13/cobra"
 )
 
@@ -9,7 +10,7 @@ var delete_storageCmd = &cobra.Command{
 	Short: "Deletes the specified Storage",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return deleteID(args, "Storage")
+		return deleteID(cli.Context(), args, "Storage")
 	},
 }
 

--- a/cli/command/delete/delete-user.go
+++ b/cli/command/delete/delete-user.go
@@ -1,6 +1,7 @@
 package delete
 
 import (
+	"github.com/Telmate/proxmox-api-go/cli"
 	"github.com/spf13/cobra"
 )
 
@@ -9,7 +10,7 @@ var delete_userCmd = &cobra.Command{
 	Short: "Deletes the specified User",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return deleteID(args, "User")
+		return deleteID(cli.Context(), args, "User")
 	},
 }
 

--- a/cli/command/delete/delete.go
+++ b/cli/command/delete/delete.go
@@ -1,6 +1,7 @@
 package delete
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/Telmate/proxmox-api-go/cli"
@@ -17,28 +18,28 @@ func init() {
 	cli.RootCmd.AddCommand(deleteCmd)
 }
 
-func deleteID(args []string, IDtype string) (err error) {
+func deleteID(ctx context.Context, args []string, IDtype string) (err error) {
 	var exitStatus string
 	id := cli.RequiredIDset(args, 0, IDtype+"ID")
 	c := cli.NewClient()
 	switch IDtype {
 	case "AcmeAccount":
-		exitStatus, err = c.DeleteAcmeAccount(id)
+		exitStatus, err = c.DeleteAcmeAccount(ctx, id)
 	case "Group":
-		err = proxmox.GroupName(id).Delete(c)
+		err = proxmox.GroupName(id).Delete(ctx, c)
 	case "MetricServer":
-		err = c.DeleteMetricServer(id)
+		err = c.DeleteMetricServer(ctx, id)
 	case "Pool":
-		err = proxmox.PoolName(id).Delete(c)
+		err = proxmox.PoolName(id).Delete(ctx, c)
 	case "Storage":
-		err = c.DeleteStorage(id)
+		err = c.DeleteStorage(ctx, id)
 	case "User":
 		var userId proxmox.UserID
 		userId, err = proxmox.NewUserID(id)
 		if err != nil {
 			return
 		}
-		err = proxmox.ConfigUser{User: userId}.DeleteUser(c)
+		err = proxmox.ConfigUser{User: userId}.DeleteUser(ctx, c)
 	}
 	if err != nil {
 		if exitStatus != "" {

--- a/cli/command/get/get.go
+++ b/cli/command/get/get.go
@@ -21,22 +21,22 @@ func getConfig(args []string, IDtype string) (err error) {
 	var config interface{}
 	switch IDtype {
 	case "AcmeAccount":
-		config, err = proxmox.NewConfigAcmeAccountFromApi(id, c)
+		config, err = proxmox.NewConfigAcmeAccountFromApi(cli.Context(), id, c)
 	case "Group":
-		config, err = proxmox.NewConfigGroupFromApi(proxmox.GroupName(id), c)
+		config, err = proxmox.NewConfigGroupFromApi(cli.Context(), proxmox.GroupName(id), c)
 	case "MetricServer":
-		config, err = proxmox.NewConfigMetricsFromApi(id, c)
+		config, err = proxmox.NewConfigMetricsFromApi(cli.Context(), id, c)
 	case "Pool":
-		config, err = c.GetPoolInfo(id)
+		config, err = c.GetPoolInfo(cli.Context(), id)
 	case "Storage":
-		config, err = proxmox.NewConfigStorageFromApi(id, c)
+		config, err = proxmox.NewConfigStorageFromApi(cli.Context(), id, c)
 	case "User":
 		var userId proxmox.UserID
 		userId, err = proxmox.NewUserID(id)
 		if err != nil {
 			return
 		}
-		config, err = proxmox.NewConfigUserFromApi(userId, c)
+		config, err = proxmox.NewConfigUserFromApi(cli.Context(), userId, c)
 	}
 	if err != nil {
 		return

--- a/cli/command/get/guest/get-guest-config.go
+++ b/cli/command/get/guest/get-guest-config.go
@@ -14,7 +14,7 @@ var configCmd = &cobra.Command{
 		id := cli.ValidateIntIDset(args, "GuestID")
 		vmr := proxmox.NewVmRef(id)
 		c := cli.NewClient()
-		err = c.CheckVmRef(vmr)
+		err = c.CheckVmRef(cli.Context(), vmr)
 		if err != nil {
 			return
 		}
@@ -22,9 +22,9 @@ var configCmd = &cobra.Command{
 		var config interface{}
 		switch vmType {
 		case "qemu":
-			config, err = proxmox.NewConfigQemuFromApi(vmr, c)
+			config, err = proxmox.NewConfigQemuFromApi(cli.Context(), vmr, c)
 		case "lxc":
-			config, err = proxmox.NewConfigLxcFromApi(vmr, c)
+			config, err = proxmox.NewConfigLxcFromApi(cli.Context(), vmr, c)
 		}
 		if err != nil {
 			return

--- a/cli/command/get/guest/get-guest-feature.go
+++ b/cli/command/get/guest/get-guest-feature.go
@@ -14,11 +14,11 @@ var featureCmd = &cobra.Command{
 		id := cli.ValidateIntIDset(args, "GuestID")
 		vmr := proxmox.NewVmRef(id)
 		c := cli.NewClient()
-		err = c.CheckVmRef(vmr)
+		err = c.CheckVmRef(cli.Context(), vmr)
 		if err != nil {
 			return
 		}
-		features, err := proxmox.ListGuestFeatures(vmr, c)
+		features, err := proxmox.ListGuestFeatures(cli.Context(), vmr, c)
 		if err != nil {
 			return
 		}

--- a/cli/command/get/id/get-id-check.go
+++ b/cli/command/get/id/get-id-check.go
@@ -14,7 +14,7 @@ var id_checkCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		id := cli.ValidateIntIDset(args, "ID")
 		c := cli.NewClient()
-		exists, err := c.VMIdExists(id)
+		exists, err := c.VMIdExists(cli.Context(), id)
 		if err != nil {
 			return
 		}

--- a/cli/command/get/id/get-id-max.go
+++ b/cli/command/get/id/get-id-max.go
@@ -14,7 +14,7 @@ var id_maxCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		c := cli.NewClient()
-		id, err := proxmox.MaxVmId(c)
+		id, err := proxmox.MaxVmId(cli.Context(), c)
 		if err != nil {
 			return
 		}

--- a/cli/command/get/id/get-id-next.go
+++ b/cli/command/get/id/get-id-next.go
@@ -13,7 +13,7 @@ var id_nextCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		c := cli.NewClient()
-		id, err := c.GetNextID(0)
+		id, err := c.GetNextID(cli.Context(), 0)
 		if err != nil {
 			return
 		}

--- a/cli/command/guest/guest-rollback.go
+++ b/cli/command/guest/guest-rollback.go
@@ -15,7 +15,7 @@ var guest_rollbackCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		snapName := cli.RequiredIDset(args, 1, "SnapshotName")
-		_, err = proxmox.SnapshotName(snapName).Rollback(cli.NewClient(), vmr)
+		_, err = proxmox.SnapshotName(snapName).Rollback(cli.Context(), cli.NewClient(), vmr)
 		if err == nil {
 			fmt.Fprintf(GuestCmd.OutOrStdout(), "Guest with id (%d) has been rolled back to snapshot (%s)\n", vmr.VmId(), snapName)
 		}

--- a/cli/command/guest/guest-shutdown.go
+++ b/cli/command/guest/guest-shutdown.go
@@ -13,7 +13,7 @@ var guest_shutdownCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		c := cli.NewClient()
-		_, err = c.ShutdownVm(vmr)
+		_, err = c.ShutdownVm(cli.Context(), vmr)
 		if err == nil {
 			cli.PrintGuestStatus(GuestCmd.OutOrStdout(), vmr.VmId(), "stopped")
 		}

--- a/cli/command/guest/guest-start.go
+++ b/cli/command/guest/guest-start.go
@@ -13,7 +13,7 @@ var guest_statusCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		c := cli.NewClient()
-		_, err = c.StartVm(vmr)
+		_, err = c.StartVm(cli.Context(), vmr)
 		if err == nil {
 			cli.PrintGuestStatus(GuestCmd.OutOrStdout(), vmr.VmId(), "started")
 		}

--- a/cli/command/guest/guest-status.go
+++ b/cli/command/guest/guest-status.go
@@ -15,7 +15,7 @@ var guest_startCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		c := cli.NewClient()
-		vmState, err := c.GetVmState(vmr)
+		vmState, err := c.GetVmState(cli.Context(), vmr)
 		if err == nil {
 			fmt.Fprintf(GuestCmd.OutOrStdout(), "Status of guest with id (%d) is %s\n", vmr.VmId(), vmState["status"].(string))
 		}

--- a/cli/command/guest/guest-stop.go
+++ b/cli/command/guest/guest-stop.go
@@ -13,7 +13,7 @@ var guest_stopCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		c := cli.NewClient()
-		_, err = c.StopVm(vmr)
+		_, err = c.StopVm(cli.Context(), vmr)
 		if err == nil {
 			cli.PrintGuestStatus(GuestCmd.OutOrStdout(), vmr.VmId(), "stopped")
 		}

--- a/cli/command/guest/guest-uptime.go
+++ b/cli/command/guest/guest-uptime.go
@@ -15,7 +15,7 @@ var guest_uptimeCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		c := cli.NewClient()
-		vmState, err := c.GetVmState(vmr)
+		vmState, err := c.GetVmState(cli.Context(), vmr)
 		if err == nil {
 			fmt.Fprintf(GuestCmd.OutOrStdout(), "Uptime of guest with id (%d) is %d\n", vmr.VmId(), int(vmState["uptime"].(float64)))
 		}

--- a/cli/command/guest/qemu/guest-qemu-hibernate.go
+++ b/cli/command/guest/qemu/guest-qemu-hibernate.go
@@ -13,7 +13,7 @@ var qemu_hibernateCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		c := cli.NewClient()
-		_, err = c.HibernateVm(vmr)
+		_, err = c.HibernateVm(cli.Context(), vmr)
 		if err == nil {
 			cli.PrintGuestStatus(qemuCmd.OutOrStdout(), vmr.VmId(), "suspended to disk")
 		}

--- a/cli/command/guest/qemu/guest-qemu-pause.go
+++ b/cli/command/guest/qemu/guest-qemu-pause.go
@@ -13,7 +13,7 @@ var qemu_pauseCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		c := cli.NewClient()
-		_, err = c.PauseVm(vmr)
+		_, err = c.PauseVm(cli.Context(), vmr)
 		if err == nil {
 			cli.PrintGuestStatus(qemuCmd.OutOrStdout(), vmr.VmId(), "paused")
 		}

--- a/cli/command/guest/qemu/guest-qemu-reset.go
+++ b/cli/command/guest/qemu/guest-qemu-reset.go
@@ -13,7 +13,7 @@ var qemu_resetCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		c := cli.NewClient()
-		_, err = c.StartVm(vmr)
+		_, err = c.StartVm(cli.Context(), vmr)
 		if err == nil {
 			cli.PrintGuestStatus(qemuCmd.OutOrStdout(), vmr.VmId(), "reset")
 		}

--- a/cli/command/guest/qemu/guest-qemu-resume.go
+++ b/cli/command/guest/qemu/guest-qemu-resume.go
@@ -13,7 +13,7 @@ var qemu_resumeCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		vmr := proxmox.NewVmRef(cli.ValidateIntIDset(args, "GuestID"))
 		c := cli.NewClient()
-		_, err = c.ResumeVm(vmr)
+		_, err = c.ResumeVm(cli.Context(), vmr)
 		if err == nil {
 			cli.PrintGuestStatus(qemuCmd.OutOrStdout(), vmr.VmId(), "resumed")
 		}

--- a/cli/command/list/list-acmeaccounts.go
+++ b/cli/command/list/list-acmeaccounts.go
@@ -1,6 +1,7 @@
 package list
 
 import (
+	"github.com/Telmate/proxmox-api-go/cli"
 	"github.com/spf13/cobra"
 )
 
@@ -9,7 +10,7 @@ var list_acmeaccountsCmd = &cobra.Command{
 	Short: "Prints a list of AcmeAccounts in raw json format",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		listRaw("AcmeAccounts")
+		listRaw(cli.Context(), "AcmeAccounts")
 	},
 }
 

--- a/cli/command/list/list-acmeplugins.go
+++ b/cli/command/list/list-acmeplugins.go
@@ -1,6 +1,7 @@
 package list
 
 import (
+	"github.com/Telmate/proxmox-api-go/cli"
 	"github.com/spf13/cobra"
 )
 
@@ -9,7 +10,7 @@ var list_acmepluginsCmd = &cobra.Command{
 	Short: "Prints a list of AcmePlugins in raw json format",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		listRaw("AcmePlugins")
+		listRaw(cli.Context(), "AcmePlugins")
 	},
 }
 

--- a/cli/command/list/list-files.go
+++ b/cli/command/list/list-files.go
@@ -12,7 +12,7 @@ var list_FileCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		c := cli.NewClient()
-		templates, err := proxmox.ListFiles(c, args[0], args[1], proxmox.ContentType(args[2]))
+		templates, err := proxmox.ListFiles(cli.Context(), c, args[0], args[1], proxmox.ContentType(args[2]))
 		if err != nil {
 			return
 		}

--- a/cli/command/list/list-groups.go
+++ b/cli/command/list/list-groups.go
@@ -15,7 +15,7 @@ var list_groupsCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		c := cli.NewClient()
-		groups, err := proxmox.ListGroups(c)
+		groups, err := proxmox.ListGroups(cli.Context(), c)
 		if err != nil {
 			return
 		}

--- a/cli/command/list/list-guests.go
+++ b/cli/command/list/list-guests.go
@@ -12,7 +12,7 @@ var list_qemuguestsCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		c := cli.NewClient()
-		guests, err := proxmox.ListGuests(c)
+		guests, err := proxmox.ListGuests(cli.Context(), c)
 		cli.LogFatalListing("Guests", err)
 		cli.PrintRawJson(listCmd.OutOrStdout(), guests)
 	},

--- a/cli/command/list/list-metricservers.go
+++ b/cli/command/list/list-metricservers.go
@@ -1,6 +1,7 @@
 package list
 
 import (
+	"github.com/Telmate/proxmox-api-go/cli"
 	"github.com/spf13/cobra"
 )
 
@@ -9,7 +10,7 @@ var list_metricserversCmd = &cobra.Command{
 	Short: "Prints a list of MetricServers in raw json format",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		listRaw("MetricServers")
+		listRaw(cli.Context(), "MetricServers")
 	},
 }
 

--- a/cli/command/list/list-nodes.go
+++ b/cli/command/list/list-nodes.go
@@ -1,6 +1,7 @@
 package list
 
 import (
+	"github.com/Telmate/proxmox-api-go/cli"
 	"github.com/spf13/cobra"
 )
 
@@ -9,7 +10,7 @@ var list_nodesCmd = &cobra.Command{
 	Short: "Prints a list of Nodes in raw json format",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		listRaw("Nodes")
+		listRaw(cli.Context(), "Nodes")
 	},
 }
 

--- a/cli/command/list/list-pools.go
+++ b/cli/command/list/list-pools.go
@@ -12,7 +12,7 @@ var list_poolsCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		c := cli.NewClient()
-		pools, err := proxmox.ListPools(c)
+		pools, err := proxmox.ListPools(cli.Context(), c)
 		if err != nil {
 			return
 		}

--- a/cli/command/list/list-snapshots.go
+++ b/cli/command/list/list-snapshots.go
@@ -16,7 +16,7 @@ var (
 		Args:             cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) (err error) {
 			id := cli.ValidateExistingGuestID(args, 0)
-			rawSnapshots, err := proxmox.ListSnapshots(cli.NewClient(), proxmox.NewVmRef(id))
+			rawSnapshots, err := proxmox.ListSnapshots(cli.Context(), cli.NewClient(), proxmox.NewVmRef(id))
 			if err != nil {
 				noTree = false
 				return

--- a/cli/command/list/list-storages.go
+++ b/cli/command/list/list-storages.go
@@ -1,6 +1,7 @@
 package list
 
 import (
+	"github.com/Telmate/proxmox-api-go/cli"
 	"github.com/spf13/cobra"
 )
 
@@ -9,7 +10,7 @@ var list_storagesCmd = &cobra.Command{
 	Short: "Prints a list of Storages in raw json format",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		listRaw("Storages")
+		listRaw(cli.Context(), "Storages")
 	},
 }
 

--- a/cli/command/list/list-users.go
+++ b/cli/command/list/list-users.go
@@ -16,7 +16,7 @@ var list_usersCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		c := cli.NewClient()
 		groups, _ := cmd.Flags().GetBool("groups")
-		users, err := proxmox.ListUsers(c, groups)
+		users, err := proxmox.ListUsers(cli.Context(), c, groups)
 		if err != nil {
 			return
 		}

--- a/cli/command/list/list.go
+++ b/cli/command/list/list.go
@@ -1,6 +1,8 @@
 package list
 
 import (
+	"context"
+
 	"github.com/Telmate/proxmox-api-go/cli"
 	"github.com/spf13/cobra"
 )
@@ -14,21 +16,21 @@ func init() {
 	cli.RootCmd.AddCommand(listCmd)
 }
 
-func listRaw(IDtype string) {
+func listRaw(ctx context.Context, IDtype string) {
 	c := cli.NewClient()
 	var list interface{}
 	var err error
 	switch IDtype {
 	case "AcmeAccounts":
-		list, err = c.GetAcmeAccountList()
+		list, err = c.GetAcmeAccountList(ctx)
 	case "AcmePlugins":
-		list, err = c.GetAcmePluginList()
+		list, err = c.GetAcmePluginList(ctx)
 	case "MetricServers":
-		list, err = c.GetMetricsServerList()
+		list, err = c.GetMetricsServerList(ctx)
 	case "Nodes":
-		list, err = c.GetNodeList()
+		list, err = c.GetNodeList(ctx)
 	case "Storages":
-		list, err = c.GetStorageList()
+		list, err = c.GetStorageList(ctx)
 	}
 	cli.LogFatalListing(IDtype, err)
 	cli.PrintRawJson(listCmd.OutOrStdout(), list)

--- a/cli/command/member/group/add-users.go
+++ b/cli/command/member/group/add-users.go
@@ -17,7 +17,7 @@ var group_addCmd = &cobra.Command{
 			return
 		}
 		c := cli.NewClient()
-		err = proxmox.GroupName(args[0]).AddUsersToGroup(users, c)
+		err = proxmox.GroupName(args[0]).AddUsersToGroup(cli.Context(), users, c)
 		if err != nil {
 			return
 		}

--- a/cli/command/member/group/clear-users.go
+++ b/cli/command/member/group/clear-users.go
@@ -12,7 +12,7 @@ var group_clearCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		c := cli.NewClient()
-		err = proxmox.GroupName(args[0]).RemoveAllUsersFromGroup(c)
+		err = proxmox.GroupName(args[0]).RemoveAllUsersFromGroup(cli.Context(), c)
 		if err != nil {
 			return
 		}

--- a/cli/command/member/group/remove-users.go
+++ b/cli/command/member/group/remove-users.go
@@ -17,7 +17,7 @@ var group_removeCmd = &cobra.Command{
 			return
 		}
 		c := cli.NewClient()
-		err = proxmox.GroupName(args[0]).RemoveUsersFromGroup(users, c)
+		err = proxmox.GroupName(args[0]).RemoveUsersFromGroup(cli.Context(), users, c)
 		if err != nil {
 			return
 		}

--- a/cli/command/member/group/set-users.go
+++ b/cli/command/member/group/set-users.go
@@ -22,7 +22,7 @@ var group_setCmd = &cobra.Command{
 			}
 		}
 		c := cli.NewClient()
-		err = proxmox.GroupName(args[0]).SetMembers(users, c)
+		err = proxmox.GroupName(args[0]).SetMembers(cli.Context(), users, c)
 		if err != nil {
 			return
 		}

--- a/cli/command/node/node-reboot.go
+++ b/cli/command/node/node-reboot.go
@@ -12,7 +12,7 @@ var reboot_nodeCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		node := cli.RequiredIDset(args, 0, "node")
 		c := cli.NewClient()
-		_, err = c.RebootNode(node)
+		_, err = c.RebootNode(cli.Context(), node)
 		if err != nil {
 			return
 		}

--- a/cli/command/node/node-shutdown.go
+++ b/cli/command/node/node-shutdown.go
@@ -12,7 +12,7 @@ var shutdown_nodeCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		node := cli.RequiredIDset(args, 0, "node")
 		c := cli.NewClient()
-		_, err = c.ShutdownNode(node)
+		_, err = c.ShutdownNode(cli.Context(), node)
 		if err != nil {
 			return
 		}

--- a/cli/command/set/set-group.go
+++ b/cli/command/set/set-group.go
@@ -35,7 +35,7 @@ var (
 				Comment: comment,
 				Members: formattedMembers,
 			}
-			err = config.Set(cli.NewClient())
+			err = config.Set(cli.Context(), cli.NewClient())
 			if err != nil {
 				return
 			}

--- a/cli/command/set/set-metricserver.go
+++ b/cli/command/set/set-metricserver.go
@@ -21,7 +21,7 @@ For config examples see "example metricserver"`,
 			return
 		}
 		c := cli.NewClient()
-		err = config.SetMetrics(id, c)
+		err = config.SetMetrics(cli.Context(), id, c)
 		if err != nil {
 			return
 		}

--- a/cli/command/set/set-user.go
+++ b/cli/command/set/set-user.go
@@ -29,7 +29,7 @@ For config examples see "example user"`,
 			password = proxmox.UserPassword(args[1])
 		}
 		c := cli.NewClient()
-		err = config.SetUser(userId, password, c)
+		err = config.SetUser(cli.Context(), userId, password, c)
 		if err != nil {
 			return
 		}

--- a/cli/command/update/update-poolcomment.go
+++ b/cli/command/update/update-poolcomment.go
@@ -20,7 +20,7 @@ var update_poolCmd = &cobra.Command{
 		err = proxmox.ConfigPool{
 			Name:    proxmox.PoolName(id),
 			Comment: comment,
-		}.Update(c)
+		}.Update(cli.Context(), c)
 		if err != nil {
 			return
 		}

--- a/cli/command/update/update-snapshotdescription.go
+++ b/cli/command/update/update-snapshotdescription.go
@@ -14,7 +14,7 @@ var update_snapshotCmd = &cobra.Command{
 		id := cli.ValidateIntIDset(args, "GuestID")
 		snapName := cli.RequiredIDset(args, 1, "SnapshotName")
 		des := cli.OptionalIDset(args, 2)
-		err = proxmox.SnapshotName(snapName).UpdateDescription(cli.NewClient(), proxmox.NewVmRef(id), des)
+		err = proxmox.SnapshotName(snapName).UpdateDescription(cli.Context(), cli.NewClient(), proxmox.NewVmRef(id), des)
 		if err != nil {
 			return
 		}

--- a/cli/command/update/update-storage.go
+++ b/cli/command/update/update-storage.go
@@ -20,7 +20,7 @@ For config examples see "example storage"`,
 			return
 		}
 		c := cli.NewClient()
-		err = config.UpdateWithValidate(id, c)
+		err = config.UpdateWithValidate(cli.Context(), id, c)
 		if err != nil {
 			return
 		}

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -4,6 +4,7 @@ package proxmox
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"errors"
@@ -143,19 +144,19 @@ func (c *Client) SetTicket(ticket, csrfPreventionToken string) {
 	c.session.setTicket(ticket, csrfPreventionToken)
 }
 
-func (c *Client) Login(username string, password string, otp string) (err error) {
+func (c *Client) Login(ctx context.Context, username string, password string, otp string) (err error) {
 	c.Username = username
 	c.Password = password
 	c.Otp = otp
-	return c.session.Login(username, password, otp)
+	return c.session.Login(ctx, username, password, otp)
 }
 
 // Updates the client's cached version information and returns it.
-func (c *Client) GetVersion() (version Version, err error) {
+func (c *Client) GetVersion(ctx context.Context) (version Version, err error) {
 	if c == nil {
 		return Version{}, errors.New(Client_Error_Nil)
 	}
-	params, err := c.GetItemConfigMapStringInterface("/version", "version", "data")
+	params, err := c.GetItemConfigMapStringInterface(ctx, "/version", "version", "data")
 	version = version.mapToSDK(params)
 	cachedVersion := Version{ // clones the struct
 		Major: version.Major,
@@ -168,10 +169,10 @@ func (c *Client) GetVersion() (version Version, err error) {
 	return
 }
 
-func (c *Client) GetJsonRetryable(url string, data *map[string]interface{}, tries int, errorString ...string) error {
+func (c *Client) GetJsonRetryable(ctx context.Context, url string, data *map[string]interface{}, tries int, errorString ...string) error {
 	var statErr error
 	for ii := 0; ii < tries; ii++ {
-		_, statErr = c.session.GetJSON(url, nil, nil, data)
+		_, statErr = c.session.GetJSON(ctx, url, nil, nil, data)
 		if statErr == nil {
 			return nil
 		}
@@ -190,8 +191,8 @@ func (c *Client) GetJsonRetryable(url string, data *map[string]interface{}, trie
 	return statErr
 }
 
-func (c *Client) GetNodeList() (list map[string]interface{}, err error) {
-	err = c.GetJsonRetryable("/nodes", &list, 3)
+func (c *Client) GetNodeList(ctx context.Context) (list map[string]interface{}, err error) {
+	err = c.GetJsonRetryable(ctx, "/nodes", &list, 3)
 	return
 }
 
@@ -201,32 +202,32 @@ const resourceListGuest string = "vm"
 // For resource types that can be in a disabled state, disabled resources
 // will not be returned
 // TODO this func should not be exported
-func (c *Client) GetResourceList(resourceType string) (list []interface{}, err error) {
+func (c *Client) GetResourceList(ctx context.Context, resourceType string) (list []interface{}, err error) {
 	url := "/cluster/resources"
 	if resourceType != "" {
 		url = url + "?type=" + resourceType
 	}
-	return c.GetItemListInterfaceArray(url)
+	return c.GetItemListInterfaceArray(ctx, url)
 }
 
 // TODO deprecate once nothing uses this anymore, use ListGuests() instead
-func (c *Client) GetVmList() (map[string]interface{}, error) {
-	list, err := c.GetResourceList(resourceListGuest)
+func (c *Client) GetVmList(ctx context.Context) (map[string]interface{}, error) {
+	list, err := c.GetResourceList(ctx, resourceListGuest)
 	return map[string]interface{}{"data": list}, err
 }
 
-func (c *Client) CheckVmRef(vmr *VmRef) (err error) {
+func (c *Client) CheckVmRef(ctx context.Context, vmr *VmRef) (err error) {
 	if vmr == nil {
 		return errors.New(VmRef_Error_Nil)
 	}
 	if vmr.node == "" || vmr.vmType == "" {
-		_, err = c.GetVmInfo(vmr)
+		_, err = c.GetVmInfo(ctx, vmr)
 	}
 	return
 }
 
-func (c *Client) GetVmInfo(vmr *VmRef) (vmInfo map[string]interface{}, err error) {
-	vms, err := c.GetResourceList(resourceListGuest)
+func (c *Client) GetVmInfo(ctx context.Context, vmr *VmRef) (vmInfo map[string]interface{}, err error) {
+	vms, err := c.GetResourceList(ctx, resourceListGuest)
 	if err != nil {
 		return
 	}
@@ -249,8 +250,8 @@ func (c *Client) GetVmInfo(vmr *VmRef) (vmInfo map[string]interface{}, err error
 	return nil, fmt.Errorf("vm '%d' not found", vmr.vmId)
 }
 
-func (c *Client) GetVmRefByName(vmName string) (vmr *VmRef, err error) {
-	vmrs, err := c.GetVmRefsByName(vmName)
+func (c *Client) GetVmRefByName(ctx context.Context, vmName string) (vmr *VmRef, err error) {
+	vmrs, err := c.GetVmRefsByName(ctx, vmName)
 	if err != nil {
 		return nil, err
 	}
@@ -258,8 +259,8 @@ func (c *Client) GetVmRefByName(vmName string) (vmr *VmRef, err error) {
 	return vmrs[0], nil
 }
 
-func (c *Client) GetVmRefsByName(vmName string) (vmrs []*VmRef, err error) {
-	vms, err := c.GetResourceList(resourceListGuest)
+func (c *Client) GetVmRefsByName(ctx context.Context, vmName string) (vmrs []*VmRef, err error) {
+	vms, err := c.GetResourceList(ctx, resourceListGuest)
 	if err != nil {
 		return
 	}
@@ -286,9 +287,9 @@ func (c *Client) GetVmRefsByName(vmName string) (vmrs []*VmRef, err error) {
 	}
 }
 
-func (c *Client) GetVmRefById(vmId int) (vmr *VmRef, err error) {
+func (c *Client) GetVmRefById(ctx context.Context, vmId int) (vmr *VmRef, err error) {
 	var exist bool = false
-	vms, err := c.GetResourceList(resourceListGuest)
+	vms, err := c.GetResourceList(ctx, resourceListGuest)
 	if err != nil {
 		return
 	}
@@ -315,30 +316,30 @@ func (c *Client) GetVmRefById(vmId int) (vmr *VmRef, err error) {
 	}
 }
 
-func (c *Client) GetVmState(vmr *VmRef) (vmState map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) GetVmState(ctx context.Context, vmr *VmRef) (vmState map[string]interface{}, err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return nil, err
 	}
-	return c.GetItemConfigMapStringInterface("/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/status/current", "vm", "STATE")
+	return c.GetItemConfigMapStringInterface(ctx, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/status/current", "vm", "STATE")
 }
 
-func (c *Client) GetVmConfig(vmr *VmRef) (vmConfig map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) GetVmConfig(ctx context.Context, vmr *VmRef) (vmConfig map[string]interface{}, err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return nil, err
 	}
-	return c.GetItemConfigMapStringInterface("/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/config", "vm", "CONFIG")
+	return c.GetItemConfigMapStringInterface(ctx, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/config", "vm", "CONFIG")
 }
 
-func (c *Client) GetStorageStatus(vmr *VmRef, storageName string) (storageStatus map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) GetStorageStatus(ctx context.Context, vmr *VmRef, storageName string) (storageStatus map[string]interface{}, err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return nil, err
 	}
 	var data map[string]interface{}
 	url := fmt.Sprintf("/nodes/%s/storage/%s/status", vmr.node, storageName)
-	err = c.GetJsonRetryable(url, &data, 3)
+	err = c.GetJsonRetryable(ctx, url, &data, 3)
 	if err != nil {
 		return nil, err
 	}
@@ -349,13 +350,13 @@ func (c *Client) GetStorageStatus(vmr *VmRef, storageName string) (storageStatus
 	return
 }
 
-func (c *Client) GetStorageContent(vmr *VmRef, storageName string) (data map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) GetStorageContent(ctx context.Context, vmr *VmRef, storageName string) (data map[string]interface{}, err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return nil, err
 	}
 	url := fmt.Sprintf("/nodes/%s/storage/%s/content", vmr.node, storageName)
-	err = c.GetJsonRetryable(url, &data, 3)
+	err = c.GetJsonRetryable(ctx, url, &data, 3)
 	if err != nil {
 		return nil, err
 	}
@@ -365,14 +366,14 @@ func (c *Client) GetStorageContent(vmr *VmRef, storageName string) (data map[str
 	return
 }
 
-func (c *Client) GetVmSpiceProxy(vmr *VmRef) (vmSpiceProxy map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) GetVmSpiceProxy(ctx context.Context, vmr *VmRef) (vmSpiceProxy map[string]interface{}, err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return nil, err
 	}
 	var data map[string]interface{}
 	url := fmt.Sprintf("/nodes/%s/%s/%d/spiceproxy", vmr.node, vmr.vmType, vmr.vmId)
-	_, err = c.session.PostJSON(url, nil, nil, nil, &data)
+	_, err = c.session.PostJSON(ctx, url, nil, nil, nil, &data)
 	if err != nil {
 		return nil, err
 	}
@@ -384,18 +385,18 @@ func (c *Client) GetVmSpiceProxy(vmr *VmRef) (vmSpiceProxy map[string]interface{
 }
 
 // deprecated use *VmRef.GetAgentInformation() instead
-func (c *Client) GetVmAgentNetworkInterfaces(vmr *VmRef) ([]AgentNetworkInterface, error) {
-	return vmr.GetAgentInformation(c, true)
+func (c *Client) GetVmAgentNetworkInterfaces(ctx context.Context, vmr *VmRef) ([]AgentNetworkInterface, error) {
+	return vmr.GetAgentInformation(ctx, c, true)
 }
 
-func (c *Client) CreateTemplate(vmr *VmRef) error {
-	err := c.CheckVmRef(vmr)
+func (c *Client) CreateTemplate(ctx context.Context, vmr *VmRef) error {
+	err := c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return err
 	}
 
 	url := fmt.Sprintf("/nodes/%s/%s/%d/template", vmr.node, vmr.vmType, vmr.vmId)
-	resp, err := c.session.Post(url, nil, nil, nil)
+	resp, err := c.session.Post(ctx, url, nil, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -405,7 +406,7 @@ func (c *Client) CreateTemplate(vmr *VmRef) error {
 		return err
 	}
 
-	exitStatus, err := c.WaitForCompletion(taskResponse)
+	exitStatus, err := c.WaitForCompletion(ctx, taskResponse)
 	if err != nil {
 		return err
 	}
@@ -419,14 +420,14 @@ func (c *Client) CreateTemplate(vmr *VmRef) error {
 	return nil
 }
 
-func (c *Client) MonitorCmd(vmr *VmRef, command string) (monitorRes map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) MonitorCmd(ctx context.Context, vmr *VmRef, command string) (monitorRes map[string]interface{}, err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return nil, err
 	}
 	reqbody := ParamsToBody(map[string]interface{}{"command": command})
 	url := fmt.Sprintf("/nodes/%s/%s/%d/monitor", vmr.node, vmr.vmType, vmr.vmId)
-	resp, err := c.session.Post(url, nil, nil, &reqbody)
+	resp, err := c.session.Post(ctx, url, nil, nil, &reqbody)
 	if err != nil {
 		return nil, err
 	}
@@ -434,21 +435,21 @@ func (c *Client) MonitorCmd(vmr *VmRef, command string) (monitorRes map[string]i
 	return
 }
 
-func (c *Client) Sendkey(vmr *VmRef, qmKey string) error {
-	err := c.CheckVmRef(vmr)
+func (c *Client) Sendkey(ctx context.Context, vmr *VmRef, qmKey string) error {
+	err := c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return err
 	}
 	reqbody := ParamsToBody(map[string]interface{}{"key": qmKey})
 	url := fmt.Sprintf("/nodes/%s/%s/%d/sendkey", vmr.node, vmr.vmType, vmr.vmId)
 	// No return, even for errors: https://bugzilla.proxmox.com/show_bug.cgi?id=2275
-	_, err = c.session.Put(url, nil, nil, &reqbody)
+	_, err = c.session.Put(ctx, url, nil, nil, &reqbody)
 
 	return err
 }
 
 // WaitForCompletion - poll the API for task completion
-func (c *Client) WaitForCompletion(taskResponse map[string]interface{}) (waitExitStatus string, err error) {
+func (c *Client) WaitForCompletion(ctx context.Context, taskResponse map[string]interface{}) (waitExitStatus string, err error) {
 	if taskResponse["errors"] != nil {
 		errJSON, _ := json.MarshalIndent(taskResponse["errors"], "", "  ")
 		return string(errJSON), fmt.Errorf("error response")
@@ -459,7 +460,7 @@ func (c *Client) WaitForCompletion(taskResponse map[string]interface{}) (waitExi
 	waited := 0
 	taskUpid := taskResponse["data"].(string)
 	for waited < c.TaskTimeout {
-		exitStatus, statErr := c.GetTaskExitstatus(taskUpid)
+		exitStatus, statErr := c.GetTaskExitstatus(ctx, taskUpid)
 		if statErr != nil {
 			if statErr != io.ErrUnexpectedEOF { // don't give up on ErrUnexpectedEOF
 				return "", statErr
@@ -480,11 +481,11 @@ var (
 	rxExitStatusSuccess = regexp.MustCompile(`^(OK|WARNINGS)`)
 )
 
-func (c *Client) GetTaskExitstatus(taskUpid string) (exitStatus interface{}, err error) {
+func (c *Client) GetTaskExitstatus(ctx context.Context, taskUpid string) (exitStatus interface{}, err error) {
 	node := rxTaskNode.FindStringSubmatch(taskUpid)[1]
 	url := fmt.Sprintf("/nodes/%s/tasks/%s/status", node, taskUpid)
 	var data map[string]interface{}
-	_, err = c.session.GetJSON(url, nil, nil, &data)
+	_, err = c.session.GetJSON(ctx, url, nil, nil, &data)
 	if err == nil {
 		exitStatus = data["data"].(map[string]interface{})["exitstatus"]
 	}
@@ -494,14 +495,14 @@ func (c *Client) GetTaskExitstatus(taskUpid string) (exitStatus interface{}, err
 	return
 }
 
-func (c *Client) StatusChangeVm(vmr *VmRef, params map[string]interface{}, setStatus string) (exitStatus string, err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) StatusChangeVm(ctx context.Context, vmr *VmRef, params map[string]interface{}, setStatus string) (exitStatus string, err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return
 	}
 	url := fmt.Sprintf("/nodes/%s/%s/%d/status/%s", vmr.node, vmr.vmType, vmr.vmId, setStatus)
 	for i := 0; i < 3; i++ {
-		exitStatus, err = c.PostWithTask(params, url)
+		exitStatus, err = c.PostWithTask(ctx, params, url)
 		if err != nil {
 			time.Sleep(TaskStatusCheckInterval * time.Second)
 		} else {
@@ -511,47 +512,47 @@ func (c *Client) StatusChangeVm(vmr *VmRef, params map[string]interface{}, setSt
 	return
 }
 
-func (c *Client) StartVm(vmr *VmRef) (exitStatus string, err error) {
-	return c.StatusChangeVm(vmr, nil, "start")
+func (c *Client) StartVm(ctx context.Context, vmr *VmRef) (exitStatus string, err error) {
+	return c.StatusChangeVm(ctx, vmr, nil, "start")
 }
 
-func (c *Client) StopVm(vmr *VmRef) (exitStatus string, err error) {
-	return c.StatusChangeVm(vmr, nil, "stop")
+func (c *Client) StopVm(ctx context.Context, vmr *VmRef) (exitStatus string, err error) {
+	return c.StatusChangeVm(ctx, vmr, nil, "stop")
 }
 
-func (c *Client) ShutdownVm(vmr *VmRef) (exitStatus string, err error) {
-	return c.StatusChangeVm(vmr, nil, "shutdown")
+func (c *Client) ShutdownVm(ctx context.Context, vmr *VmRef) (exitStatus string, err error) {
+	return c.StatusChangeVm(ctx, vmr, nil, "shutdown")
 }
 
-func (c *Client) ResetVm(vmr *VmRef) (exitStatus string, err error) {
-	return c.StatusChangeVm(vmr, nil, "reset")
+func (c *Client) ResetVm(ctx context.Context, vmr *VmRef) (exitStatus string, err error) {
+	return c.StatusChangeVm(ctx, vmr, nil, "reset")
 }
 
-func (c *Client) RebootVm(vmr *VmRef) (exitStatus string, err error) {
-	return c.StatusChangeVm(vmr, nil, "reboot")
+func (c *Client) RebootVm(ctx context.Context, vmr *VmRef) (exitStatus string, err error) {
+	return c.StatusChangeVm(ctx, vmr, nil, "reboot")
 }
 
-func (c *Client) PauseVm(vmr *VmRef) (exitStatus string, err error) {
-	return c.StatusChangeVm(vmr, nil, "suspend")
+func (c *Client) PauseVm(ctx context.Context, vmr *VmRef) (exitStatus string, err error) {
+	return c.StatusChangeVm(ctx, vmr, nil, "suspend")
 }
 
-func (c *Client) HibernateVm(vmr *VmRef) (exitStatus string, err error) {
+func (c *Client) HibernateVm(ctx context.Context, vmr *VmRef) (exitStatus string, err error) {
 	params := map[string]interface{}{
 		"todisk": true,
 	}
-	return c.StatusChangeVm(vmr, params, "suspend")
+	return c.StatusChangeVm(ctx, vmr, params, "suspend")
 }
 
-func (c *Client) ResumeVm(vmr *VmRef) (exitStatus string, err error) {
-	return c.StatusChangeVm(vmr, nil, "resume")
+func (c *Client) ResumeVm(ctx context.Context, vmr *VmRef) (exitStatus string, err error) {
+	return c.StatusChangeVm(ctx, vmr, nil, "resume")
 }
 
-func (c *Client) DeleteVm(vmr *VmRef) (exitStatus string, err error) {
-	return c.DeleteVmParams(vmr, nil)
+func (c *Client) DeleteVm(ctx context.Context, vmr *VmRef) (exitStatus string, err error) {
+	return c.DeleteVmParams(ctx, vmr, nil)
 }
 
-func (c *Client) DeleteVmParams(vmr *VmRef, params map[string]interface{}) (exitStatus string, err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) DeleteVmParams(ctx context.Context, vmr *VmRef, params map[string]interface{}) (exitStatus string, err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return "", err
 	}
@@ -559,13 +560,13 @@ func (c *Client) DeleteVmParams(vmr *VmRef, params map[string]interface{}) (exit
 	// Remove HA if required
 	if vmr.haState != "" {
 		url := fmt.Sprintf("/cluster/ha/resources/%d", vmr.vmId)
-		resp, err := c.session.Delete(url, nil, nil)
+		resp, err := c.session.Delete(ctx, url, nil, nil)
 		if err == nil {
 			taskResponse, err := ResponseJSON(resp)
 			if err != nil {
 				return "", err
 			}
-			exitStatus, err = c.WaitForCompletion(taskResponse)
+			exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 			if err != nil {
 				return "", err
 			}
@@ -576,20 +577,20 @@ func (c *Client) DeleteVmParams(vmr *VmRef, params map[string]interface{}) (exit
 	url := fmt.Sprintf("/nodes/%s/%s/%d", vmr.node, vmr.vmType, vmr.vmId)
 	var taskResponse map[string]interface{}
 	if len(values) != 0 {
-		_, err = c.session.RequestJSON("DELETE", url, &values, nil, nil, &taskResponse)
+		_, err = c.session.RequestJSON(ctx, "DELETE", url, &values, nil, nil, &taskResponse)
 	} else {
-		_, err = c.session.RequestJSON("DELETE", url, nil, nil, nil, &taskResponse)
+		_, err = c.session.RequestJSON(ctx, "DELETE", url, nil, nil, nil, &taskResponse)
 	}
 	if err != nil {
 		return
 	}
-	exitStatus, err = c.WaitForCompletion(taskResponse)
+	exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 	return
 }
 
-func (c *Client) CreateQemuVm(node string, vmParams map[string]interface{}) (exitStatus string, err error) {
+func (c *Client) CreateQemuVm(ctx context.Context, node string, vmParams map[string]interface{}) (exitStatus string, err error) {
 	// Create VM disks first to ensure disks names.
-	createdDisks, createdDisksErr := c.createVMDisks(node, vmParams)
+	createdDisks, createdDisksErr := c.createVMDisks(ctx, node, vmParams)
 	if createdDisksErr != nil {
 		return "", createdDisksErr
 	}
@@ -598,7 +599,7 @@ func (c *Client) CreateQemuVm(node string, vmParams map[string]interface{}) (exi
 	reqbody := ParamsToBody(vmParams)
 	url := fmt.Sprintf("/nodes/%s/qemu", node)
 	var resp *http.Response
-	resp, err = c.session.Post(url, nil, nil, &reqbody)
+	resp, err = c.session.Post(ctx, url, nil, nil, &reqbody)
 	if err != nil {
 		// Only attempt to read the body if it is available.
 		if resp != nil && resp.Body != nil {
@@ -618,10 +619,10 @@ func (c *Client) CreateQemuVm(node string, vmParams map[string]interface{}) (exi
 	if err != nil {
 		return "", err
 	}
-	exitStatus, err = c.WaitForCompletion(taskResponse)
+	exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 	// Delete VM disks if the VM didn't create.
 	if exitStatus != "OK" {
-		deleteDisksErr := c.DeleteVMDisks(node, createdDisks)
+		deleteDisksErr := c.DeleteVMDisks(ctx, node, createdDisks)
 		if deleteDisksErr != nil {
 			return "", deleteDisksErr
 		}
@@ -630,11 +631,11 @@ func (c *Client) CreateQemuVm(node string, vmParams map[string]interface{}) (exi
 	return
 }
 
-func (c *Client) CreateLxcContainer(node string, vmParams map[string]interface{}) (exitStatus string, err error) {
+func (c *Client) CreateLxcContainer(ctx context.Context, node string, vmParams map[string]interface{}) (exitStatus string, err error) {
 	reqbody := ParamsToBody(vmParams)
 	url := fmt.Sprintf("/nodes/%s/lxc", node)
 	var resp *http.Response
-	resp, err = c.session.Post(url, nil, nil, &reqbody)
+	resp, err = c.session.Post(ctx, url, nil, nil, &reqbody)
 	if err != nil {
 		defer resp.Body.Close()
 		// This might not work if we never got a body. We'll ignore errors in trying to read,
@@ -648,21 +649,21 @@ func (c *Client) CreateLxcContainer(node string, vmParams map[string]interface{}
 	if err != nil {
 		return "", err
 	}
-	exitStatus, err = c.WaitForCompletion(taskResponse)
+	exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 
 	return
 }
 
-func (c *Client) CloneLxcContainer(vmr *VmRef, vmParams map[string]interface{}) (exitStatus string, err error) {
+func (c *Client) CloneLxcContainer(ctx context.Context, vmr *VmRef, vmParams map[string]interface{}) (exitStatus string, err error) {
 	reqbody := ParamsToBody(vmParams)
 	url := fmt.Sprintf("/nodes/%s/lxc/%s/clone", vmr.node, vmParams["vmid"])
-	resp, err := c.session.Post(url, nil, nil, &reqbody)
+	resp, err := c.session.Post(ctx, url, nil, nil, &reqbody)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
 			return "", err
 		}
-		exitStatus, err = c.WaitForCompletion(taskResponse)
+		exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 		if err != nil {
 			return "", err
 		}
@@ -670,16 +671,16 @@ func (c *Client) CloneLxcContainer(vmr *VmRef, vmParams map[string]interface{}) 
 	return
 }
 
-func (c *Client) CloneQemuVm(vmr *VmRef, vmParams map[string]interface{}) (exitStatus string, err error) {
+func (c *Client) CloneQemuVm(ctx context.Context, vmr *VmRef, vmParams map[string]interface{}) (exitStatus string, err error) {
 	reqbody := ParamsToBody(vmParams)
 	url := fmt.Sprintf("/nodes/%s/qemu/%d/clone", vmr.node, vmr.vmId)
-	resp, err := c.session.Post(url, nil, nil, &reqbody)
+	resp, err := c.session.Post(ctx, url, nil, nil, &reqbody)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
 			return "", err
 		}
-		exitStatus, err = c.WaitForCompletion(taskResponse)
+		exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 		if err != nil {
 			return "", err
 		}
@@ -689,7 +690,8 @@ func (c *Client) CloneQemuVm(vmr *VmRef, vmParams map[string]interface{}) (exitS
 
 // DEPRECATED superseded by CreateSnapshot()
 func (c *Client) CreateQemuSnapshot(vmr *VmRef, snapshotName string) (exitStatus string, err error) {
-	err = c.CheckVmRef(vmr)
+	ctx := context.Background()
+	err = c.CheckVmRef(ctx, vmr)
 	snapshotParams := map[string]interface{}{
 		"snapname": snapshotName,
 	}
@@ -698,13 +700,13 @@ func (c *Client) CreateQemuSnapshot(vmr *VmRef, snapshotName string) (exitStatus
 		return "", err
 	}
 	url := fmt.Sprintf("/nodes/%s/%s/%d/snapshot/", vmr.node, vmr.vmType, vmr.vmId)
-	resp, err := c.session.Post(url, nil, nil, &reqbody)
+	resp, err := c.session.Post(ctx, url, nil, nil, &reqbody)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
 			return "", err
 		}
-		exitStatus, err = c.WaitForCompletion(taskResponse)
+		exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 		if err != nil {
 			return "", err
 		}
@@ -714,17 +716,18 @@ func (c *Client) CreateQemuSnapshot(vmr *VmRef, snapshotName string) (exitStatus
 
 // DEPRECATED superseded by DeleteSnapshot()
 func (c *Client) DeleteQemuSnapshot(vmr *VmRef, snapshotName string) (exitStatus string, err error) {
-	return DeleteSnapshot(c, vmr, SnapshotName(snapshotName))
+	return DeleteSnapshot(context.Background(), c, vmr, SnapshotName(snapshotName))
 }
 
 // DEPRECATED superseded by ListSnapshots()
 func (c *Client) ListQemuSnapshot(vmr *VmRef) (taskResponse map[string]interface{}, exitStatus string, err error) {
-	err = c.CheckVmRef(vmr)
+	ctx := context.Background()
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return nil, "", err
 	}
 	url := fmt.Sprintf("/nodes/%s/%s/%d/snapshot/", vmr.node, vmr.vmType, vmr.vmId)
-	resp, err := c.session.Get(url, nil, nil)
+	resp, err := c.session.Get(ctx, url, nil, nil)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
@@ -737,25 +740,25 @@ func (c *Client) ListQemuSnapshot(vmr *VmRef) (taskResponse map[string]interface
 
 // DEPRECATED superseded by RollbackSnapshot()
 func (c *Client) RollbackQemuVm(vmr *VmRef, snapshot string) (exitStatus string, err error) {
-	return RollbackSnapshot(c, vmr, SnapshotName(snapshot))
+	return RollbackSnapshot(context.Background(), c, vmr, SnapshotName(snapshot))
 }
 
 // DEPRECATED SetVmConfig - send config options
 func (c *Client) SetVmConfig(vmr *VmRef, params map[string]interface{}) (exitStatus interface{}, err error) {
-	return c.PostWithTask(params, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/config")
+	return c.PostWithTask(context.Background(), params, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/config")
 }
 
 // SetLxcConfig - send config options
-func (c *Client) SetLxcConfig(vmr *VmRef, vmParams map[string]interface{}) (exitStatus interface{}, err error) {
+func (c *Client) SetLxcConfig(ctx context.Context, vmr *VmRef, vmParams map[string]interface{}) (exitStatus interface{}, err error) {
 	reqbody := ParamsToBody(vmParams)
 	url := fmt.Sprintf("/nodes/%s/%s/%d/config", vmr.node, vmr.vmType, vmr.vmId)
-	resp, err := c.session.Put(url, nil, nil, &reqbody)
+	resp, err := c.session.Put(ctx, url, nil, nil, &reqbody)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
 			return nil, err
 		}
-		exitStatus, err = c.WaitForCompletion(taskResponse)
+		exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 		if err != nil {
 			return "", err
 		}
@@ -764,16 +767,16 @@ func (c *Client) SetLxcConfig(vmr *VmRef, vmParams map[string]interface{}) (exit
 }
 
 // MigrateNode - Migrate a VM
-func (c *Client) MigrateNode(vmr *VmRef, newTargetNode string, online bool) (exitStatus interface{}, err error) {
+func (c *Client) MigrateNode(ctx context.Context, vmr *VmRef, newTargetNode string, online bool) (exitStatus interface{}, err error) {
 	reqbody := ParamsToBody(map[string]interface{}{"target": newTargetNode, "online": online, "with-local-disks": true})
 	url := fmt.Sprintf("/nodes/%s/%s/%d/migrate", vmr.node, vmr.vmType, vmr.vmId)
-	resp, err := c.session.Post(url, nil, nil, &reqbody)
+	resp, err := c.session.Post(ctx, url, nil, nil, &reqbody)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
 			return nil, err
 		}
-		exitStatus, err = c.WaitForCompletion(taskResponse)
+		exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 		return exitStatus, err
 	}
 	return nil, err
@@ -781,9 +784,9 @@ func (c *Client) MigrateNode(vmr *VmRef, newTargetNode string, online bool) (exi
 
 // ResizeQemuDisk allows the caller to increase the size of a disk by the indicated number of gigabytes
 // TODO Deprecate once LXC is able to resize disk by itself (qemu can already do this)
-func (c *Client) ResizeQemuDisk(vmr *VmRef, disk string, moreSizeGB int) (exitStatus interface{}, err error) {
+func (c *Client) ResizeQemuDisk(ctx context.Context, vmr *VmRef, disk string, moreSizeGB int) (exitStatus interface{}, err error) {
 	size := fmt.Sprintf("+%dG", moreSizeGB)
-	return c.ResizeQemuDiskRaw(vmr, disk, size)
+	return c.ResizeQemuDiskRaw(ctx, vmr, disk, size)
 }
 
 // ResizeQemuDiskRaw allows the caller to provide the raw resize string to be send to proxmox.
@@ -792,7 +795,7 @@ func (c *Client) ResizeQemuDisk(vmr *VmRef, disk string, moreSizeGB int) (exitSt
 // itself it will do an absolute resizing to the specified size. Permitted suffixes are K, M, G, T
 // to indicate order of magnitude (kilobyte, megabyte, etc). Decrease of disk size is not permitted.
 // TODO Deprecate once LXC is able to resize disk by itself (qemu can already do this)
-func (c *Client) ResizeQemuDiskRaw(vmr *VmRef, disk string, size string) (exitStatus interface{}, err error) {
+func (c *Client) ResizeQemuDiskRaw(ctx context.Context, vmr *VmRef, disk string, size string) (exitStatus interface{}, err error) {
 	// PUT
 	//disk:virtio0
 	// size:+2G
@@ -801,13 +804,13 @@ func (c *Client) ResizeQemuDiskRaw(vmr *VmRef, disk string, size string) (exitSt
 	}
 	reqbody := ParamsToBody(map[string]interface{}{"disk": disk, "size": size})
 	url := fmt.Sprintf("/nodes/%s/%s/%d/resize", vmr.node, vmr.vmType, vmr.vmId)
-	resp, err := c.session.Put(url, nil, nil, &reqbody)
+	resp, err := c.session.Put(ctx, url, nil, nil, &reqbody)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
 			return nil, err
 		}
-		exitStatus, err = c.WaitForCompletion(taskResponse)
+		exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 		if err != nil {
 			return "", err
 		}
@@ -815,16 +818,16 @@ func (c *Client) ResizeQemuDiskRaw(vmr *VmRef, disk string, size string) (exitSt
 	return
 }
 
-func (c *Client) MoveLxcDisk(vmr *VmRef, disk string, storage string) (exitStatus interface{}, err error) {
+func (c *Client) MoveLxcDisk(ctx context.Context, vmr *VmRef, disk string, storage string) (exitStatus interface{}, err error) {
 	reqbody := ParamsToBody(map[string]interface{}{"disk": disk, "storage": storage, "delete": true})
 	url := fmt.Sprintf("/nodes/%s/%s/%d/move_volume", vmr.node, vmr.vmType, vmr.vmId)
-	resp, err := c.session.Post(url, nil, nil, &reqbody)
+	resp, err := c.session.Post(ctx, url, nil, nil, &reqbody)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
 			return nil, err
 		}
-		exitStatus, err = c.WaitForCompletion(taskResponse)
+		exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 		if err != nil {
 			return "", err
 		}
@@ -835,18 +838,19 @@ func (c *Client) MoveLxcDisk(vmr *VmRef, disk string, storage string) (exitStatu
 // DEPRECATED use MoveQemuDisk() instead.
 // MoveQemuDisk - Move a disk from one storage to another
 func (c *Client) MoveQemuDisk(vmr *VmRef, disk string, storage string) (exitStatus interface{}, err error) {
+	ctx := context.Background()
 	if disk == "" {
 		disk = "virtio0"
 	}
 	reqbody := ParamsToBody(map[string]interface{}{"disk": disk, "storage": storage, "delete": true})
 	url := fmt.Sprintf("/nodes/%s/%s/%d/move_disk", vmr.node, vmr.vmType, vmr.vmId)
-	resp, err := c.session.Post(url, nil, nil, &reqbody)
+	resp, err := c.session.Post(ctx, url, nil, nil, &reqbody)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
 			return nil, err
 		}
-		exitStatus, err = c.WaitForCompletion(taskResponse)
+		exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 		if err != nil {
 			return "", err
 		}
@@ -855,16 +859,16 @@ func (c *Client) MoveQemuDisk(vmr *VmRef, disk string, storage string) (exitStat
 }
 
 // MoveQemuDiskToVM - Move a disk to a different VM, using the same storage
-func (c *Client) MoveQemuDiskToVM(vmrSource *VmRef, disk string, vmrTarget *VmRef) (exitStatus interface{}, err error) {
+func (c *Client) MoveQemuDiskToVM(ctx context.Context, vmrSource *VmRef, disk string, vmrTarget *VmRef) (exitStatus interface{}, err error) {
 	reqbody := ParamsToBody(map[string]interface{}{"disk": disk, "target-vmid": vmrTarget.vmId, "delete": true})
 	url := fmt.Sprintf("/nodes/%s/%s/%d/move_disk", vmrSource.node, vmrSource.vmType, vmrSource.vmId)
-	resp, err := c.session.Post(url, nil, nil, &reqbody)
+	resp, err := c.session.Post(ctx, url, nil, nil, &reqbody)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
 			return nil, err
 		}
-		exitStatus, err = c.WaitForCompletion(taskResponse)
+		exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 		if err != nil {
 			return "", err
 		}
@@ -874,13 +878,13 @@ func (c *Client) MoveQemuDiskToVM(vmrSource *VmRef, disk string, vmrTarget *VmRe
 
 // Unlink - Unlink (detach) a set of disks from a VM.
 // Reference: https://pve.proxmox.com/pve-docs/api-viewer/index.html#/nodes/{node}/qemu/{vmid}/unlink
-func (c *Client) Unlink(node string, vmId int, diskIds string, forceRemoval bool) (exitStatus string, err error) {
+func (c *Client) Unlink(ctx context.Context, node string, vmId int, diskIds string, forceRemoval bool) (exitStatus string, err error) {
 	url := fmt.Sprintf("/nodes/%s/qemu/%d/unlink", node, vmId)
 	data := ParamsToBody(map[string]interface{}{
 		"idlist": diskIds,
 		"force":  forceRemoval,
 	})
-	resp, err := c.session.Put(url, nil, nil, &data)
+	resp, err := c.session.Put(ctx, url, nil, nil, &data)
 	if err != nil {
 		return c.HandleTaskError(resp), err
 	}
@@ -888,11 +892,11 @@ func (c *Client) Unlink(node string, vmId int, diskIds string, forceRemoval bool
 	if err != nil {
 		return "", err
 	}
-	return c.WaitForCompletion(json)
+	return c.WaitForCompletion(ctx, json)
 }
 
 // GetNextID - Get next free VMID
-func (c *Client) GetNextID(currentID int) (nextID int, err error) {
+func (c *Client) GetNextID(ctx context.Context, currentID int) (nextID int, err error) {
 	var data map[string]interface{}
 	var url string
 	if currentID >= 100 {
@@ -900,25 +904,25 @@ func (c *Client) GetNextID(currentID int) (nextID int, err error) {
 	} else {
 		url = "/cluster/nextid"
 	}
-	_, err = c.session.GetJSON(url, nil, nil, &data)
+	_, err = c.session.GetJSON(ctx, url, nil, nil, &data)
 	if err == nil {
 		if data["errors"] != nil {
 			if currentID >= 100 {
-				return c.GetNextID(currentID + 1)
+				return c.GetNextID(ctx, currentID+1)
 			} else {
 				return -1, fmt.Errorf("error using /cluster/nextid")
 			}
 		}
 		nextID, err = strconv.Atoi(data["data"].(string))
 	} else if strings.HasPrefix(err.Error(), "400 ") {
-		return c.GetNextID(currentID + 1)
+		return c.GetNextID(ctx, currentID+1)
 	}
 	return
 }
 
 // VMIdExists - If you pass an VMID that exists it will return true, otherwise it wil return false
-func (c *Client) VMIdExists(vmID int) (exists bool, err error) {
-	vms, err := c.GetResourceList(resourceListGuest)
+func (c *Client) VMIdExists(ctx context.Context, vmID int) (exists bool, err error) {
+	vms, err := c.GetResourceList(ctx, resourceListGuest)
 	if err != nil {
 		return
 	}
@@ -933,6 +937,7 @@ func (c *Client) VMIdExists(vmID int) (exists bool, err error) {
 
 // CreateVMDisk - Create single disk for VM on host node.
 func (c *Client) CreateVMDisk(
+	ctx context.Context,
 	nodeName string,
 	storageName string,
 	fullDiskName string,
@@ -940,7 +945,7 @@ func (c *Client) CreateVMDisk(
 ) error {
 	reqbody := ParamsToBody(diskParams)
 	url := fmt.Sprintf("/nodes/%s/storage/%s/content", nodeName, storageName)
-	resp, err := c.session.Post(url, nil, nil, &reqbody)
+	resp, err := c.session.Post(ctx, url, nil, nil, &reqbody)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
@@ -960,6 +965,7 @@ var rxStorageModels = regexp.MustCompile(`(ide|sata|scsi|virtio)\d+`)
 
 // createVMDisks - Make disks parameters and create all VM disks on host node.
 func (c *Client) createVMDisks(
+	ctx context.Context,
 	node string,
 	vmParams map[string]interface{},
 ) (disks []string, err error) {
@@ -977,7 +983,7 @@ func (c *Client) createVMDisks(
 					"filename": volumeName,
 					"size":     deviceConfMap["size"],
 				}
-				err := c.CreateVMDisk(node, storageName, fullDiskName, diskParams)
+				err := c.CreateVMDisk(ctx, node, storageName, fullDiskName, diskParams)
 				if err != nil {
 					return createdDisks, err
 				} else {
@@ -992,16 +998,16 @@ func (c *Client) createVMDisks(
 
 // CreateNewDisk - This method allows simpler disk creation for direct client users
 // It should work for any existing container and virtual machine
-func (c *Client) CreateNewDisk(vmr *VmRef, disk string, volume string) (exitStatus interface{}, err error) {
+func (c *Client) CreateNewDisk(ctx context.Context, vmr *VmRef, disk string, volume string) (exitStatus interface{}, err error) {
 	reqbody := ParamsToBody(map[string]interface{}{disk: volume})
 	url := fmt.Sprintf("/nodes/%s/%s/%d/config", vmr.node, vmr.vmType, vmr.vmId)
-	resp, err := c.session.Put(url, nil, nil, &reqbody)
+	resp, err := c.session.Put(ctx, url, nil, nil, &reqbody)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
 			return nil, err
 		}
-		exitStatus, err = c.WaitForCompletion(taskResponse)
+		exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 		if err != nil {
 			return "", err
 		}
@@ -1013,13 +1019,14 @@ func (c *Client) CreateNewDisk(vmr *VmRef, disk string, volume string) (exitStat
 // By default the VM disks are deleted when the VM is deleted,
 // so mainly this is used to delete the disks in case VM creation didn't complete.
 func (c *Client) DeleteVMDisks(
+	ctx context.Context,
 	node string,
 	disks []string,
 ) error {
 	for _, fullDiskName := range disks {
 		storageName, volumeName := getStorageAndVolumeName(fullDiskName, ":")
 		url := fmt.Sprintf("/nodes/%s/storage/%s/content/%s", node, storageName, volumeName)
-		_, err := c.session.Post(url, nil, nil, nil)
+		_, err := c.session.Post(ctx, url, nil, nil, nil)
 		if err != nil {
 			return err
 		}
@@ -1029,20 +1036,20 @@ func (c *Client) DeleteVMDisks(
 }
 
 // VzDump - Create backup
-func (c *Client) VzDump(vmr *VmRef, params map[string]interface{}) (exitStatus interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) VzDump(ctx context.Context, vmr *VmRef, params map[string]interface{}) (exitStatus interface{}, err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return nil, err
 	}
 	reqbody := ParamsToBody(params)
 	url := fmt.Sprintf("/nodes/%s/vzdump", vmr.node)
-	resp, err := c.session.Post(url, nil, nil, &reqbody)
+	resp, err := c.session.Post(ctx, url, nil, nil, &reqbody)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
 			return nil, err
 		}
-		exitStatus, err = c.WaitForCompletion(taskResponse)
+		exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 		if err != nil {
 			return "", err
 		}
@@ -1051,19 +1058,19 @@ func (c *Client) VzDump(vmr *VmRef, params map[string]interface{}) (exitStatus i
 }
 
 // DeleteVolume - Delete volume
-func (c *Client) DeleteVolume(vmr *VmRef, storageName string, volumeName string) (exitStatus interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) DeleteVolume(ctx context.Context, vmr *VmRef, storageName string, volumeName string) (exitStatus interface{}, err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return nil, err
 	}
 	url := fmt.Sprintf("/nodes/%s/storage/%s/content/%s", vmr.node, storageName, volumeName)
-	resp, err := c.session.Delete(url, nil, nil)
+	resp, err := c.session.Delete(ctx, url, nil, nil)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
 			return nil, err
 		}
-		exitStatus, err = c.WaitForCompletion(taskResponse)
+		exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 		if err != nil {
 			return "", err
 		}
@@ -1072,14 +1079,14 @@ func (c *Client) DeleteVolume(vmr *VmRef, storageName string, volumeName string)
 }
 
 // CreateVNCProxy - Creates a TCP VNC proxy connections
-func (c *Client) CreateVNCProxy(vmr *VmRef, params map[string]interface{}) (vncProxyRes map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) CreateVNCProxy(ctx context.Context, vmr *VmRef, params map[string]interface{}) (vncProxyRes map[string]interface{}, err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return nil, err
 	}
 	reqbody := ParamsToBody(params)
 	url := fmt.Sprintf("/nodes/%s/qemu/%d/vncproxy", vmr.node, vmr.vmId)
-	resp, err := c.session.Post(url, nil, nil, &reqbody)
+	resp, err := c.session.Post(ctx, url, nil, nil, &reqbody)
 	if err != nil {
 		return nil, err
 	}
@@ -1095,13 +1102,13 @@ func (c *Client) CreateVNCProxy(vmr *VmRef, params map[string]interface{}) (vncP
 }
 
 // QemuAgentPing - Execute ping.
-func (c *Client) QemuAgentPing(vmr *VmRef) (pingRes map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) QemuAgentPing(ctx context.Context, vmr *VmRef) (pingRes map[string]interface{}, err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return nil, err
 	}
 	url := fmt.Sprintf("/nodes/%s/qemu/%d/agent/ping", vmr.node, vmr.vmId)
-	resp, err := c.session.Post(url, nil, nil, nil)
+	resp, err := c.session.Post(ctx, url, nil, nil, nil)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
@@ -1116,26 +1123,26 @@ func (c *Client) QemuAgentPing(vmr *VmRef) (pingRes map[string]interface{}, err 
 }
 
 // QemuAgentFileWrite - Writes the given file via guest agent.
-func (c *Client) QemuAgentFileWrite(vmr *VmRef, params map[string]interface{}) (err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) QemuAgentFileWrite(ctx context.Context, vmr *VmRef, params map[string]interface{}) (err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return err
 	}
 	reqbody := ParamsToBody(params)
 	url := fmt.Sprintf("/nodes/%s/qemu/%d/agent/file-write", vmr.node, vmr.vmId)
-	_, err = c.session.Post(url, nil, nil, &reqbody)
+	_, err = c.session.Post(ctx, url, nil, nil, &reqbody)
 	return
 }
 
 // QemuAgentSetUserPassword - Sets the password for the given user to the given password.
-func (c *Client) QemuAgentSetUserPassword(vmr *VmRef, params map[string]interface{}) (result map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) QemuAgentSetUserPassword(ctx context.Context, vmr *VmRef, params map[string]interface{}) (result map[string]interface{}, err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return nil, err
 	}
 	reqbody := ParamsToBody(params)
 	url := fmt.Sprintf("/nodes/%s/qemu/%d/agent/set-user-password", vmr.node, vmr.vmId)
-	resp, err := c.session.Post(url, nil, nil, &reqbody)
+	resp, err := c.session.Post(ctx, url, nil, nil, &reqbody)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
@@ -1150,14 +1157,14 @@ func (c *Client) QemuAgentSetUserPassword(vmr *VmRef, params map[string]interfac
 }
 
 // QemuAgentExec - Executes the given command in the vm via the guest-agent and returns an object with the pid.
-func (c *Client) QemuAgentExec(vmr *VmRef, params map[string]interface{}) (result map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) QemuAgentExec(ctx context.Context, vmr *VmRef, params map[string]interface{}) (result map[string]interface{}, err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return nil, err
 	}
 	reqbody := ParamsToBody(params)
 	url := fmt.Sprintf("/nodes/%s/qemu/%d/agent/exec", vmr.node, vmr.vmId)
-	resp, err := c.session.Post(url, nil, nil, &reqbody)
+	resp, err := c.session.Post(ctx, url, nil, nil, &reqbody)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
@@ -1172,12 +1179,12 @@ func (c *Client) QemuAgentExec(vmr *VmRef, params map[string]interface{}) (resul
 }
 
 // GetExecStatus - Gets the status of the given pid started by the guest-agent
-func (c *Client) GetExecStatus(vmr *VmRef, pid string) (status map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) GetExecStatus(ctx context.Context, vmr *VmRef, pid string) (status map[string]interface{}, err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return nil, err
 	}
-	err = c.GetJsonRetryable(fmt.Sprintf("/nodes/%s/%s/%d/agent/exec-status?pid=%s", vmr.node, vmr.vmType, vmr.vmId, pid), &status, 3)
+	err = c.GetJsonRetryable(ctx, fmt.Sprintf("/nodes/%s/%s/%d/agent/exec-status?pid=%s", vmr.node, vmr.vmType, vmr.vmId, pid), &status, 3)
 	if err == nil {
 		status = status["data"].(map[string]interface{})
 	}
@@ -1185,20 +1192,20 @@ func (c *Client) GetExecStatus(vmr *VmRef, pid string) (status map[string]interf
 }
 
 // SetQemuFirewallOptions - Set Firewall options.
-func (c *Client) SetQemuFirewallOptions(vmr *VmRef, fwOptions map[string]interface{}) (exitStatus interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) SetQemuFirewallOptions(ctx context.Context, vmr *VmRef, fwOptions map[string]interface{}) (exitStatus interface{}, err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return nil, err
 	}
 	reqbody := ParamsToBody(fwOptions)
 	url := fmt.Sprintf("/nodes/%s/qemu/%d/firewall/options", vmr.node, vmr.vmId)
-	resp, err := c.session.Put(url, nil, nil, &reqbody)
+	resp, err := c.session.Put(ctx, url, nil, nil, &reqbody)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
 			return nil, err
 		}
-		exitStatus, err = c.WaitForCompletion(taskResponse)
+		exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 		if err != nil {
 			return "", err
 		}
@@ -1207,13 +1214,13 @@ func (c *Client) SetQemuFirewallOptions(vmr *VmRef, fwOptions map[string]interfa
 }
 
 // GetQemuFirewallOptions - Get VM firewall options.
-func (c *Client) GetQemuFirewallOptions(vmr *VmRef) (firewallOptions map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) GetQemuFirewallOptions(ctx context.Context, vmr *VmRef) (firewallOptions map[string]interface{}, err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return nil, err
 	}
 	url := fmt.Sprintf("/nodes/%s/qemu/%d/firewall/options", vmr.node, vmr.vmId)
-	resp, err := c.session.Get(url, nil, nil)
+	resp, err := c.session.Get(ctx, url, nil, nil)
 	if err == nil {
 		firewallOptions, err := ResponseJSON(resp)
 		if err != nil {
@@ -1225,20 +1232,20 @@ func (c *Client) GetQemuFirewallOptions(vmr *VmRef) (firewallOptions map[string]
 }
 
 // CreateQemuIPSet - Create new IPSet
-func (c *Client) CreateQemuIPSet(vmr *VmRef, params map[string]interface{}) (exitStatus interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) CreateQemuIPSet(ctx context.Context, vmr *VmRef, params map[string]interface{}) (exitStatus interface{}, err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return nil, err
 	}
 	reqbody := ParamsToBody(params)
 	url := fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset", vmr.node, vmr.vmId)
-	resp, err := c.session.Post(url, nil, nil, &reqbody)
+	resp, err := c.session.Post(ctx, url, nil, nil, &reqbody)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
 			return nil, err
 		}
-		exitStatus, err = c.WaitForCompletion(taskResponse)
+		exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 		if err != nil {
 			return "", err
 		}
@@ -1247,20 +1254,20 @@ func (c *Client) CreateQemuIPSet(vmr *VmRef, params map[string]interface{}) (exi
 }
 
 // AddQemuIPSet - Add IP or Network to IPSet.
-func (c *Client) AddQemuIPSet(vmr *VmRef, name string, params map[string]interface{}) (exitStatus interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) AddQemuIPSet(ctx context.Context, vmr *VmRef, name string, params map[string]interface{}) (exitStatus interface{}, err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return nil, err
 	}
 	reqbody := ParamsToBody(params)
 	url := fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s", vmr.node, vmr.vmId, name)
-	resp, err := c.session.Post(url, nil, nil, &reqbody)
+	resp, err := c.session.Post(ctx, url, nil, nil, &reqbody)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
 			return nil, err
 		}
-		exitStatus, err = c.WaitForCompletion(taskResponse)
+		exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 		if err != nil {
 			return "", err
 		}
@@ -1269,13 +1276,13 @@ func (c *Client) AddQemuIPSet(vmr *VmRef, name string, params map[string]interfa
 }
 
 // GetQemuIPSet - List IPSets
-func (c *Client) GetQemuIPSet(vmr *VmRef) (ipsets map[string]interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) GetQemuIPSet(ctx context.Context, vmr *VmRef) (ipsets map[string]interface{}, err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return nil, err
 	}
 	url := fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset", vmr.node, vmr.vmId)
-	resp, err := c.session.Get(url, nil, nil)
+	resp, err := c.session.Get(ctx, url, nil, nil)
 	if err == nil {
 		ipsets, err := ResponseJSON(resp)
 		if err != nil {
@@ -1287,19 +1294,19 @@ func (c *Client) GetQemuIPSet(vmr *VmRef) (ipsets map[string]interface{}, err er
 }
 
 // DeleteQemuIPSet - Delete IPSet
-func (c *Client) DeleteQemuIPSet(vmr *VmRef, IPSetName string) (exitStatus interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) DeleteQemuIPSet(ctx context.Context, vmr *VmRef, IPSetName string) (exitStatus interface{}, err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return nil, err
 	}
 	url := fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s", vmr.node, vmr.vmId, IPSetName)
-	resp, err := c.session.Delete(url, nil, nil)
+	resp, err := c.session.Delete(ctx, url, nil, nil)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
 			return nil, err
 		}
-		exitStatus, err = c.WaitForCompletion(taskResponse)
+		exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 		if err != nil {
 			return "", err
 		}
@@ -1308,20 +1315,20 @@ func (c *Client) DeleteQemuIPSet(vmr *VmRef, IPSetName string) (exitStatus inter
 }
 
 // DeleteQemuIPSetNetwork - Remove IP or Network from IPSet.
-func (c *Client) DeleteQemuIPSetNetwork(vmr *VmRef, IPSetName string, network string, params map[string]interface{}) (exitStatus interface{}, err error) {
-	err = c.CheckVmRef(vmr)
+func (c *Client) DeleteQemuIPSetNetwork(ctx context.Context, vmr *VmRef, IPSetName string, network string, params map[string]interface{}) (exitStatus interface{}, err error) {
+	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {
 		return nil, err
 	}
 	values := ParamsToValues(params)
 	url := fmt.Sprintf("/nodes/%s/qemu/%d/firewall/ipset/%s/%s", vmr.node, vmr.vmId, IPSetName, network)
-	resp, err := c.session.Delete(url, &values, nil)
+	resp, err := c.session.Delete(ctx, url, &values, nil)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
 			return nil, err
 		}
-		exitStatus, err = c.WaitForCompletion(taskResponse)
+		exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 		if err != nil {
 			return "", err
 		}
@@ -1329,7 +1336,7 @@ func (c *Client) DeleteQemuIPSetNetwork(vmr *VmRef, IPSetName string, network st
 	return
 }
 
-func (c *Client) Upload(node string, storage string, contentType string, filename string, file io.Reader) error {
+func (c *Client) Upload(ctx context.Context, node string, storage string, contentType string, filename string, file io.Reader) error {
 	var doStreamingIO bool
 	var fileSize int64
 	var contentLength int64
@@ -1360,7 +1367,7 @@ func (c *Client) Upload(node string, storage string, contentType string, filenam
 	headers := c.session.Headers.Clone()
 	headers.Add("Content-Type", mimetype)
 	headers.Add("Accept", "application/json")
-	req, err := c.session.NewRequest(http.MethodPost, url, &headers, body)
+	req, err := c.session.NewRequest(ctx, http.MethodPost, url, &headers, body)
 	if err != nil {
 		return err
 	}
@@ -1378,7 +1385,7 @@ func (c *Client) Upload(node string, storage string, contentType string, filenam
 	if err != nil {
 		return err
 	}
-	exitStatus, err := c.WaitForCompletion(taskResponse)
+	exitStatus, err := c.WaitForCompletion(ctx, taskResponse)
 	if err != nil {
 		return err
 	}
@@ -1388,7 +1395,7 @@ func (c *Client) Upload(node string, storage string, contentType string, filenam
 	return nil
 }
 
-func (c *Client) UploadLargeFile(node string, storage string, contentType string, filename string, filesize int64, file io.Reader) error {
+func (c *Client) UploadLargeFile(ctx context.Context, node string, storage string, contentType string, filename string, filesize int64, file io.Reader) error {
 	var contentLength int64
 
 	var body io.Reader
@@ -1403,7 +1410,7 @@ func (c *Client) UploadLargeFile(node string, storage string, contentType string
 	headers := c.session.Headers.Clone()
 	headers.Add("Content-Type", mimetype)
 	headers.Add("Accept", "application/json")
-	req, err := c.session.NewRequest(http.MethodPost, url, &headers, body)
+	req, err := c.session.NewRequest(ctx, http.MethodPost, url, &headers, body)
 	if err != nil {
 		return err
 	}
@@ -1419,7 +1426,7 @@ func (c *Client) UploadLargeFile(node string, storage string, contentType string
 	if err != nil {
 		return err
 	}
-	exitStatus, err := c.WaitForCompletion(taskResponse)
+	exitStatus, err := c.WaitForCompletion(ctx, taskResponse)
 	if err != nil {
 		return err
 	}
@@ -1507,7 +1514,7 @@ func getStorageAndVolumeName(
 }
 
 // Still used by Terraform. Deprecated: use ConfigQemu.Update() instead
-func (c *Client) UpdateVMPool(vmr *VmRef, pool string) (exitStatus interface{}, err error) {
+func (c *Client) UpdateVMPool(ctx context.Context, vmr *VmRef, pool string) (exitStatus interface{}, err error) {
 	// Same pool
 	if vmr.pool == pool {
 		return
@@ -1521,13 +1528,13 @@ func (c *Client) UpdateVMPool(vmr *VmRef, pool string) (exitStatus interface{}, 
 		}
 		reqbody := ParamsToBody(paramMap)
 		url := fmt.Sprintf("/pools/%s", vmr.pool)
-		resp, err := c.session.Put(url, nil, nil, &reqbody)
+		resp, err := c.session.Put(ctx, url, nil, nil, &reqbody)
 		if err == nil {
 			taskResponse, err := ResponseJSON(resp)
 			if err != nil {
 				return nil, err
 			}
-			exitStatus, err = c.WaitForCompletion(taskResponse)
+			exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 
 			if err != nil {
 				return nil, err
@@ -1541,13 +1548,13 @@ func (c *Client) UpdateVMPool(vmr *VmRef, pool string) (exitStatus interface{}, 
 		}
 		reqbody := ParamsToBody(paramMap)
 		url := fmt.Sprintf("/pools/%s", pool)
-		resp, err := c.session.Put(url, nil, nil, &reqbody)
+		resp, err := c.session.Put(ctx, url, nil, nil, &reqbody)
 		if err == nil {
 			taskResponse, err := ResponseJSON(resp)
 			if err != nil {
 				return nil, err
 			}
-			exitStatus, err = c.WaitForCompletion(taskResponse)
+			exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 			if err != nil {
 				return nil, err
 			}
@@ -1558,10 +1565,10 @@ func (c *Client) UpdateVMPool(vmr *VmRef, pool string) (exitStatus interface{}, 
 	return
 }
 
-func (c *Client) ReadVMHA(vmr *VmRef) (err error) {
+func (c *Client) ReadVMHA(ctx context.Context, vmr *VmRef) (err error) {
 	var list map[string]interface{}
 	url := fmt.Sprintf("/cluster/ha/resources/%d", vmr.vmId)
-	err = c.GetJsonRetryable(url, &list, 3)
+	err = c.GetJsonRetryable(ctx, url, &list, 3)
 	if err == nil {
 		list = list["data"].(map[string]interface{})
 		for elem, value := range list {
@@ -1576,7 +1583,7 @@ func (c *Client) ReadVMHA(vmr *VmRef) (err error) {
 	return
 }
 
-func (c *Client) UpdateVMHA(vmr *VmRef, haState string, haGroup string) (exitStatus interface{}, err error) {
+func (c *Client) UpdateVMHA(ctx context.Context, vmr *VmRef, haState string, haGroup string) (exitStatus interface{}, err error) {
 	// Same hastate & hagroup
 	if vmr.haState == haState && vmr.haGroup == haGroup {
 		return
@@ -1585,13 +1592,13 @@ func (c *Client) UpdateVMHA(vmr *VmRef, haState string, haGroup string) (exitSta
 	// Remove HA
 	if haState == "" {
 		url := fmt.Sprintf("/cluster/ha/resources/%d", vmr.vmId)
-		resp, err := c.session.Delete(url, nil, nil)
+		resp, err := c.session.Delete(ctx, url, nil, nil)
 		if err == nil {
 			taskResponse, err := ResponseJSON(resp)
 			if err != nil {
 				return nil, err
 			}
-			exitStatus, err = c.WaitForCompletion(taskResponse)
+			exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 			if err != nil {
 				return nil, err
 			}
@@ -1608,13 +1615,13 @@ func (c *Client) UpdateVMHA(vmr *VmRef, haState string, haGroup string) (exitSta
 			paramMap["group"] = haGroup
 		}
 		reqbody := ParamsToBody(paramMap)
-		resp, err := c.session.Post("/cluster/ha/resources", nil, nil, &reqbody)
+		resp, err := c.session.Post(ctx, "/cluster/ha/resources", nil, nil, &reqbody)
 		if err == nil {
 			taskResponse, err := ResponseJSON(resp)
 			if err != nil {
 				return nil, err
 			}
-			exitStatus, err = c.WaitForCompletion(taskResponse)
+			exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 
 			if err != nil {
 				return nil, err
@@ -1629,13 +1636,13 @@ func (c *Client) UpdateVMHA(vmr *VmRef, haState string, haGroup string) (exitSta
 	}
 	reqbody := ParamsToBody(paramMap)
 	url := fmt.Sprintf("/cluster/ha/resources/%d", vmr.vmId)
-	resp, err := c.session.Put(url, nil, nil, &reqbody)
+	resp, err := c.session.Put(ctx, url, nil, nil, &reqbody)
 	if err == nil {
 		taskResponse, err := ResponseJSON(resp)
 		if err != nil {
 			return nil, err
 		}
-		exitStatus, err = c.WaitForCompletion(taskResponse)
+		exitStatus, err = c.WaitForCompletion(ctx, taskResponse)
 		if err != nil {
 			return nil, err
 		}
@@ -1645,18 +1652,18 @@ func (c *Client) UpdateVMHA(vmr *VmRef, haState string, haGroup string) (exitSta
 }
 
 // Still used by Terraform. Deprecated: use ListPoolsWithComments() instead
-func (c *Client) GetPoolList() (pools map[string]interface{}, err error) {
-	return c.GetItemList("/pools")
+func (c *Client) GetPoolList(ctx context.Context) (pools map[string]interface{}, err error) {
+	return c.GetItemList(ctx, "/pools")
 }
 
 // TODO: implement replacement
-func (c *Client) GetPoolInfo(poolid string) (poolInfo map[string]interface{}, err error) {
-	return c.GetItemConfigMapStringInterface("/pools/"+poolid, "pool", "CONFIG")
+func (c *Client) GetPoolInfo(ctx context.Context, poolid string) (poolInfo map[string]interface{}, err error) {
+	return c.GetItemConfigMapStringInterface(ctx, "/pools/"+poolid, "pool", "CONFIG")
 }
 
 // Deprecated: use ConfigPool.Create() instead
 func (c *Client) CreatePool(poolid string, comment string) error {
-	return c.Post(map[string]interface{}{
+	return c.Post(context.Background(), map[string]interface{}{
 		"poolid":  poolid,
 		"comment": comment,
 	}, "/pools")
@@ -1664,7 +1671,7 @@ func (c *Client) CreatePool(poolid string, comment string) error {
 
 // Deprecated: use ConfigPool.Update() instead
 func (c *Client) UpdatePoolComment(poolid string, comment string) error {
-	return c.Put(map[string]interface{}{
+	return c.Put(context.Background(), map[string]interface{}{
 		"poolid":  poolid,
 		"comment": comment,
 	}, "/pools/"+poolid)
@@ -1672,19 +1679,19 @@ func (c *Client) UpdatePoolComment(poolid string, comment string) error {
 
 // Deprecated: use PoolName.Delete() instead
 func (c *Client) DeletePool(poolid string) error {
-	return c.Delete("/pools/" + poolid)
+	return c.Delete(context.Background(), "/pools/"+poolid)
 }
 
 // permissions check
-func (c *Client) GetUserPermissions(id UserID, path string) (permissions []string, err error) {
-	existence, err := CheckUserExistence(id, c)
+func (c *Client) GetUserPermissions(ctx context.Context, id UserID, path string) (permissions []string, err error) {
+	existence, err := CheckUserExistence(ctx, id, c)
 	if err != nil {
 		return nil, err
 	}
 	if !existence {
 		return nil, fmt.Errorf("cannot get user (%s) permissions, the user does not exist", id)
 	}
-	permlist, err := c.GetItemList("/access/permissions?userid=" + id.String() + "&path=" + path)
+	permlist, err := c.GetItemList(ctx, "/access/permissions?userid="+id.String()+"&path="+path)
 	failError(err)
 	data := permlist["data"].(map[string]interface{})
 	for pth, prm := range data {
@@ -1699,8 +1706,8 @@ func (c *Client) GetUserPermissions(id UserID, path string) (permissions []strin
 }
 
 // ACME
-func (c *Client) GetAcmeDirectoriesUrl() (url []string, err error) {
-	config, err := c.GetItemConfigInterfaceArray("/cluster/acme/directories", "Acme directories", "CONFIG")
+func (c *Client) GetAcmeDirectoriesUrl(ctx context.Context) (url []string, err error) {
+	config, err := c.GetItemConfigInterfaceArray(ctx, "/cluster/acme/directories", "Acme directories", "CONFIG")
 	url = make([]string, len(config))
 	for i, element := range config {
 		url[i] = element.(map[string]interface{})["url"].(string)
@@ -1708,119 +1715,119 @@ func (c *Client) GetAcmeDirectoriesUrl() (url []string, err error) {
 	return
 }
 
-func (c *Client) GetAcmeTosUrl() (url string, err error) {
-	return c.GetItemConfigString("/cluster/acme/tos", "Acme T.O.S.", "CONFIG")
+func (c *Client) GetAcmeTosUrl(ctx context.Context) (url string, err error) {
+	return c.GetItemConfigString(ctx, "/cluster/acme/tos", "Acme T.O.S.", "CONFIG")
 }
 
 // ACME Account
-func (c *Client) GetAcmeAccountList() (accounts map[string]interface{}, err error) {
-	return c.GetItemList("/cluster/acme/account")
+func (c *Client) GetAcmeAccountList(ctx context.Context) (accounts map[string]interface{}, err error) {
+	return c.GetItemList(ctx, "/cluster/acme/account")
 }
 
-func (c *Client) GetAcmeAccountConfig(id string) (config map[string]interface{}, err error) {
-	return c.GetItemConfigMapStringInterface("/cluster/acme/account/"+id, "acme", "CONFIG")
+func (c *Client) GetAcmeAccountConfig(ctx context.Context, id string) (config map[string]interface{}, err error) {
+	return c.GetItemConfigMapStringInterface(ctx, "/cluster/acme/account/"+id, "acme", "CONFIG")
 }
 
-func (c *Client) CreateAcmeAccount(params map[string]interface{}) (exitStatus string, err error) {
-	return c.PostWithTask(params, "/cluster/acme/account/")
+func (c *Client) CreateAcmeAccount(ctx context.Context, params map[string]interface{}) (exitStatus string, err error) {
+	return c.PostWithTask(ctx, params, "/cluster/acme/account/")
 }
 
-func (c *Client) UpdateAcmeAccountEmails(id, emails string) (exitStatus string, err error) {
+func (c *Client) UpdateAcmeAccountEmails(ctx context.Context, id, emails string) (exitStatus string, err error) {
 	params := map[string]interface{}{
 		"contact": emails,
 	}
-	return c.PutWithTask(params, "/cluster/acme/account/"+id)
+	return c.PutWithTask(ctx, params, "/cluster/acme/account/"+id)
 }
 
-func (c *Client) DeleteAcmeAccount(id string) (exitStatus string, err error) {
-	return c.DeleteWithTask("/cluster/acme/account/" + id)
+func (c *Client) DeleteAcmeAccount(ctx context.Context, id string) (exitStatus string, err error) {
+	return c.DeleteWithTask(ctx, "/cluster/acme/account/"+id)
 }
 
 // ACME Plugin
-func (c *Client) GetAcmePluginList() (accounts map[string]interface{}, err error) {
-	return c.GetItemList("/cluster/acme/plugins")
+func (c *Client) GetAcmePluginList(ctx context.Context) (accounts map[string]interface{}, err error) {
+	return c.GetItemList(ctx, "/cluster/acme/plugins")
 }
 
-func (c *Client) GetAcmePluginConfig(id string) (config map[string]interface{}, err error) {
-	return c.GetItemConfigMapStringInterface("/cluster/acme/plugins/"+id, "acme plugin", "CONFIG")
+func (c *Client) GetAcmePluginConfig(ctx context.Context, id string) (config map[string]interface{}, err error) {
+	return c.GetItemConfigMapStringInterface(ctx, "/cluster/acme/plugins/"+id, "acme plugin", "CONFIG")
 }
 
-func (c *Client) CreateAcmePlugin(params map[string]interface{}) error {
-	return c.Post(params, "/cluster/acme/plugins/")
+func (c *Client) CreateAcmePlugin(ctx context.Context, params map[string]interface{}) error {
+	return c.Post(ctx, params, "/cluster/acme/plugins/")
 }
 
-func (c *Client) UpdateAcmePlugin(id string, params map[string]interface{}) error {
-	return c.Put(params, "/cluster/acme/plugins/"+id)
+func (c *Client) UpdateAcmePlugin(ctx context.Context, id string, params map[string]interface{}) error {
+	return c.Put(ctx, params, "/cluster/acme/plugins/"+id)
 }
 
-func (c *Client) CheckAcmePluginExistence(id string) (existance bool, err error) {
-	list, err := c.GetAcmePluginList()
+func (c *Client) CheckAcmePluginExistence(ctx context.Context, id string) (existance bool, err error) {
+	list, err := c.GetAcmePluginList(ctx)
 	existance = ItemInKeyOfArray(list["data"].([]interface{}), "plugin", id)
 	return
 }
 
-func (c *Client) DeleteAcmePlugin(id string) (err error) {
-	return c.Delete("/cluster/acme/plugins/" + id)
+func (c *Client) DeleteAcmePlugin(ctx context.Context, id string) (err error) {
+	return c.Delete(ctx, "/cluster/acme/plugins/"+id)
 }
 
 // Metrics
-func (c *Client) GetMetricServerConfig(id string) (config map[string]interface{}, err error) {
-	return c.GetItemConfigMapStringInterface("/cluster/metrics/server/"+id, "metrics server", "CONFIG")
+func (c *Client) GetMetricServerConfig(ctx context.Context, id string) (config map[string]interface{}, err error) {
+	return c.GetItemConfigMapStringInterface(ctx, "/cluster/metrics/server/"+id, "metrics server", "CONFIG")
 }
 
-func (c *Client) GetMetricsServerList() (metricServers map[string]interface{}, err error) {
-	return c.GetItemList("/cluster/metrics/server")
+func (c *Client) GetMetricsServerList(ctx context.Context) (metricServers map[string]interface{}, err error) {
+	return c.GetItemList(ctx, "/cluster/metrics/server")
 }
 
-func (c *Client) CreateMetricServer(id string, params map[string]interface{}) error {
-	return c.Post(params, "/cluster/metrics/server/"+id)
+func (c *Client) CreateMetricServer(ctx context.Context, id string, params map[string]interface{}) error {
+	return c.Post(ctx, params, "/cluster/metrics/server/"+id)
 }
 
-func (c *Client) UpdateMetricServer(id string, params map[string]interface{}) error {
-	return c.Put(params, "/cluster/metrics/server/"+id)
+func (c *Client) UpdateMetricServer(ctx context.Context, id string, params map[string]interface{}) error {
+	return c.Put(ctx, params, "/cluster/metrics/server/"+id)
 }
 
-func (c *Client) CheckMetricServerExistence(id string) (existance bool, err error) {
-	list, err := c.GetMetricsServerList()
+func (c *Client) CheckMetricServerExistence(ctx context.Context, id string) (existance bool, err error) {
+	list, err := c.GetMetricsServerList(ctx)
 	existance = ItemInKeyOfArray(list["data"].([]interface{}), "id", id)
 	return
 }
 
-func (c *Client) DeleteMetricServer(id string) error {
-	return c.Delete("/cluster/metrics/server/" + id)
+func (c *Client) DeleteMetricServer(ctx context.Context, id string) error {
+	return c.Delete(ctx, "/cluster/metrics/server/"+id)
 }
 
 // storage
-func (c *Client) EnableStorage(id string) error {
-	return c.Put(map[string]interface{}{
+func (c *Client) EnableStorage(ctx context.Context, id string) error {
+	return c.Put(ctx, map[string]interface{}{
 		"disable": false,
 	}, "/storage/"+id)
 }
 
-func (c *Client) GetStorageList() (metricServers map[string]interface{}, err error) {
-	return c.GetItemList("/storage")
+func (c *Client) GetStorageList(ctx context.Context) (metricServers map[string]interface{}, err error) {
+	return c.GetItemList(ctx, "/storage")
 }
 
-func (c *Client) GetStorageConfig(id string) (config map[string]interface{}, err error) {
-	return c.GetItemConfigMapStringInterface("/storage/"+id, "storage", "CONFIG")
+func (c *Client) GetStorageConfig(ctx context.Context, id string) (config map[string]interface{}, err error) {
+	return c.GetItemConfigMapStringInterface(ctx, "/storage/"+id, "storage", "CONFIG")
 }
 
-func (c *Client) CreateStorage(params map[string]interface{}) error {
-	return c.Post(params, "/storage")
+func (c *Client) CreateStorage(ctx context.Context, params map[string]interface{}) error {
+	return c.Post(ctx, params, "/storage")
 }
 
-func (c *Client) CheckStorageExistance(id string) (existance bool, err error) {
-	list, err := c.GetStorageList()
+func (c *Client) CheckStorageExistance(ctx context.Context, id string) (existance bool, err error) {
+	list, err := c.GetStorageList(ctx)
 	existance = ItemInKeyOfArray(list["data"].([]interface{}), "storage", id)
 	return
 }
 
-func (c *Client) UpdateStorage(id string, params map[string]interface{}) error {
-	return c.Put(params, "/storage/"+id)
+func (c *Client) UpdateStorage(ctx context.Context, id string, params map[string]interface{}) error {
+	return c.Put(ctx, params, "/storage/"+id)
 }
 
-func (c *Client) DeleteStorage(id string) error {
-	return c.Delete("/storage/" + id)
+func (c *Client) DeleteStorage(ctx context.Context, id string) error {
+	return c.Delete(ctx, "/storage/"+id)
 }
 
 // Network
@@ -1829,12 +1836,12 @@ func (c *Client) DeleteStorage(id string) error {
 // passed in node. The typeFilter parameter can be used to filter by interface type. Pass in
 // the empty string "" for typeFilter to list all network interfaces on the node.
 // It returns the body from the API response and any HTTP error the API returns.
-func (c *Client) GetNetworkList(node string, typeFilter string) (exitStatus string, err error) {
+func (c *Client) GetNetworkList(ctx context.Context, node string, typeFilter string) (exitStatus string, err error) {
 	url := fmt.Sprintf("/nodes/%s/network", node)
 	if typeFilter != "" {
 		url += fmt.Sprintf("?type=%s", typeFilter)
 	}
-	resp, err := c.session.Get(url, nil, nil)
+	resp, err := c.session.Get(ctx, url, nil, nil)
 	exitStatus = c.HandleTaskError(resp)
 	return
 }
@@ -1842,9 +1849,9 @@ func (c *Client) GetNetworkList(node string, typeFilter string) (exitStatus stri
 // GetNetworkInterface gets a json encoded object containing the configuration of the network
 // interface with the name passed in as iface from the passed in node.
 // It returns the body from the API response and any HTTP error the API returns.
-func (c *Client) GetNetworkInterface(node string, iface string) (exitStatus string, err error) {
+func (c *Client) GetNetworkInterface(ctx context.Context, node string, iface string) (exitStatus string, err error) {
 	url := fmt.Sprintf("/nodes/%s/network/%s", node, iface)
-	resp, err := c.session.Get(url, nil, nil)
+	resp, err := c.session.Get(ctx, url, nil, nil)
 	exitStatus = c.HandleTaskError(resp)
 	return
 }
@@ -1852,59 +1859,59 @@ func (c *Client) GetNetworkInterface(node string, iface string) (exitStatus stri
 // CreateNetwork creates a network with the configuration of the passed in parameters
 // on the passed in node.
 // It returns the body from the API response and any HTTP error the API returns.
-func (c *Client) CreateNetwork(node string, params map[string]interface{}) (exitStatus string, err error) {
+func (c *Client) CreateNetwork(ctx context.Context, node string, params map[string]interface{}) (exitStatus string, err error) {
 	url := fmt.Sprintf("/nodes/%s/network", node)
-	return c.CreateItemReturnStatus(params, url)
+	return c.CreateItemReturnStatus(ctx, params, url)
 }
 
 // UpdateNetwork updates the network corresponding to the passed in interface name on the passed
 // in node with the configuration in the passed in parameters.
 // It returns the body from the API response and any HTTP error the API returns.
-func (c *Client) UpdateNetwork(node string, iface string, params map[string]interface{}) (exitStatus string, err error) {
+func (c *Client) UpdateNetwork(ctx context.Context, node string, iface string, params map[string]interface{}) (exitStatus string, err error) {
 	url := fmt.Sprintf("/nodes/%s/network/%s", node, iface)
-	return c.UpdateItemReturnStatus(params, url)
+	return c.UpdateItemReturnStatus(ctx, params, url)
 }
 
 // DeleteNetwork deletes the network with the passed in iface name on the passed in node.
 // It returns the body from the API response and any HTTP error the API returns.
-func (c *Client) DeleteNetwork(node string, iface string) (exitStatus string, err error) {
+func (c *Client) DeleteNetwork(ctx context.Context, node string, iface string) (exitStatus string, err error) {
 	url := fmt.Sprintf("/nodes/%s/network/%s", node, iface)
-	resp, err := c.session.Delete(url, nil, nil)
+	resp, err := c.session.Delete(ctx, url, nil, nil)
 	exitStatus = c.HandleTaskError(resp)
 	return
 }
 
 // ApplyNetwork applies the pending network configuration on the passed in node.
 // It returns the body from the API response and any HTTP error the API returns.
-func (c Client) ApplyNetwork(node string) (exitStatus string, err error) {
+func (c Client) ApplyNetwork(ctx context.Context, node string) (exitStatus string, err error) {
 	url := fmt.Sprintf("/nodes/%s/network", node)
-	return c.PutWithTask(nil, url)
+	return c.PutWithTask(ctx, nil, url)
 }
 
 // RevertNetwork reverts the pending network configuration on the passed in node.
 // It returns the body from the API response and any HTTP error the API returns.
-func (c *Client) RevertNetwork(node string) (exitStatus string, err error) {
+func (c *Client) RevertNetwork(ctx context.Context, node string) (exitStatus string, err error) {
 	url := fmt.Sprintf("/nodes/%s/network", node)
-	return c.DeleteWithTask(url)
+	return c.DeleteWithTask(ctx, url)
 }
 
 // SDN
 
-func (c *Client) ApplySDN() (string, error) {
-	return c.PutWithTask(nil, "/cluster/sdn")
+func (c *Client) ApplySDN(ctx context.Context) (string, error) {
+	return c.PutWithTask(ctx, nil, "/cluster/sdn")
 }
 
 // GetSDNVNets returns a list of all VNet definitions in the "data" element of the returned
 // map.
-func (c *Client) GetSDNVNets(pending bool) (list map[string]interface{}, err error) {
+func (c *Client) GetSDNVNets(ctx context.Context, pending bool) (list map[string]interface{}, err error) {
 	url := fmt.Sprintf("/cluster/sdn/vnets?pending=%d", Btoi(pending))
-	err = c.GetJsonRetryable(url, &list, 3)
+	err = c.GetJsonRetryable(ctx, url, &list, 3)
 	return
 }
 
 // CheckSDNVNetExistance returns true if a DNS entry with the provided ID exists, false otherwise.
-func (c *Client) CheckSDNVNetExistance(id string) (existance bool, err error) {
-	list, err := c.GetSDNVNets(true)
+func (c *Client) CheckSDNVNetExistance(ctx context.Context, id string) (existance bool, err error) {
+	list, err := c.GetSDNVNets(ctx, true)
 	existance = ItemInKeyOfArray(list["data"].([]interface{}), "vnet", id)
 	return
 }
@@ -1912,38 +1919,38 @@ func (c *Client) CheckSDNVNetExistance(id string) (existance bool, err error) {
 // GetSDNVNet returns details about the DNS entry whose name was provided.
 // An error is returned if the zone doesn't exist.
 // The returned zone can be unmarshalled into a ConfigSDNVNet struct.
-func (c *Client) GetSDNVNet(name string) (dns map[string]interface{}, err error) {
+func (c *Client) GetSDNVNet(ctx context.Context, name string) (dns map[string]interface{}, err error) {
 	url := fmt.Sprintf("/cluster/sdn/vnets/%s", name)
-	err = c.GetJsonRetryable(url, &dns, 3)
+	err = c.GetJsonRetryable(ctx, url, &dns, 3)
 	return
 }
 
 // CreateSDNVNet creates a new SDN DNS in the cluster
-func (c *Client) CreateSDNVNet(params map[string]interface{}) error {
-	return c.Post(params, "/cluster/sdn/vnets")
+func (c *Client) CreateSDNVNet(ctx context.Context, params map[string]interface{}) error {
+	return c.Post(ctx, params, "/cluster/sdn/vnets")
 }
 
 // DeleteSDNVNet deletes an existing SDN DNS in the cluster
-func (c *Client) DeleteSDNVNet(name string) error {
-	return c.Delete(fmt.Sprintf("/cluster/sdn/vnets/%s", name))
+func (c *Client) DeleteSDNVNet(ctx context.Context, name string) error {
+	return c.Delete(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s", name))
 }
 
 // UpdateSDNVNet updates the given DNS with the provided parameters
-func (c *Client) UpdateSDNVNet(id string, params map[string]interface{}) error {
-	return c.Put(params, "/cluster/sdn/vnets/"+id)
+func (c *Client) UpdateSDNVNet(ctx context.Context, id string, params map[string]interface{}) error {
+	return c.Put(ctx, params, "/cluster/sdn/vnets/"+id)
 }
 
 // GetSDNSubnets returns a list of all Subnet definitions in the "data" element of the returned
 // map.
-func (c *Client) GetSDNSubnets(vnet string) (list map[string]interface{}, err error) {
+func (c *Client) GetSDNSubnets(ctx context.Context, vnet string) (list map[string]interface{}, err error) {
 	url := fmt.Sprintf("/cluster/sdn/vnets/%s/subnets", vnet)
-	err = c.GetJsonRetryable(url, &list, 3)
+	err = c.GetJsonRetryable(ctx, url, &list, 3)
 	return
 }
 
 // CheckSDNSubnetExistance returns true if a DNS entry with the provided ID exists, false otherwise.
-func (c *Client) CheckSDNSubnetExistance(vnet, id string) (existance bool, err error) {
-	list, err := c.GetSDNSubnets(vnet)
+func (c *Client) CheckSDNSubnetExistance(ctx context.Context, vnet, id string) (existance bool, err error) {
+	list, err := c.GetSDNSubnets(ctx, vnet)
 	existance = ItemInKeyOfArray(list["data"].([]interface{}), "subnet", id)
 	return
 }
@@ -1951,41 +1958,41 @@ func (c *Client) CheckSDNSubnetExistance(vnet, id string) (existance bool, err e
 // GetSDNSubnet returns details about the Subnet entry whose name was provided.
 // An error is returned if the zone doesn't exist.
 // The returned map["data"] section can be unmarshalled into a ConfigSDNSubnet struct.
-func (c *Client) GetSDNSubnet(vnet, name string) (subnet map[string]interface{}, err error) {
+func (c *Client) GetSDNSubnet(ctx context.Context, vnet, name string) (subnet map[string]interface{}, err error) {
 	url := fmt.Sprintf("/cluster/sdn/vnets/%s/subnets/%s", vnet, name)
-	err = c.GetJsonRetryable(url, &subnet, 3)
+	err = c.GetJsonRetryable(ctx, url, &subnet, 3)
 	return
 }
 
 // CreateSDNSubnet creates a new SDN DNS in the cluster
-func (c *Client) CreateSDNSubnet(vnet string, params map[string]interface{}) error {
-	return c.Post(params, fmt.Sprintf("/cluster/sdn/vnets/%s/subnets", vnet))
+func (c *Client) CreateSDNSubnet(ctx context.Context, vnet string, params map[string]interface{}) error {
+	return c.Post(ctx, params, fmt.Sprintf("/cluster/sdn/vnets/%s/subnets", vnet))
 }
 
 // DeleteSDNSubnet deletes an existing SDN DNS in the cluster
-func (c *Client) DeleteSDNSubnet(vnet, name string) error {
-	return c.Delete(fmt.Sprintf("/cluster/sdn/vnets/%s/subnets/%s", vnet, name))
+func (c *Client) DeleteSDNSubnet(ctx context.Context, vnet, name string) error {
+	return c.Delete(ctx, fmt.Sprintf("/cluster/sdn/vnets/%s/subnets/%s", vnet, name))
 }
 
 // UpdateSDNSubnet updates the given DNS with the provided parameters
-func (c *Client) UpdateSDNSubnet(vnet, id string, params map[string]interface{}) error {
-	return c.Put(params, fmt.Sprintf("/cluster/sdn/vnets/%s/subnets/%s", vnet, id))
+func (c *Client) UpdateSDNSubnet(ctx context.Context, vnet, id string, params map[string]interface{}) error {
+	return c.Put(ctx, params, fmt.Sprintf("/cluster/sdn/vnets/%s/subnets/%s", vnet, id))
 }
 
 // GetSDNDNSs returns a list of all DNS definitions in the "data" element of the returned
 // map.
-func (c *Client) GetSDNDNSs(typeFilter string) (list map[string]interface{}, err error) {
+func (c *Client) GetSDNDNSs(ctx context.Context, typeFilter string) (list map[string]interface{}, err error) {
 	url := "/cluster/sdn/dns"
 	if typeFilter != "" {
 		url += fmt.Sprintf("&type=%s", typeFilter)
 	}
-	err = c.GetJsonRetryable(url, &list, 3)
+	err = c.GetJsonRetryable(ctx, url, &list, 3)
 	return
 }
 
 // CheckSDNDNSExistance returns true if a DNS entry with the provided ID exists, false otherwise.
-func (c *Client) CheckSDNDNSExistance(id string) (existance bool, err error) {
-	list, err := c.GetSDNDNSs("")
+func (c *Client) CheckSDNDNSExistance(ctx context.Context, id string) (existance bool, err error) {
+	list, err := c.GetSDNDNSs(ctx, "")
 	existance = ItemInKeyOfArray(list["data"].([]interface{}), "dns", id)
 	return
 }
@@ -1993,40 +2000,40 @@ func (c *Client) CheckSDNDNSExistance(id string) (existance bool, err error) {
 // GetSDNDNS returns details about the DNS entry whose name was provided.
 // An error is returned if the zone doesn't exist.
 // The returned zone can be unmarshalled into a ConfigSDNDNS struct.
-func (c *Client) GetSDNDNS(name string) (dns map[string]interface{}, err error) {
+func (c *Client) GetSDNDNS(ctx context.Context, name string) (dns map[string]interface{}, err error) {
 	url := fmt.Sprintf("/cluster/sdn/dns/%s", name)
-	err = c.GetJsonRetryable(url, &dns, 3)
+	err = c.GetJsonRetryable(ctx, url, &dns, 3)
 	return
 }
 
 // CreateSDNDNS creates a new SDN DNS in the cluster
-func (c *Client) CreateSDNDNS(params map[string]interface{}) error {
-	return c.Post(params, "/cluster/sdn/dns")
+func (c *Client) CreateSDNDNS(ctx context.Context, params map[string]interface{}) error {
+	return c.Post(ctx, params, "/cluster/sdn/dns")
 }
 
 // DeleteSDNDNS deletes an existing SDN DNS in the cluster
-func (c *Client) DeleteSDNDNS(name string) error {
-	return c.Delete(fmt.Sprintf("/cluster/sdn/dns/%s", name))
+func (c *Client) DeleteSDNDNS(ctx context.Context, name string) error {
+	return c.Delete(ctx, fmt.Sprintf("/cluster/sdn/dns/%s", name))
 }
 
 // UpdateSDNDNS updates the given DNS with the provided parameters
-func (c *Client) UpdateSDNDNS(id string, params map[string]interface{}) error {
-	return c.Put(params, "/cluster/sdn/dns/"+id)
+func (c *Client) UpdateSDNDNS(ctx context.Context, id string, params map[string]interface{}) error {
+	return c.Put(ctx, params, "/cluster/sdn/dns/"+id)
 }
 
 // GetSDNZones returns a list of all the SDN zones defined in the cluster.
-func (c *Client) GetSDNZones(pending bool, typeFilter string) (list map[string]interface{}, err error) {
+func (c *Client) GetSDNZones(ctx context.Context, pending bool, typeFilter string) (list map[string]interface{}, err error) {
 	url := fmt.Sprintf("/cluster/sdn/zones?pending=%d", Btoi(pending))
 	if typeFilter != "" {
 		url += fmt.Sprintf("&type=%s", typeFilter)
 	}
-	err = c.GetJsonRetryable(url, &list, 3)
+	err = c.GetJsonRetryable(ctx, url, &list, 3)
 	return
 }
 
 // CheckSDNZoneExistance returns true if a zone with the provided ID exists, false otherwise.
-func (c *Client) CheckSDNZoneExistance(id string) (existance bool, err error) {
-	list, err := c.GetSDNZones(true, "")
+func (c *Client) CheckSDNZoneExistance(ctx context.Context, id string) (existance bool, err error) {
+	list, err := c.GetSDNZones(ctx, true, "")
 	existance = ItemInKeyOfArray(list["data"].([]interface{}), "zone", id)
 	return
 }
@@ -2034,54 +2041,54 @@ func (c *Client) CheckSDNZoneExistance(id string) (existance bool, err error) {
 // GetSDNZone returns details about the zone whose name was provided.
 // An error is returned if the zone doesn't exist.
 // The returned zone can be unmarshalled into a ConfigSDNZone struct.
-func (c *Client) GetSDNZone(zoneName string) (zone map[string]interface{}, err error) {
+func (c *Client) GetSDNZone(ctx context.Context, zoneName string) (zone map[string]interface{}, err error) {
 	url := fmt.Sprintf("/cluster/sdn/zones/%s", zoneName)
-	err = c.GetJsonRetryable(url, &zone, 3)
+	err = c.GetJsonRetryable(ctx, url, &zone, 3)
 	return
 }
 
 // CreateSDNZone creates a new SDN zone in the cluster
-func (c *Client) CreateSDNZone(params map[string]interface{}) error {
-	return c.Post(params, "/cluster/sdn/zones")
+func (c *Client) CreateSDNZone(ctx context.Context, params map[string]interface{}) error {
+	return c.Post(ctx, params, "/cluster/sdn/zones")
 }
 
 // DeleteSDNZone deletes an existing SDN zone in the cluster
-func (c *Client) DeleteSDNZone(zoneName string) error {
-	return c.Delete(fmt.Sprintf("/cluster/sdn/zones/%s", zoneName))
+func (c *Client) DeleteSDNZone(ctx context.Context, zoneName string) error {
+	return c.Delete(ctx, fmt.Sprintf("/cluster/sdn/zones/%s", zoneName))
 }
 
 // UpdateSDNZone updates the given zone with the provided parameters
-func (c *Client) UpdateSDNZone(id string, params map[string]interface{}) error {
-	return c.Put(params, "/cluster/sdn/zones/"+id)
+func (c *Client) UpdateSDNZone(ctx context.Context, id string, params map[string]interface{}) error {
+	return c.Put(ctx, params, "/cluster/sdn/zones/"+id)
 }
 
 // Shared
-func (c *Client) GetItemConfigMapStringInterface(url, text, message string, errorString ...string) (map[string]interface{}, error) {
-	data, err := c.GetItemConfig(url, text, message, errorString...)
+func (c *Client) GetItemConfigMapStringInterface(ctx context.Context, url, text, message string, errorString ...string) (map[string]interface{}, error) {
+	data, err := c.GetItemConfig(ctx, url, text, message, errorString...)
 	if err != nil {
 		return nil, err
 	}
 	return data["data"].(map[string]interface{}), err
 }
 
-func (c *Client) GetItemConfigString(url, text, message string) (string, error) {
-	data, err := c.GetItemConfig(url, text, message)
+func (c *Client) GetItemConfigString(ctx context.Context, url, text, message string) (string, error) {
+	data, err := c.GetItemConfig(ctx, url, text, message)
 	if err != nil {
 		return "", err
 	}
 	return data["data"].(string), err
 }
 
-func (c *Client) GetItemConfigInterfaceArray(url, text, message string) ([]interface{}, error) {
-	data, err := c.GetItemConfig(url, text, message)
+func (c *Client) GetItemConfigInterfaceArray(ctx context.Context, url, text, message string) ([]interface{}, error) {
+	data, err := c.GetItemConfig(ctx, url, text, message)
 	if err != nil {
 		return nil, err
 	}
 	return data["data"].([]interface{}), err
 }
 
-func (c *Client) GetItemConfig(url, text, message string, errorString ...string) (config map[string]interface{}, err error) {
-	err = c.GetJsonRetryable(url, &config, 3, errorString...)
+func (c *Client) GetItemConfig(ctx context.Context, url, text, message string, errorString ...string) (config map[string]interface{}, err error) {
+	err = c.GetJsonRetryable(ctx, url, &config, 3, errorString...)
 	if err != nil {
 		return nil, err
 	}
@@ -2093,82 +2100,82 @@ func (c *Client) GetItemConfig(url, text, message string, errorString ...string)
 
 // Makes a POST request without waiting on proxmox for the task to complete.
 // It returns the HTTP error as 'err'.
-func (c *Client) Post(Params map[string]interface{}, url string) (err error) {
+func (c *Client) Post(ctx context.Context, Params map[string]interface{}, url string) (err error) {
 	reqbody := ParamsToBody(Params)
-	_, err = c.session.Post(url, nil, nil, &reqbody)
+	_, err = c.session.Post(ctx, url, nil, nil, &reqbody)
 	return
 }
 
 // CreateItemReturnStatus creates an item on the Proxmox API.
 // It returns the body of the HTTP response and any HTTP error occurred during the request.
-func (c *Client) CreateItemReturnStatus(params map[string]interface{}, url string) (exitStatus string, err error) {
+func (c *Client) CreateItemReturnStatus(ctx context.Context, params map[string]interface{}, url string) (exitStatus string, err error) {
 	reqbody := ParamsToBody(params)
-	resp, err := c.session.Post(url, nil, nil, &reqbody)
+	resp, err := c.session.Post(ctx, url, nil, nil, &reqbody)
 	exitStatus = c.HandleTaskError(resp)
 	return
 }
 
 // Makes a POST request and waits on proxmox for the task to complete.
 // It returns the status of the test as 'exitStatus' and the HTTP error as 'err'.
-func (c *Client) PostWithTask(Params map[string]interface{}, url string) (exitStatus string, err error) {
+func (c *Client) PostWithTask(ctx context.Context, Params map[string]interface{}, url string) (exitStatus string, err error) {
 	reqbody := ParamsToBody(Params)
 	var resp *http.Response
-	resp, err = c.session.Post(url, nil, nil, &reqbody)
+	resp, err = c.session.Post(ctx, url, nil, nil, &reqbody)
 	if err != nil {
 		return c.HandleTaskError(resp), err
 	}
-	return c.CheckTask(resp)
+	return c.CheckTask(ctx, resp)
 }
 
 // Makes a PUT request without waiting on proxmox for the task to complete.
 // It returns the HTTP error as 'err'.
-func (c *Client) Put(Params map[string]interface{}, url string) (err error) {
+func (c *Client) Put(ctx context.Context, Params map[string]interface{}, url string) (err error) {
 	reqbody := ParamsToBodyWithAllEmpty(Params)
-	_, err = c.session.Put(url, nil, nil, &reqbody)
+	_, err = c.session.Put(ctx, url, nil, nil, &reqbody)
 	return
 }
 
 // UpdateItemReturnStatus updates an item on the Proxmox API.
 // It returns the body of the HTTP response and any HTTP error occurred during the request.
-func (c *Client) UpdateItemReturnStatus(params map[string]interface{}, url string) (exitStatus string, err error) {
+func (c *Client) UpdateItemReturnStatus(ctx context.Context, params map[string]interface{}, url string) (exitStatus string, err error) {
 	reqbody := ParamsToBody(params)
-	resp, err := c.session.Put(url, nil, nil, &reqbody)
+	resp, err := c.session.Put(ctx, url, nil, nil, &reqbody)
 	exitStatus = c.HandleTaskError(resp)
 	return
 }
 
 // Makes a PUT request and waits on proxmox for the task to complete.
 // It returns the status of the test as 'exitStatus' and the HTTP error as 'err'.
-func (c *Client) PutWithTask(Params map[string]interface{}, url string) (exitStatus string, err error) {
+func (c *Client) PutWithTask(ctx context.Context, Params map[string]interface{}, url string) (exitStatus string, err error) {
 	reqbody := ParamsToBodyWithAllEmpty(Params)
 	var resp *http.Response
-	resp, err = c.session.Put(url, nil, nil, &reqbody)
+	resp, err = c.session.Put(ctx, url, nil, nil, &reqbody)
 	if err != nil {
 		return c.HandleTaskError(resp), err
 	}
-	return c.CheckTask(resp)
+	return c.CheckTask(ctx, resp)
 }
 
 // Makes a DELETE request without waiting on proxmox for the task to complete.
 // It returns the HTTP error as 'err'.
-func (c *Client) Delete(url string) (err error) {
-	_, err = c.session.Delete(url, nil, nil)
+func (c *Client) Delete(ctx context.Context, url string) (err error) {
+	_, err = c.session.Delete(ctx, url, nil, nil)
 	return
 }
 
 // Makes a DELETE request and waits on proxmox for the task to complete.
 // It returns the status of the test as 'exitStatus' and the HTTP error as 'err'.
-func (c *Client) DeleteWithTask(url string) (exitStatus string, err error) {
+func (c *Client) DeleteWithTask(ctx context.Context, url string) (exitStatus string, err error) {
 	var resp *http.Response
-	resp, err = c.session.Delete(url, nil, nil)
+	resp, err = c.session.Delete(ctx, url, nil, nil)
 	if err != nil {
 		return c.HandleTaskError(resp), err
 	}
-	return c.CheckTask(resp)
+	return c.CheckTask(ctx, resp)
 }
 
-func (c *Client) GetItemListInterfaceArray(url string) ([]interface{}, error) {
-	list, err := c.GetItemList(url)
+func (c *Client) GetItemListInterfaceArray(ctx context.Context, url string) ([]interface{}, error) {
+	list, err := c.GetItemList(ctx, url)
 	if err != nil {
 		return nil, err
 	}
@@ -2179,8 +2186,8 @@ func (c *Client) GetItemListInterfaceArray(url string) ([]interface{}, error) {
 	return data, nil
 }
 
-func (c *Client) GetItemList(url string) (list map[string]interface{}, err error) {
-	err = c.GetJsonRetryable(url, &list, 3)
+func (c *Client) GetItemList(ctx context.Context, url string) (list map[string]interface{}, err error) {
+	err = c.GetJsonRetryable(ctx, url, &list, 3)
 	return
 }
 
@@ -2202,20 +2209,20 @@ func (c *Client) HandleTaskError(resp *http.Response) (exitStatus string) {
 
 // CheckTask polls the API to check if the Proxmox task has been completed.
 // It returns the body of the HTTP response and any HTTP error occurred during the request.
-func (c *Client) CheckTask(resp *http.Response) (exitStatus string, err error) {
+func (c *Client) CheckTask(ctx context.Context, resp *http.Response) (exitStatus string, err error) {
 	taskResponse, err := ResponseJSON(resp)
 	if err != nil {
 		return "", err
 	}
-	return c.WaitForCompletion(taskResponse)
+	return c.WaitForCompletion(ctx, taskResponse)
 }
 
 // return a list of requested permissions from the cache for further processing
-func (c *Client) cachedPermissions(paths []permissionPath) (map[permissionPath]privileges, error) {
+func (c *Client) cachedPermissions(ctx context.Context, paths []permissionPath) (map[permissionPath]privileges, error) {
 	c.permissionMutex.Lock()
 	defer c.permissionMutex.Unlock()
 	if c.permissions == nil {
-		permissionMap, err := c.getPermissions()
+		permissionMap, err := c.getPermissions(ctx)
 		if err != nil {
 			return nil, err
 		}
@@ -2231,24 +2238,24 @@ func (c *Client) cachedPermissions(paths []permissionPath) (map[permissionPath]p
 }
 
 // Returns an error if the user does not have the required permissions on the given category and itme.
-func (c *Client) CheckPermissions(perms []Permission) error {
+func (c *Client) CheckPermissions(ctx context.Context, perms []Permission) error {
 	for _, perm := range perms {
 		if err := perm.Validate(); err != nil {
 			return err
 		}
 	}
-	return c.checkPermissions(perms)
+	return c.checkPermissions(ctx, perms)
 }
 
 // internal function to check permissions, does not validate input.
-func (c *Client) checkPermissions(perms []Permission) error {
+func (c *Client) checkPermissions(ctx context.Context, perms []Permission) error {
 	if c == nil {
 		return errors.New(Client_Error_Nil)
 	}
 	if c.Username == "root@pam" { // no permissions check for root
 		return nil
 	}
-	permissions, err := c.cachedPermissions(Permission{}.buildPathList(perms))
+	permissions, err := c.cachedPermissions(ctx, Permission{}.buildPathList(perms))
 	if err != nil {
 		return err
 	}
@@ -2262,8 +2269,8 @@ func (c *Client) checkPermissions(perms []Permission) error {
 }
 
 // inserts a permission into the cache, this is useful for when we create an item, as refreshing the whole cache is quite expensive.
-func (c *Client) insertCachedPermission(path permissionPath) error {
-	rawPermissions, err := c.getPermissionsRaw()
+func (c *Client) insertCachedPermission(ctx context.Context, path permissionPath) error {
+	rawPermissions, err := c.getPermissionsRaw(ctx)
 	if err != nil {
 		return err
 	}
@@ -2278,8 +2285,8 @@ func (c *Client) insertCachedPermission(path permissionPath) error {
 }
 
 // get the users permissions from the cache and decodes them for the SDK
-func (c *Client) getPermissions() (map[permissionPath]privileges, error) {
-	permissions, err := c.getPermissionsRaw()
+func (c *Client) getPermissions(ctx context.Context) (map[permissionPath]privileges, error) {
+	permissions, err := c.getPermissionsRaw(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -2287,16 +2294,16 @@ func (c *Client) getPermissions() (map[permissionPath]privileges, error) {
 }
 
 // returns the raw permissions from the API
-func (c *Client) getPermissionsRaw() (map[string]interface{}, error) {
-	return c.GetItemConfigMapStringInterface("/access/permissions", "", "permissions")
+func (c *Client) getPermissionsRaw(ctx context.Context) (map[string]interface{}, error) {
+	return c.GetItemConfigMapStringInterface(ctx, "/access/permissions", "", "permissions")
 }
 
 // RefreshPermissions fetches the permissions from the API and updates the cache.
-func (c *Client) RefreshPermissions() error {
+func (c *Client) RefreshPermissions(ctx context.Context) error {
 	if c == nil {
 		return errors.New(Client_Error_Nil)
 	}
-	tmpPermsissions, err := c.getPermissions()
+	tmpPermsissions, err := c.getPermissions(ctx)
 	if err != nil {
 		return err
 	}
@@ -2307,12 +2314,12 @@ func (c *Client) RefreshPermissions() error {
 }
 
 // Returns the Client's cached version if it exists, otherwise fetches the version from the API.
-func (c *Client) Version() (Version, error) {
+func (c *Client) Version(ctx context.Context) (Version, error) {
 	if c == nil {
 		return Version{}, errors.New(Client_Error_Nil)
 	}
 	if c.version == nil {
-		return c.GetVersion()
+		return c.GetVersion(ctx)
 	}
 	c.versionMutex.Lock()
 	defer c.versionMutex.Unlock()

--- a/proxmox/client_test.go
+++ b/proxmox/client_test.go
@@ -1,6 +1,7 @@
 package proxmox
 
 import (
+	"context"
 	"errors"
 	"sync"
 	"testing"
@@ -45,7 +46,7 @@ func Test_Client_CheckPermissions(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			require.Equal(t, test.output, test.input.client.CheckPermissions(test.input.perms))
+			require.Equal(t, test.output, test.input.client.CheckPermissions(context.Background(), test.input.perms))
 		})
 	}
 }

--- a/proxmox/config_hagroup.go
+++ b/proxmox/config_hagroup.go
@@ -1,6 +1,7 @@
 package proxmox
 
 import (
+	"context"
 	"errors"
 	"strings"
 )
@@ -14,8 +15,8 @@ type HAGroup struct {
 	Type       string   // Group type
 }
 
-func (c *Client) GetHAGroupList() (haGroups []HAGroup, err error) {
-	list, err := c.GetItemList("/cluster/ha/groups")
+func (c *Client) GetHAGroupList(ctx context.Context) (haGroups []HAGroup, err error) {
+	list, err := c.GetItemList(ctx, "/cluster/ha/groups")
 
 	if err != nil {
 		return nil, err
@@ -39,8 +40,8 @@ func (c *Client) GetHAGroupList() (haGroups []HAGroup, err error) {
 	return haGroups, nil
 }
 
-func (c *Client) GetHAGroupByName(GroupName string) (*HAGroup, error) {
-	groups, err := c.GetHAGroupList()
+func (c *Client) GetHAGroupByName(ctx context.Context, GroupName string) (*HAGroup, error) {
+	groups, err := c.GetHAGroupList(ctx)
 
 	if err != nil {
 		return nil, err

--- a/proxmox/config_network.go
+++ b/proxmox/config_network.go
@@ -1,6 +1,7 @@
 package proxmox
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 )
@@ -59,10 +60,10 @@ func (config ConfigNetwork) mapToApiValues() map[string]interface{} {
 // CreateNetwork creates a network on the Proxmox host with the stored
 // config.
 // It returns an error if the creation of the network fails.
-func (config ConfigNetwork) CreateNetwork(client *Client) (err error) {
+func (config ConfigNetwork) CreateNetwork(ctx context.Context, client *Client) (err error) {
 	paramMap := config.mapToApiValues()
 
-	exitStatus, err := client.CreateNetwork(config.Node, paramMap)
+	exitStatus, err := client.CreateNetwork(ctx, config.Node, paramMap)
 	if err != nil {
 		params, _ := json.Marshal(&paramMap)
 		return fmt.Errorf("error creating network: %v\n\t\t api response: %s\n\t\t params: %v", err, exitStatus, string(params))
@@ -73,10 +74,10 @@ func (config ConfigNetwork) CreateNetwork(client *Client) (err error) {
 // UpdateNetwork updates a network on the Proxmox host with the stored
 // config.
 // It returns an error if updating the network fails.
-func (config ConfigNetwork) UpdateNetwork(client *Client) (err error) {
+func (config ConfigNetwork) UpdateNetwork(ctx context.Context, client *Client) (err error) {
 	paramMap := config.mapToApiValues()
 
-	exitStatus, err := client.UpdateNetwork(config.Node, config.Iface, paramMap)
+	exitStatus, err := client.UpdateNetwork(ctx, config.Node, config.Iface, paramMap)
 	if err != nil {
 		params, _ := json.Marshal(paramMap)
 		return fmt.Errorf("error creating network: %v\n\t\t api response: %s\n\t\t params: %v", err, exitStatus, string(params))

--- a/proxmox/config_pool_test.go
+++ b/proxmox/config_pool_test.go
@@ -1,6 +1,7 @@
 package proxmox
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -11,13 +12,13 @@ import (
 
 func Test_ListPools(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { _, err = ListPools(nil) })
+	require.NotPanics(t, func() { _, err = ListPools(context.Background(), nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
 func Test_ListPoolsWithComments(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { _, err = ListPoolsWithComments(nil) })
+	require.NotPanics(t, func() { _, err = ListPoolsWithComments(context.Background(), nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
@@ -131,49 +132,49 @@ func Test_ConfigPool_mapToSDK(t *testing.T) {
 
 func Test_ConfigPool_Create(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { err = ConfigPool{Name: "test"}.Create(nil) })
+	require.NotPanics(t, func() { err = ConfigPool{Name: "test"}.Create(context.Background(), nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
 func Test_ConfigPool_Create_Unsafe(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { err = ConfigPool{Name: "test"}.Create_Unsafe(nil) })
+	require.NotPanics(t, func() { err = ConfigPool{Name: "test"}.Create_Unsafe(context.Background(), nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
 func Test_ConfigPool_Delete(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { err = ConfigPool{Name: "test"}.Delete(nil) })
+	require.NotPanics(t, func() { err = ConfigPool{Name: "test"}.Delete(context.Background(), nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
 func Test_ConfigPool_Exists(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { _, err = ConfigPool{Name: "test"}.Exists(nil) })
+	require.NotPanics(t, func() { _, err = ConfigPool{Name: "test"}.Exists(context.Background(), nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
 func Test_ConfigPool_Set(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { err = ConfigPool{Name: "test"}.Set(nil) })
+	require.NotPanics(t, func() { err = ConfigPool{Name: "test"}.Set(context.Background(), nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
 func Test_ConfigPool_Set_Unsafe(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { err = ConfigPool{Name: "test"}.Set_Unsafe(nil) })
+	require.NotPanics(t, func() { err = ConfigPool{Name: "test"}.Set_Unsafe(context.Background(), nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
 func Test_ConfigPool_Update(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { err = ConfigPool{Name: "test"}.Update(nil) })
+	require.NotPanics(t, func() { err = ConfigPool{Name: "test"}.Update(context.Background(), nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
 func Test_ConfigPool_Update_Unsafe(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { err = ConfigPool{Name: "test"}.Update_Unsafe(nil) })
+	require.NotPanics(t, func() { err = ConfigPool{Name: "test"}.Update_Unsafe(context.Background(), nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
@@ -204,49 +205,49 @@ func Test_ConfigPool_Validate(t *testing.T) {
 
 func Test_PoolName_AddGuests(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { err = PoolName("test").AddGuests(nil, nil) })
+	require.NotPanics(t, func() { err = PoolName("test").AddGuests(context.Background(), nil, nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
 func Test_PoolName_AddGuests_Unsafe(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { err = PoolName("test").AddGuests_Unsafe(nil, nil) })
+	require.NotPanics(t, func() { err = PoolName("test").AddGuests_Unsafe(context.Background(), nil, nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
 func Test_PoolName_Delete(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { err = PoolName("test").Delete(nil) })
+	require.NotPanics(t, func() { err = PoolName("test").Delete(context.Background(), nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
 func Test_PoolName_Delete_Unsafe(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { err = PoolName("test").Delete_Unsafe(nil) })
+	require.NotPanics(t, func() { err = PoolName("test").Delete_Unsafe(context.Background(), nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
 func Test_PoolName_Exists(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { _, err = PoolName("test").Exists(nil) })
+	require.NotPanics(t, func() { _, err = PoolName("test").Exists(context.Background(), nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
 func Test_PoolName_Exists_Unsafe(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { _, err = PoolName("test").Exists_Unsafe(nil) })
+	require.NotPanics(t, func() { _, err = PoolName("test").Exists_Unsafe(context.Background(), nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
 func Test_PoolName_Get(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { _, err = PoolName("test").Get(nil) })
+	require.NotPanics(t, func() { _, err = PoolName("test").Get(context.Background(), nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
 func Test_PoolName_Get_Unsafe(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { _, err = PoolName("test").Get_Unsafe(nil) })
+	require.NotPanics(t, func() { _, err = PoolName("test").Get_Unsafe(context.Background(), nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
@@ -301,25 +302,25 @@ func Test_PoolName_guestsToRemoveFromPools(t *testing.T) {
 
 func Test_PoolName_RemoveGuests(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { err = PoolName("test").RemoveGuests(nil, nil) })
+	require.NotPanics(t, func() { err = PoolName("test").RemoveGuests(context.Background(), nil, nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
 func Test_PoolName_RemoveGuests_Unsafe(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { err = PoolName("test").RemoveGuests_Unsafe(nil, nil) })
+	require.NotPanics(t, func() { err = PoolName("test").RemoveGuests_Unsafe(context.Background(), nil, nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
 func Test_PoolName_SetGuests(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { err = PoolName("test").SetGuests(nil, nil) })
+	require.NotPanics(t, func() { err = PoolName("test").SetGuests(context.Background(), nil, nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
 func Test_PoolName_SetGuests_Unsafe(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { err = PoolName("test").SetGuests_Unsafe(nil, nil) })
+	require.NotPanics(t, func() { err = PoolName("test").SetGuests_Unsafe(context.Background(), nil, nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 

--- a/proxmox/config_sdn_dns.go
+++ b/proxmox/config_sdn_dns.go
@@ -1,6 +1,7 @@
 package proxmox
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 )
@@ -28,32 +29,32 @@ func NewConfigSDNDNSFromJson(input []byte) (config *ConfigSDNDNS, err error) {
 	return
 }
 
-func (config *ConfigSDNDNS) CreateWithValidate(id string, client *Client) (err error) {
-	err = config.Validate(id, true, client)
+func (config *ConfigSDNDNS) CreateWithValidate(ctx context.Context, id string, client *Client) (err error) {
+	err = config.Validate(ctx, id, true, client)
 	if err != nil {
 		return
 	}
-	return config.Create(id, client)
+	return config.Create(ctx, id, client)
 }
 
-func (config *ConfigSDNDNS) Create(id string, client *Client) (err error) {
+func (config *ConfigSDNDNS) Create(ctx context.Context, id string, client *Client) (err error) {
 	config.DNS = id
 	params := config.mapToApiValues()
-	return client.CreateSDNDNS(params)
+	return client.CreateSDNDNS(ctx, params)
 }
 
-func (config *ConfigSDNDNS) UpdateWithValidate(id string, client *Client) (err error) {
-	err = config.Validate(id, false, client)
+func (config *ConfigSDNDNS) UpdateWithValidate(ctx context.Context, id string, client *Client) (err error) {
+	err = config.Validate(ctx, id, false, client)
 	if err != nil {
 		return
 	}
-	return config.Update(id, client)
+	return config.Update(ctx, id, client)
 }
 
-func (config *ConfigSDNDNS) Update(id string, client *Client) (err error) {
+func (config *ConfigSDNDNS) Update(ctx context.Context, id string, client *Client) (err error) {
 	config.DNS = id
 	params := config.mapToApiValues()
-	err = client.UpdateSDNDNS(id, params)
+	err = client.UpdateSDNDNS(ctx, id, params)
 	if err != nil {
 		params, _ := json.Marshal(&params)
 		return fmt.Errorf("error updating SDN DNS: %v, (params: %v)", err, string(params))
@@ -61,8 +62,8 @@ func (config *ConfigSDNDNS) Update(id string, client *Client) (err error) {
 	return
 }
 
-func (c *ConfigSDNDNS) Validate(id string, create bool, client *Client) (err error) {
-	exists, err := client.CheckSDNDNSExistance(id)
+func (c *ConfigSDNDNS) Validate(ctx context.Context, id string, create bool, client *Client) (err error) {
+	exists, err := client.CheckSDNDNSExistance(ctx, id)
 	if err != nil {
 		return
 	}

--- a/proxmox/config_sdn_subnet.go
+++ b/proxmox/config_sdn_subnet.go
@@ -1,6 +1,7 @@
 package proxmox
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net"
@@ -34,34 +35,34 @@ func NewConfigSDNSubnetFromJson(input []byte) (config *ConfigSDNSubnet, err erro
 	return
 }
 
-func (config *ConfigSDNSubnet) CreateWithValidate(vnet, id string, client *Client) (err error) {
-	err = config.Validate(vnet, id, true, client)
+func (config *ConfigSDNSubnet) CreateWithValidate(ctx context.Context, vnet, id string, client *Client) (err error) {
+	err = config.Validate(ctx, vnet, id, true, client)
 	if err != nil {
 		return
 	}
-	return config.Create(vnet, id, client)
+	return config.Create(ctx, vnet, id, client)
 }
 
-func (config *ConfigSDNSubnet) Create(vnet, id string, client *Client) (err error) {
+func (config *ConfigSDNSubnet) Create(ctx context.Context, vnet, id string, client *Client) (err error) {
 	config.Subnet = id
 	config.Type = "subnet"
 	params := config.mapToApiValues()
-	return client.CreateSDNSubnet(vnet, params)
+	return client.CreateSDNSubnet(ctx, vnet, params)
 }
 
-func (config *ConfigSDNSubnet) UpdateWithValidate(vnet, id string, client *Client) (err error) {
-	err = config.Validate(vnet, id, false, client)
+func (config *ConfigSDNSubnet) UpdateWithValidate(ctx context.Context, vnet, id string, client *Client) (err error) {
+	err = config.Validate(ctx, vnet, id, false, client)
 	if err != nil {
 		return
 	}
-	return config.Update(vnet, id, client)
+	return config.Update(ctx, vnet, id, client)
 }
 
-func (config *ConfigSDNSubnet) Update(vnet, id string, client *Client) (err error) {
+func (config *ConfigSDNSubnet) Update(ctx context.Context, vnet, id string, client *Client) (err error) {
 	config.Subnet = id
 	config.Type = "" // For some reason, this shouldn't be sent on update. Only on create.
 	params := config.mapToApiValues()
-	err = client.UpdateSDNSubnet(vnet, id, params)
+	err = client.UpdateSDNSubnet(ctx, vnet, id, params)
 	if err != nil {
 		params, _ := json.Marshal(&params)
 		return fmt.Errorf("error updating SDN Subnet: %v, (params: %v)", err, string(params))
@@ -69,15 +70,15 @@ func (config *ConfigSDNSubnet) Update(vnet, id string, client *Client) (err erro
 	return
 }
 
-func (c *ConfigSDNSubnet) Validate(vnet, id string, create bool, client *Client) (err error) {
-	vnetExists, err := client.CheckSDNVNetExistance(vnet)
+func (c *ConfigSDNSubnet) Validate(ctx context.Context, vnet, id string, create bool, client *Client) (err error) {
+	vnetExists, err := client.CheckSDNVNetExistance(ctx, vnet)
 	if err != nil {
 		return
 	}
 	if !vnetExists {
 		return fmt.Errorf("subnet must be created in an existing vnet. vnet (%s) wasn't found", vnet)
 	}
-	exists, err := client.CheckSDNSubnetExistance(vnet, id)
+	exists, err := client.CheckSDNSubnetExistance(ctx, vnet, id)
 	if err != nil {
 		return
 	}

--- a/proxmox/config_sdn_vnet.go
+++ b/proxmox/config_sdn_vnet.go
@@ -1,6 +1,7 @@
 package proxmox
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"regexp"
@@ -23,32 +24,32 @@ func NewConfigSDNVNetFromJson(input []byte) (config *ConfigSDNVNet, err error) {
 	return
 }
 
-func (config *ConfigSDNVNet) CreateWithValidate(id string, client *Client) (err error) {
-	err = config.Validate(id, true, client)
+func (config *ConfigSDNVNet) CreateWithValidate(ctx context.Context, id string, client *Client) (err error) {
+	err = config.Validate(ctx, id, true, client)
 	if err != nil {
 		return
 	}
-	return config.Create(id, client)
+	return config.Create(ctx, id, client)
 }
 
-func (config *ConfigSDNVNet) Create(id string, client *Client) (err error) {
+func (config *ConfigSDNVNet) Create(ctx context.Context, id string, client *Client) (err error) {
 	config.VNet = id
 	params := config.mapToApiValues()
-	return client.CreateSDNVNet(params)
+	return client.CreateSDNVNet(ctx, params)
 }
 
-func (config *ConfigSDNVNet) UpdateWithValidate(id string, client *Client) (err error) {
-	err = config.Validate(id, false, client)
+func (config *ConfigSDNVNet) UpdateWithValidate(ctx context.Context, id string, client *Client) (err error) {
+	err = config.Validate(ctx, id, false, client)
 	if err != nil {
 		return
 	}
-	return config.Update(id, client)
+	return config.Update(ctx, id, client)
 }
 
-func (config *ConfigSDNVNet) Update(id string, client *Client) (err error) {
+func (config *ConfigSDNVNet) Update(ctx context.Context, id string, client *Client) (err error) {
 	config.VNet = id
 	params := config.mapToApiValues()
-	err = client.UpdateSDNVNet(id, params)
+	err = client.UpdateSDNVNet(ctx, id, params)
 	if err != nil {
 		params, _ := json.Marshal(&params)
 		return fmt.Errorf("error updating SDN VNet: %v, (params: %v)", err, string(params))
@@ -56,8 +57,8 @@ func (config *ConfigSDNVNet) Update(id string, client *Client) (err error) {
 	return
 }
 
-func (c *ConfigSDNVNet) Validate(id string, create bool, client *Client) (err error) {
-	exists, err := client.CheckSDNVNetExistance(id)
+func (c *ConfigSDNVNet) Validate(ctx context.Context, id string, create bool, client *Client) (err error) {
+	exists, err := client.CheckSDNVNetExistance(ctx, id)
 	if err != nil {
 		return
 	}
@@ -67,7 +68,7 @@ func (c *ConfigSDNVNet) Validate(id string, create bool, client *Client) (err er
 	if !exists && !create {
 		return ErrorItemNotExists(id, "vnet")
 	}
-	zoneExists, err := client.CheckSDNZoneExistance(c.Zone)
+	zoneExists, err := client.CheckSDNZoneExistance(ctx, c.Zone)
 	if err != nil {
 		return
 	}

--- a/proxmox/config_sdn_zone.go
+++ b/proxmox/config_sdn_zone.go
@@ -1,6 +1,7 @@
 package proxmox
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 )
@@ -46,32 +47,32 @@ func NewConfigSDNZoneFromJson(input []byte) (config *ConfigSDNZone, err error) {
 	return
 }
 
-func (config *ConfigSDNZone) CreateWithValidate(id string, client *Client) (err error) {
-	err = config.Validate(id, true, client)
+func (config *ConfigSDNZone) CreateWithValidate(ctx context.Context, id string, client *Client) (err error) {
+	err = config.Validate(ctx, id, true, client)
 	if err != nil {
 		return
 	}
-	return config.Create(id, client)
+	return config.Create(ctx, id, client)
 }
 
-func (config *ConfigSDNZone) Create(id string, client *Client) (err error) {
+func (config *ConfigSDNZone) Create(ctx context.Context, id string, client *Client) (err error) {
 	config.Zone = id
 	params := config.mapToApiValues()
-	return client.CreateSDNZone(params)
+	return client.CreateSDNZone(ctx, params)
 }
 
-func (config *ConfigSDNZone) UpdateWithValidate(id string, client *Client) (err error) {
-	err = config.Validate(id, false, client)
+func (config *ConfigSDNZone) UpdateWithValidate(ctx context.Context, id string, client *Client) (err error) {
+	err = config.Validate(ctx, id, false, client)
 	if err != nil {
 		return
 	}
-	return config.Update(id, client)
+	return config.Update(ctx, id, client)
 }
 
-func (config *ConfigSDNZone) Update(id string, client *Client) (err error) {
+func (config *ConfigSDNZone) Update(ctx context.Context, id string, client *Client) (err error) {
 	config.Zone = id
 	params := config.mapToApiValues()
-	err = client.UpdateSDNZone(id, params)
+	err = client.UpdateSDNZone(ctx, id, params)
 	if err != nil {
 		params, _ := json.Marshal(&params)
 		return fmt.Errorf("error updating SDN Zone: %v, (params: %v)", err, string(params))
@@ -79,8 +80,8 @@ func (config *ConfigSDNZone) Update(id string, client *Client) (err error) {
 	return
 }
 
-func (c *ConfigSDNZone) Validate(id string, create bool, client *Client) (err error) {
-	exists, err := client.CheckSDNZoneExistance(id)
+func (c *ConfigSDNZone) Validate(ctx context.Context, id string, create bool, client *Client) (err error) {
+	exists, err := client.CheckSDNZoneExistance(ctx, id)
 	if err != nil {
 		return
 	}

--- a/proxmox/content.go
+++ b/proxmox/content.go
@@ -1,6 +1,7 @@
 package proxmox
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"time"
@@ -128,22 +129,22 @@ func createFilesList(fileList []interface{}) *[]Content_FileProperties {
 }
 
 // Deletes te specified file from the specified storage.
-func DeleteFile(client *Client, node string, content Content_File) (err error) {
+func DeleteFile(ctx context.Context, client *Client, node string, content Content_File) (err error) {
 	content.ContentType, err = content.ContentType.toApiValueAndValidate()
 	if err != nil {
 		return
 	}
-	_, err = client.DeleteWithTask("/nodes/" + node + "/storage/" + content.Storage + "/content" + content.format())
+	_, err = client.DeleteWithTask(ctx, "/nodes/"+node+"/storage/"+content.Storage+"/content"+content.format())
 	return
 }
 
 // List all files of the given type in the the specified storage
-func ListFiles(client *Client, node, storage string, content ContentType) (files *[]Content_FileProperties, err error) {
+func ListFiles(ctx context.Context, client *Client, node, storage string, content ContentType) (files *[]Content_FileProperties, err error) {
 	content, err = content.toApiValueAndValidate()
 	if err != nil {
 		return
 	}
-	fileList, err := client.GetItemListInterfaceArray("/nodes/" + node + "/storage/" + storage + "/content?content=" + string(content))
+	fileList, err := client.GetItemListInterfaceArray(ctx, "/nodes/"+node+"/storage/"+storage+"/content?content="+string(content))
 	if err != nil {
 		return
 	}

--- a/proxmox/content_iso.go
+++ b/proxmox/content_iso.go
@@ -1,6 +1,7 @@
 package proxmox
 
 import (
+	"context"
 	"errors"
 )
 
@@ -47,8 +48,8 @@ func (content ConfigContent_Iso) Validate() (err error) {
 
 // Download an Iso file from a given URL.
 // https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/storage/{storage}/download-url
-func DownloadIsoFromUrl(client *Client, content ConfigContent_Iso) (err error) {
-	_, err = client.PostWithTask(content.mapToApiValues(), "/nodes/"+content.Node+"/storage/"+content.Storage+"/download-url")
+func DownloadIsoFromUrl(ctx context.Context, client *Client, content ConfigContent_Iso) (err error) {
+	_, err = client.PostWithTask(ctx, content.mapToApiValues(), "/nodes/"+content.Node+"/storage/"+content.Storage+"/download-url")
 	if err != nil {
 		return err
 	}

--- a/proxmox/content_template.go
+++ b/proxmox/content_template.go
@@ -1,6 +1,7 @@
 package proxmox
 
 import (
+	"context"
 	"errors"
 )
 
@@ -106,14 +107,14 @@ func createTemplateList(templateList []interface{}) *[]TemplateItem {
 }
 
 // Download an LXC template.
-func DownloadLxcTemplate(client *Client, content ConfigContent_Template) (err error) {
-	_, err = client.PostWithTask(content.mapToApiValues(), "/nodes/"+content.Node+"/aplinfo")
+func DownloadLxcTemplate(ctx context.Context, client *Client, content ConfigContent_Template) (err error) {
+	_, err = client.PostWithTask(ctx, content.mapToApiValues(), "/nodes/"+content.Node+"/aplinfo")
 	return
 }
 
 // List all LXC templates available for download.
-func ListTemplates(client *Client, node string) (templateList *[]TemplateItem, err error) {
-	tmpList, err := client.GetItemListInterfaceArray("/nodes/" + node + "/aplinfo")
+func ListTemplates(ctx context.Context, client *Client, node string) (templateList *[]TemplateItem, err error) {
+	tmpList, err := client.GetItemListInterfaceArray(ctx, "/nodes/"+node+"/aplinfo")
 	if err != nil {
 		return
 	}

--- a/proxmox/data_qemu_agent.go
+++ b/proxmox/data_qemu_agent.go
@@ -1,16 +1,17 @@
 package proxmox
 
 import (
+	"context"
 	"net"
 	"strconv"
 )
 
-func (vmr *VmRef) GetAgentInformation(c *Client, statistics bool) ([]AgentNetworkInterface, error) {
-	if err := c.CheckVmRef(vmr); err != nil {
+func (vmr *VmRef) GetAgentInformation(ctx context.Context, c *Client, statistics bool) ([]AgentNetworkInterface, error) {
+	if err := c.CheckVmRef(ctx, vmr); err != nil {
 		return nil, err
 	}
 	vmid := strconv.FormatInt(int64(vmr.vmId), 10)
-	params, err := c.GetItemConfigMapStringInterface(
+	params, err := c.GetItemConfigMapStringInterface(ctx,
 		"/nodes/"+vmr.node+"/qemu/"+vmid+"/agent/network-get-interfaces", "guest agent", "data",
 		"500 QEMU guest agent is not running",
 		"500 VM "+vmid+" is not running")

--- a/proxmox/node.go
+++ b/proxmox/node.go
@@ -1,13 +1,14 @@
 package proxmox
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
 )
 
-func (c *Client) nodeStatusCommand(node, command string) (exitStatus string, err error) {
-	nodes, err := c.GetNodeList()
+func (c *Client) nodeStatusCommand(ctx context.Context, node, command string) (exitStatus string, err error) {
+	nodes, err := c.GetNodeList(ctx)
 	if err != nil {
 		return
 	}
@@ -31,7 +32,7 @@ func (c *Client) nodeStatusCommand(node, command string) (exitStatus string, err
 	url := fmt.Sprintf("/nodes/%s/status", node)
 
 	var resp *http.Response
-	resp, err = c.session.Post(url, nil, nil, &reqbody)
+	resp, err = c.session.Post(ctx, url, nil, nil, &reqbody)
 	if err != nil {
 		defer resp.Body.Close()
 		// This might not work if we never got a body. We'll ignore errors in trying to read,
@@ -44,10 +45,10 @@ func (c *Client) nodeStatusCommand(node, command string) (exitStatus string, err
 	return
 }
 
-func (c *Client) ShutdownNode(node string) (exitStatus string, err error) {
-	return c.nodeStatusCommand(node, "shutdown")
+func (c *Client) ShutdownNode(ctx context.Context, node string) (exitStatus string, err error) {
+	return c.nodeStatusCommand(ctx, node, "shutdown")
 }
 
-func (c *Client) RebootNode(node string) (exitStatus string, err error) {
-	return c.nodeStatusCommand(node, "reboot")
+func (c *Client) RebootNode(ctx context.Context, node string) (exitStatus string, err error) {
+	return c.nodeStatusCommand(ctx, node, "reboot")
 }

--- a/proxmox/session.go
+++ b/proxmox/session.go
@@ -4,6 +4,7 @@ package proxmox
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -172,7 +173,7 @@ func (s *Session) setTicket(ticket, csrfPreventionToken string) {
 	s.CsrfToken = csrfPreventionToken
 }
 
-func (s *Session) Login(username string, password string, otp string) (err error) {
+func (s *Session) Login(ctx context.Context, username string, password string, otp string) (err error) {
 	reqUser := map[string]interface{}{"username": username, "password": password}
 	if otp != "" {
 		reqUser["otp"] = otp
@@ -180,7 +181,7 @@ func (s *Session) Login(username string, password string, otp string) (err error
 	reqbody := ParamsToBody(reqUser)
 	olddebug := *Debug
 	*Debug = false // don't share passwords in debug log
-	resp, err := s.Post("/access/ticket", nil, &s.Headers, &reqbody)
+	resp, err := s.Post(ctx, "/access/ticket", nil, &s.Headers, &reqbody)
 	*Debug = olddebug
 	if err != nil {
 		return err
@@ -206,8 +207,8 @@ func (s *Session) Login(username string, password string, otp string) (err error
 	return nil
 }
 
-func (s *Session) NewRequest(method, url string, headers *http.Header, body io.Reader) (req *http.Request, err error) {
-	req, err = http.NewRequest(method, url, body)
+func (s *Session) NewRequest(ctx context.Context, method, url string, headers *http.Header, body io.Reader) (req *http.Request, err error) {
+	req, err = http.NewRequestWithContext(ctx, method, url, body)
 	if err != nil {
 		return nil, err
 	}
@@ -272,6 +273,7 @@ func (s *Session) Do(req *http.Request) (*http.Response, error) {
 
 // Perform a simple get to an endpoint
 func (s *Session) Request(
+	ctx context.Context,
 	method string,
 	url string,
 	params *url.Values,
@@ -290,7 +292,7 @@ func (s *Session) Request(
 		buf = bytes.NewReader(*body)
 	}
 
-	req, err := s.NewRequest(method, url, headers, buf)
+	req, err := s.NewRequest(ctx, method, url, headers, buf)
 	if err != nil {
 		return nil, err
 	}
@@ -302,6 +304,7 @@ func (s *Session) Request(
 
 // Perform a simple get to an endpoint and unmarshal returned JSON
 func (s *Session) RequestJSON(
+	ctx context.Context,
 	method string,
 	url string,
 	params *url.Values,
@@ -322,7 +325,7 @@ func (s *Session) RequestJSON(
 	// 	headers.Add("Content-Type", "application/json")
 	// }
 
-	resp, err = s.Request(method, url, params, headers, &bodyjson)
+	resp, err = s.Request(ctx, method, url, params, headers, &bodyjson)
 	if err != nil {
 		return resp, err
 	}
@@ -344,39 +347,44 @@ func (s *Session) RequestJSON(
 }
 
 func (s *Session) Delete(
+	ctx context.Context,
 	url string,
 	params *url.Values,
 	headers *http.Header,
 ) (resp *http.Response, err error) {
-	return s.Request("DELETE", url, params, headers, nil)
+	return s.Request(ctx, "DELETE", url, params, headers, nil)
 }
 
 func (s *Session) Get(
+	ctx context.Context,
 	url string,
 	params *url.Values,
 	headers *http.Header,
 ) (resp *http.Response, err error) {
-	return s.Request("GET", url, params, headers, nil)
+	return s.Request(ctx, "GET", url, params, headers, nil)
 }
 
 func (s *Session) GetJSON(
+	ctx context.Context,
 	url string,
 	params *url.Values,
 	headers *http.Header,
 	responseContainer interface{},
 ) (resp *http.Response, err error) {
-	return s.RequestJSON("GET", url, params, headers, nil, responseContainer)
+	return s.RequestJSON(ctx, "GET", url, params, headers, nil, responseContainer)
 }
 
 func (s *Session) Head(
+	ctx context.Context,
 	url string,
 	params *url.Values,
 	headers *http.Header,
 ) (resp *http.Response, err error) {
-	return s.Request("HEAD", url, params, headers, nil)
+	return s.Request(ctx, "HEAD", url, params, headers, nil)
 }
 
 func (s *Session) Post(
+	ctx context.Context,
 	url string,
 	params *url.Values,
 	headers *http.Header,
@@ -386,20 +394,22 @@ func (s *Session) Post(
 		headers = &http.Header{}
 		headers.Add("Content-Type", "application/x-www-form-urlencoded")
 	}
-	return s.Request("POST", url, params, headers, body)
+	return s.Request(ctx, "POST", url, params, headers, body)
 }
 
 func (s *Session) PostJSON(
+	ctx context.Context,
 	url string,
 	params *url.Values,
 	headers *http.Header,
 	body interface{},
 	responseContainer interface{},
 ) (resp *http.Response, err error) {
-	return s.RequestJSON("POST", url, params, headers, body, responseContainer)
+	return s.RequestJSON(ctx, "POST", url, params, headers, body, responseContainer)
 }
 
 func (s *Session) Put(
+	ctx context.Context,
 	url string,
 	params *url.Values,
 	headers *http.Header,
@@ -409,5 +419,5 @@ func (s *Session) Put(
 		headers = &http.Header{}
 		headers.Add("Content-Type", "application/x-www-form-urlencoded")
 	}
-	return s.Request("PUT", url, params, headers, body)
+	return s.Request(ctx, "PUT", url, params, headers, body)
 }

--- a/test/api/AcmeAccount/acme_account_create_remove_test.go
+++ b/test/api/AcmeAccount/acme_account_create_remove_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -26,7 +27,7 @@ func Test_Create_Acme_Account(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
 	acmeAccount, _ := pxapi.NewConfigAcmeAccountFromJson([]byte(account))
-	err := acmeAccount.CreateAcmeAccount("test", Test.GetClient())
+	err := acmeAccount.CreateAcmeAccount(context.Background(), "test", Test.GetClient())
 	require.NoError(t, err)
 }
 
@@ -34,7 +35,7 @@ func Test_Acme_Account_Is_Added(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
 
-	_, err := pxapi.NewConfigAcmeAccountFromApi("test", Test.GetClient())
+	_, err := pxapi.NewConfigAcmeAccountFromApi(context.Background(), "test", Test.GetClient())
 
 	require.NoError(t, err)
 }
@@ -42,7 +43,7 @@ func Test_Acme_Account_Is_Added(t *testing.T) {
 func Test_Remove_Acme_Account(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
-	_, err := Test.GetClient().DeleteAcmeAccount("test")
+	_, err := Test.GetClient().DeleteAcmeAccount(context.Background(), "test")
 
 	require.NoError(t, err)
 }
@@ -51,7 +52,7 @@ func Test_Acme_Account_Is_Removed(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
 
-	_, err := pxapi.NewConfigAcmeAccountFromApi("test", Test.GetClient())
+	_, err := pxapi.NewConfigAcmeAccountFromApi(context.Background(), "test", Test.GetClient())
 
 	require.Error(t, err)
 }

--- a/test/api/AcmeAccount/acme_account_list_test.go
+++ b/test/api/AcmeAccount/acme_account_list_test.go
@@ -1,14 +1,16 @@
 package api_test
 
 import (
-	"github.com/stretchr/testify/require"
+	"context"
 	"testing"
-	"github.com/Telmate/proxmox-api-go/test/api"
+
+	api_test "github.com/Telmate/proxmox-api-go/test/api"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_List_Acme_Accounts(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
-	_, err := Test.GetClient().GetAcmeAccountList()
+	_, err := Test.GetClient().GetAcmeAccountList(context.Background())
 	require.NoError(t, err)
 }

--- a/test/api/Authentication/authentication_apikey_test.go
+++ b/test/api/Authentication/authentication_apikey_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"testing"
 
 	pxapi "github.com/Telmate/proxmox-api-go/proxmox"
@@ -12,18 +13,18 @@ func Test_Root_Login_Correct_Api_Key(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
 
-	user, _ := pxapi.NewConfigUserFromApi(pxapi.UserID{Name: "root", Realm: "pam"}, Test.GetClient())
+	user, _ := pxapi.NewConfigUserFromApi(context.Background(), pxapi.UserID{Name: "root", Realm: "pam"}, Test.GetClient())
 
 	token := pxapi.ApiToken{TokenId: "testing", Comment: "This is a test", Expire: 0, Privsep: false}
 
-	value, _ := user.CreateApiToken(Test.GetClient(), token)
+	value, _ := user.CreateApiToken(context.Background(), Test.GetClient(), token)
 
 	NewTest := api_test.Test{}
 	NewTest.CreateClient()
 	NewTest.GetClient().SetAPIToken("root@pam!testing", value)
 
-	_, err := NewTest.GetClient().GetVersion()
+	_, err := NewTest.GetClient().GetVersion(context.Background())
 	require.NoError(t, err)
 
-	user.DeleteApiToken(Test.GetClient(), token)
+	user.DeleteApiToken(context.Background(), Test.GetClient(), token)
 }

--- a/test/api/CloudInit/cloudinit_test.go
+++ b/test/api/CloudInit/cloudinit_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Telmate/proxmox-api-go/internal/util"
@@ -18,9 +19,9 @@ func Test_Cloud_Init_VM(t *testing.T) {
 	// Create network
 	configNetwork := _create_network_spec()
 
-	err := configNetwork.CreateNetwork(Test.GetClient())
+	err := configNetwork.CreateNetwork(context.Background(), Test.GetClient())
 	require.NoError(t, err)
-	_, err = Test.GetClient().ApplyNetwork("pve")
+	_, err = Test.GetClient().ApplyNetwork(context.Background(), "pve")
 	require.NoError(t, err)
 
 	disk := make(map[string]interface{})
@@ -31,7 +32,7 @@ func Test_Cloud_Init_VM(t *testing.T) {
 	config.QemuDisks[0] = disk
 	config.Name = "Base-Image"
 
-	err = config.Create(vmref, Test.GetClient())
+	err = config.Create(context.Background(), vmref, Test.GetClient())
 	require.NoError(t, err)
 
 	config.Boot = "order=virtio0;ide2;net0"
@@ -42,10 +43,10 @@ func Test_Cloud_Init_VM(t *testing.T) {
 				IPv4: &pxapi.CloudInitIPv4Config{
 					Address: util.Pointer(pxapi.IPv4CIDR("10.0.0.2/24")),
 					Gateway: util.Pointer(pxapi.IPv4Address("10.0.0.1"))}}}}
-	_, err = config.Update(true, vmref, Test.GetClient())
+	_, err = config.Update(context.Background(), true, vmref, Test.GetClient())
 	require.NoError(t, err)
 
-	testConfig, _ := pxapi.NewConfigQemuFromApi(vmref, Test.GetClient())
+	testConfig, _ := pxapi.NewConfigQemuFromApi(context.Background(), vmref, Test.GetClient())
 
 	require.Equal(t, testConfig.CloudInit.NetworkInterfaces[pxapi.QemuNetworkInterfaceID0],
 		pxapi.CloudInitNetworkConfig{
@@ -53,11 +54,11 @@ func Test_Cloud_Init_VM(t *testing.T) {
 				Address: util.Pointer(pxapi.IPv4CIDR("10.0.0.2/24")),
 				Gateway: util.Pointer(pxapi.IPv4Address("10.0.0.1"))}})
 
-	_, err = Test.GetClient().DeleteVm(vmref)
+	_, err = Test.GetClient().DeleteVm(context.Background(), vmref)
 	require.NoError(t, err)
 
-	_, err = Test.GetClient().DeleteNetwork("pve", "vmbr0")
+	_, err = Test.GetClient().DeleteNetwork(context.Background(), "pve", "vmbr0")
 	require.NoError(t, err)
-	_, err = Test.GetClient().ApplyNetwork("pve")
+	_, err = Test.GetClient().ApplyNetwork(context.Background(), "pve")
 	require.NoError(t, err)
 }

--- a/test/api/Lxc/lxc_create_update_delete_test.go
+++ b/test/api/Lxc/lxc_create_update_delete_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"testing"
 
 	pxapi "github.com/Telmate/proxmox-api-go/proxmox"
@@ -13,7 +14,7 @@ func Test_Create_Lxc_Container(t *testing.T) {
 	_ = Test.CreateTest()
 	config := _create_lxc_spec(true)
 
-	err := config.CreateLxc(_create_vmref(), Test.GetClient())
+	err := config.CreateLxc(context.Background(), _create_vmref(), Test.GetClient())
 	require.NoError(t, err)
 }
 
@@ -21,7 +22,7 @@ func Test_Lxc_Container_Is_Added(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
 
-	config, _ := pxapi.NewConfigLxcFromApi(_create_vmref(), Test.GetClient())
+	config, _ := pxapi.NewConfigLxcFromApi(context.Background(), _create_vmref(), Test.GetClient())
 
 	require.Equal(t, "alpine", config.OsType)
 }
@@ -30,11 +31,11 @@ func Test_Update_Lxc_Container(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
 
-	config, _ := pxapi.NewConfigLxcFromApi(_create_vmref(), Test.GetClient())
+	config, _ := pxapi.NewConfigLxcFromApi(context.Background(), _create_vmref(), Test.GetClient())
 
 	config.Cores = 2
 
-	err := config.UpdateConfig(_create_vmref(), Test.GetClient())
+	err := config.UpdateConfig(context.Background(), _create_vmref(), Test.GetClient())
 
 	require.NoError(t, err)
 }
@@ -43,14 +44,14 @@ func Test_Lxc_Container_Is_Updated(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
 
-	config, _ := pxapi.NewConfigLxcFromApi(_create_vmref(), Test.GetClient())
+	config, _ := pxapi.NewConfigLxcFromApi(context.Background(), _create_vmref(), Test.GetClient())
 	require.Equal(t, 2, config.Cores)
 }
 
 func Test_Remove_Lxc_Container(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
-	_, err := Test.GetClient().DeleteVm(_create_vmref())
+	_, err := Test.GetClient().DeleteVm(context.Background(), _create_vmref())
 
 	require.NoError(t, err)
 }
@@ -61,9 +62,9 @@ func Test_Create_Template_Lxc_Container(t *testing.T) {
 	config := _create_lxc_spec(true)
 
 	vmRef := _create_vmref()
-	err := config.CreateLxc(vmRef, Test.GetClient())
+	err := config.CreateLxc(context.Background(), vmRef, Test.GetClient())
 	require.NoError(t, err)
 
-	err = Test.GetClient().CreateTemplate(vmRef)
+	err = Test.GetClient().CreateTemplate(context.Background(), vmRef)
 	require.NoError(t, err)
 }

--- a/test/api/Lxc/lxc_start_test.go
+++ b/test/api/Lxc/lxc_start_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"testing"
 
 	api_test "github.com/Telmate/proxmox-api-go/test/api"
@@ -12,14 +13,14 @@ func Test_Start_Stop_Lxc_Container_Setup(t *testing.T) {
 	_ = Test.CreateTest()
 
 	config := _create_lxc_spec(false)
-	config.CreateLxc(_create_vmref(), Test.GetClient())
+	config.CreateLxc(context.Background(), _create_vmref(), Test.GetClient())
 }
 
 func Test_Start_Lxc_Container(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
 
-	_, err := Test.GetClient().StartVm(_create_vmref())
+	_, err := Test.GetClient().StartVm(context.Background(), _create_vmref())
 	require.NoError(t, err)
 }
 
@@ -27,12 +28,12 @@ func Test_Stop_Lxc_Container(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
 
-	_, err := Test.GetClient().StopVm(_create_vmref())
+	_, err := Test.GetClient().StopVm(context.Background(), _create_vmref())
 	require.NoError(t, err)
 }
 
 func Test_Start_Stop_Lxc_Container_Cleanup(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
-	Test.GetClient().DeleteVm(_create_vmref())
+	Test.GetClient().DeleteVm(context.Background(), _create_vmref())
 }

--- a/test/api/Pool/pool_create_destroy_test.go
+++ b/test/api/Pool/pool_create_destroy_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Telmate/proxmox-api-go/proxmox"
@@ -11,25 +12,25 @@ import (
 func Test_Pool_Create(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
-	proxmox.ConfigPool{Name: "test-pool"}.Create(Test.GetClient())
+	proxmox.ConfigPool{Name: "test-pool"}.Create(context.Background(), Test.GetClient())
 }
 
 func Test_Pool_Is_Created(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
-	_, err := Test.GetClient().GetPoolInfo("test-pool")
+	_, err := Test.GetClient().GetPoolInfo(context.Background(), "test-pool")
 	require.NoError(t, err)
 }
 
 func Test_Pool_Delete(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
-	proxmox.ConfigPool{Name: "test-pool"}.Create(Test.GetClient())
+	proxmox.ConfigPool{Name: "test-pool"}.Create(context.Background(), Test.GetClient())
 }
 
 func Test_Pool_Is_Deleted(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
-	_, err := Test.GetClient().GetPoolInfo("test-pool")
+	_, err := Test.GetClient().GetPoolInfo(context.Background(), "test-pool")
 	require.Error(t, err)
 }

--- a/test/api/Pool/pool_list_test.go
+++ b/test/api/Pool/pool_list_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Telmate/proxmox-api-go/proxmox"
@@ -11,7 +12,7 @@ import (
 func Test_Pools_List(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
-	pools, err := proxmox.ListPools(Test.GetClient())
+	pools, err := proxmox.ListPools(context.Background(), Test.GetClient())
 	require.NoError(t, err)
 	require.Equal(t, 1, len(pools))
 }

--- a/test/api/Qemu/qemu_clone_test.go
+++ b/test/api/Qemu/qemu_clone_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"testing"
 
 	pxapi "github.com/Telmate/proxmox-api-go/proxmox"
@@ -20,7 +21,7 @@ func Test_Clone_Qemu_VM(t *testing.T) {
 	_ = Test.CreateTest()
 	config := _create_vm_spec(false)
 
-	config.Create(_create_vmref(), Test.GetClient())
+	config.Create(context.Background(), _create_vmref(), Test.GetClient())
 
 	cloneConfig := _create_vm_spec(false)
 
@@ -29,7 +30,7 @@ func Test_Clone_Qemu_VM(t *testing.T) {
 	cloneConfig.Name = "test-qemu02"
 	cloneConfig.FullClone = &fullClone
 
-	err := cloneConfig.CloneVm(_create_vmref(), _create_clone_vmref(), Test.GetClient())
+	err := cloneConfig.CloneVm(context.Background(), _create_vmref(), _create_clone_vmref(), Test.GetClient())
 
 	require.NoError(t, err)
 
@@ -40,7 +41,7 @@ func Test_Clone_Qemu_VM_To_Different_Storage(t *testing.T) {
 	_ = Test.CreateTest()
 	config := _create_vm_spec(false)
 
-	config.Create(_create_vmref(), Test.GetClient())
+	config.Create(context.Background(), _create_vmref(), Test.GetClient())
 
 	cloneConfig := _create_vm_spec(false)
 
@@ -50,7 +51,7 @@ func Test_Clone_Qemu_VM_To_Different_Storage(t *testing.T) {
 	cloneConfig.FullClone = &fullClone
 	cloneConfig.Storage = "other-storage"
 
-	err := cloneConfig.CloneVm(_create_vmref(), _create_clone_vmref(), Test.GetClient())
+	err := cloneConfig.CloneVm(context.Background(), _create_vmref(), _create_clone_vmref(), Test.GetClient())
 
 	require.NoError(t, err)
 
@@ -60,7 +61,7 @@ func Test_Qemu_VM_Is_Cloned(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
 
-	config, _ := pxapi.NewConfigQemuFromApi(_create_clone_vmref(), Test.GetClient())
+	config, _ := pxapi.NewConfigQemuFromApi(context.Background(), _create_clone_vmref(), Test.GetClient())
 
 	require.Equal(t, "order=ide2;net0", config.Boot)
 }
@@ -68,6 +69,6 @@ func Test_Qemu_VM_Is_Cloned(t *testing.T) {
 func Test_Clone_Qemu_VM_Cleanup(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
-	Test.GetClient().DeleteVm(_create_clone_vmref())
-	Test.GetClient().DeleteVm(_create_vmref())
+	Test.GetClient().DeleteVm(context.Background(), _create_clone_vmref())
+	Test.GetClient().DeleteVm(context.Background(), _create_vmref())
 }

--- a/test/api/Qemu/qemu_create_update_delete_test.go
+++ b/test/api/Qemu/qemu_create_update_delete_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"testing"
 
 	pxapi "github.com/Telmate/proxmox-api-go/proxmox"
@@ -13,7 +14,7 @@ func Test_Create_Qemu_VM(t *testing.T) {
 	_ = Test.CreateTest()
 	config := _create_vm_spec(true)
 
-	err := config.Create(_create_vmref(), Test.GetClient())
+	err := config.Create(context.Background(), _create_vmref(), Test.GetClient())
 	require.NoError(t, err)
 }
 
@@ -21,7 +22,7 @@ func Test_Qemu_VM_Is_Added(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
 
-	config, _ := pxapi.NewConfigQemuFromApi(_create_vmref(), Test.GetClient())
+	config, _ := pxapi.NewConfigQemuFromApi(context.Background(), _create_vmref(), Test.GetClient())
 
 	require.Equal(t, "order=ide2;net0", config.Boot)
 }
@@ -34,7 +35,7 @@ func Test_Update_Qemu_VM(t *testing.T) {
 
 	config.Boot = "order=net0;ide2"
 
-	_, err := config.Update(true, _create_vmref(), Test.GetClient())
+	_, err := config.Update(context.Background(), true, _create_vmref(), Test.GetClient())
 
 	require.NoError(t, err)
 }
@@ -43,14 +44,14 @@ func Test_Qemu_VM_Is_Updated(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
 
-	config, _ := pxapi.NewConfigQemuFromApi(_create_vmref(), Test.GetClient())
+	config, _ := pxapi.NewConfigQemuFromApi(context.Background(), _create_vmref(), Test.GetClient())
 	require.Equal(t, "order=net0;ide2", config.Boot)
 }
 
 func Test_Remove_Qemu_VM(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
-	_, err := Test.GetClient().DeleteVm(_create_vmref())
+	_, err := Test.GetClient().DeleteVm(context.Background(), _create_vmref())
 
 	require.NoError(t, err)
 }

--- a/test/api/Qemu/qemu_start_test.go
+++ b/test/api/Qemu/qemu_start_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"testing"
 
 	api_test "github.com/Telmate/proxmox-api-go/test/api"
@@ -12,14 +13,14 @@ func Test_Start_Stop_Qemu_VM_Setup(t *testing.T) {
 	_ = Test.CreateTest()
 
 	config := _create_vm_spec(false)
-	config.Create(_create_vmref(), Test.GetClient())
+	config.Create(context.Background(), _create_vmref(), Test.GetClient())
 }
 
 func Test_Start_Qemu_VM(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
 
-	_, err := Test.GetClient().StartVm(_create_vmref())
+	_, err := Test.GetClient().StartVm(context.Background(), _create_vmref())
 	require.NoError(t, err)
 }
 
@@ -27,12 +28,12 @@ func Test_Stop_Qemu_VM(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
 
-	_, err := Test.GetClient().StopVm(_create_vmref())
+	_, err := Test.GetClient().StopVm(context.Background(), _create_vmref())
 	require.NoError(t, err)
 }
 
 func Test_Start_Stop_Qemu_VM_Cleanup(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
-	Test.GetClient().DeleteVm(_create_vmref())
+	Test.GetClient().DeleteVm(context.Background(), _create_vmref())
 }

--- a/test/api/Test.go
+++ b/test/api/Test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"crypto/tls"
 
 	pxapi "github.com/Telmate/proxmox-api-go/proxmox"
@@ -48,7 +49,7 @@ func (test *Test) Login() (err error) {
 			return err
 		}
 	}
-	err = test._client.Login(test.UserID, test.Password, test.OTP)
+	err = test._client.Login(context.Background(), test.UserID, test.Password, test.OTP)
 	return err
 }
 

--- a/test/api/UserManagement/create_token_test.go
+++ b/test/api/UserManagement/create_token_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"testing"
 
 	pxapi "github.com/Telmate/proxmox-api-go/proxmox"
@@ -11,18 +12,18 @@ import (
 func Test_Create_Token(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
-	user, _ := pxapi.NewConfigUserFromApi(pxapi.UserID{Name: "root", Realm: "pam"}, Test.GetClient())
+	user, _ := pxapi.NewConfigUserFromApi(context.Background(), pxapi.UserID{Name: "root", Realm: "pam"}, Test.GetClient())
 
-	_, err := user.CreateApiToken(Test.GetClient(), pxapi.ApiToken{TokenId: "testing", Comment: "This is a test", Expire: 1679404904, Privsep: true})
+	_, err := user.CreateApiToken(context.Background(), Test.GetClient(), pxapi.ApiToken{TokenId: "testing", Comment: "This is a test", Expire: 1679404904, Privsep: true})
 	require.NoError(t, err)
 }
 
 func Test_Token_Is_Created(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
-	user, _ := pxapi.NewConfigUserFromApi(pxapi.UserID{Name: "root", Realm: "pam"}, Test.GetClient())
+	user, _ := pxapi.NewConfigUserFromApi(context.Background(), pxapi.UserID{Name: "root", Realm: "pam"}, Test.GetClient())
 
-	tokens, _ := user.ListApiTokens(Test.GetClient())
+	tokens, _ := user.ListApiTokens(context.Background(), Test.GetClient())
 
 	listoftokens := *tokens
 
@@ -33,24 +34,24 @@ func Test_Token_Is_Created(t *testing.T) {
 func Test_Update_Token(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
-	user, _ := pxapi.NewConfigUserFromApi(pxapi.UserID{Name: "root", Realm: "pam"}, Test.GetClient())
+	user, _ := pxapi.NewConfigUserFromApi(context.Background(), pxapi.UserID{Name: "root", Realm: "pam"}, Test.GetClient())
 
-	tokens, _ := user.ListApiTokens(Test.GetClient())
+	tokens, _ := user.ListApiTokens(context.Background(), Test.GetClient())
 
 	listoftokens := *tokens
 
 	listoftokens[0].Comment = "New Comment"
 
-	err := user.UpdateApiToken(Test.GetClient(), listoftokens[0])
+	err := user.UpdateApiToken(context.Background(), Test.GetClient(), listoftokens[0])
 	require.NoError(t, err)
 }
 
 func Test_Token_Is_Updated(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
-	user, _ := pxapi.NewConfigUserFromApi(pxapi.UserID{Name: "root", Realm: "pam"}, Test.GetClient())
+	user, _ := pxapi.NewConfigUserFromApi(context.Background(), pxapi.UserID{Name: "root", Realm: "pam"}, Test.GetClient())
 
-	tokens, _ := user.ListApiTokens(Test.GetClient())
+	tokens, _ := user.ListApiTokens(context.Background(), Test.GetClient())
 
 	listoftokens := *tokens
 
@@ -60,22 +61,22 @@ func Test_Token_Is_Updated(t *testing.T) {
 func Test_Delete_Token(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
-	user, _ := pxapi.NewConfigUserFromApi(pxapi.UserID{Name: "root", Realm: "pam"}, Test.GetClient())
+	user, _ := pxapi.NewConfigUserFromApi(context.Background(), pxapi.UserID{Name: "root", Realm: "pam"}, Test.GetClient())
 
-	tokens, _ := user.ListApiTokens(Test.GetClient())
+	tokens, _ := user.ListApiTokens(context.Background(), Test.GetClient())
 
 	listoftokens := *tokens
 
-	err := user.DeleteApiToken(Test.GetClient(), listoftokens[0])
+	err := user.DeleteApiToken(context.Background(), Test.GetClient(), listoftokens[0])
 	require.NoError(t, err)
 }
 
 func Test_Token_Is_Deleted(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
-	user, _ := pxapi.NewConfigUserFromApi(pxapi.UserID{Name: "root", Realm: "pam"}, Test.GetClient())
+	user, _ := pxapi.NewConfigUserFromApi(context.Background(), pxapi.UserID{Name: "root", Realm: "pam"}, Test.GetClient())
 
-	tokens, _ := user.ListApiTokens(Test.GetClient())
+	tokens, _ := user.ListApiTokens(context.Background(), Test.GetClient())
 
 	require.Equal(t, 0, len(*tokens))
 }

--- a/test/api/UserManagement/list_user_test.go
+++ b/test/api/UserManagement/list_user_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -12,7 +13,7 @@ import (
 func Test_List_Users(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
-	users, err := pxapi.ListUsers(Test.GetClient(), false)
+	users, err := pxapi.ListUsers(context.Background(), Test.GetClient(), false)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(*users))
 }

--- a/test/api/UserManagement/user_management_test.go
+++ b/test/api/UserManagement/user_management_test.go
@@ -1,6 +1,7 @@
 package api_test
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,7 +25,7 @@ var user = pxapi.ConfigUser{
 func Test_Create_User(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
-	err := user.CreateUser(Test.GetClient())
+	err := user.CreateUser(context.Background(), Test.GetClient())
 	require.NoError(t, err)
 }
 
@@ -32,7 +33,7 @@ func Test_User_Is_Added(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
 
-	users, _ := pxapi.ListUsers(Test.GetClient(), false)
+	users, _ := pxapi.ListUsers(context.Background(), Test.GetClient(), false)
 	var found = false
 	for _, element := range *users {
 		if element == user {
@@ -46,7 +47,7 @@ func Test_User_Is_Added(t *testing.T) {
 func Test_Remove_User(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
-	err := user.DeleteUser(Test.GetClient())
+	err := user.DeleteUser(context.Background(), Test.GetClient())
 	require.NoError(t, err)
 }
 
@@ -54,7 +55,7 @@ func Test_User_Is_Removed(t *testing.T) {
 	Test := api_test.Test{}
 	_ = Test.CreateTest()
 
-	users, _ := pxapi.ListUsers(Test.GetClient(), false)
+	users, _ := pxapi.ListUsers(context.Background(), Test.GetClient(), false)
 	var found = false
 	for _, element := range *users {
 		if element == user {

--- a/test/cli/shared_tests.go
+++ b/test/cli/shared_tests.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"strings"
@@ -117,7 +118,7 @@ type LoginTest struct {
 }
 
 func (test *LoginTest) Login(t *testing.T) {
-	_, err := cli.Client(test.APIurl, test.UserID, test.Password, test.OTP, test.HttpHeaders)
+	_, err := cli.Client(context.Background(), test.APIurl, test.UserID, test.Password, test.OTP, test.HttpHeaders)
 	if test.ReqErr {
 		require.Error(t, err)
 	} else {


### PR DESCRIPTION
Add `context.Context` to every part of the call stack that leads up to `*Session.NewRequest()`
This change allows users to specify their own context, making it possible to gracefully exit the application with `^c`.

Used a background context in the old cli to keep the same behavior.

Used a cancel-able context in the new cli, `Context()`.

Closes #383