### PR TITLE
Add `Task` Interface for long running functions

### DIFF
--- a/cli/command/content/iso/download.go
+++ b/cli/command/content/iso/download.go
@@ -24,8 +24,13 @@ var iso_downloadCmd = &cobra.Command{
 		if err != nil {
 			return
 		}
-		err = proxmox.DownloadIsoFromUrl(cli.Context(), c, config)
+		ctx := cli.Context()
+		var task proxmox.Task
+		task, err = proxmox.DownloadIsoFromUrl(ctx, c, config)
 		if err != nil {
+			return
+		}
+		if err = task.WaitForCompletion(ctx, c); err != nil {
 			return
 		}
 		cli.PrintItemCreated(isoCmd.OutOrStdout(), config.Filename, "ISO file")

--- a/cli/command/content/template/download.go
+++ b/cli/command/content/template/download.go
@@ -21,8 +21,13 @@ var template_downloadCmd = &cobra.Command{
 		if err != nil {
 			return
 		}
-		err = proxmox.DownloadLxcTemplate(cli.Context(), c, config)
+		ctx := cli.Context()
+		var task proxmox.Task
+		task, err = proxmox.DownloadLxcTemplate(ctx, c, config)
 		if err != nil {
+			return
+		}
+		if err = task.WaitForCompletion(ctx, c); err != nil {
 			return
 		}
 		cli.PrintItemCreated(templateCmd.OutOrStdout(), config.Template, "LXC Template")

--- a/cli/command/create/create-snapshot.go
+++ b/cli/command/create/create-snapshot.go
@@ -24,13 +24,18 @@ var (
 			}
 			memory = false
 			client := cli.NewClient()
+			ctx := cli.Context()
 			vmr := proxmox.NewVmRef(id)
-			_, err = client.GetVmInfo(cli.Context(), vmr)
+			_, err = client.GetVmInfo(ctx, vmr)
 			if err != nil {
 				return
 			}
-			err = config.Create(cli.Context(), client, vmr)
+			var task proxmox.Task
+			task, err = config.Create(ctx, client, vmr)
 			if err != nil {
+				return
+			}
+			if err = task.WaitForCompletion(ctx, client); err != nil {
 				return
 			}
 			cli.PrintItemCreated(CreateCmd.OutOrStdout(), snapName, "Snapshot")

--- a/cli/command/delete/delete-file.go
+++ b/cli/command/delete/delete-file.go
@@ -16,11 +16,16 @@ var delete_fileCmd = &cobra.Command{
 		if Type.Validate() != nil {
 			return
 		}
-		err = proxmox.DeleteFile(cli.Context(), c, args[0], proxmox.Content_File{
+		ctx := cli.Context()
+		var task proxmox.Task
+		task, err = proxmox.DeleteFile(ctx, c, args[0], proxmox.Content_File{
 			Storage:     args[1],
 			ContentType: Type,
-			FilePath:    args[3],
-		})
+			FilePath:    args[3]})
+		if err != nil {
+			return
+		}
+		err = task.WaitForCompletion(ctx, c)
 		if err != nil {
 			return
 		}

--- a/proxmox/config_guest.go
+++ b/proxmox/config_guest.go
@@ -218,16 +218,15 @@ func guestSetPool_Unsafe(ctx context.Context, c *Client, guestID uint, newPool P
 	return
 }
 
-func GuestShutdown(ctx context.Context, vmr *VmRef, client *Client, force bool) (err error) {
-	if err = client.CheckVmRef(ctx, vmr); err != nil {
-		return
+func GuestShutdown(ctx context.Context, vmr *VmRef, client *Client, force bool) (Task, error) {
+	if err := client.CheckVmRef(ctx, vmr); err != nil {
+		return nil, err
 	}
 	var params map[string]interface{}
 	if force {
 		params = map[string]interface{}{"forceStop": force}
 	}
-	_, err = client.PostWithTask(ctx, params, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/status/shutdown")
-	return
+	return client.postWithTask(ctx, params, "/nodes/"+vmr.node+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/status/shutdown")
 }
 
 func GuestStart(ctx context.Context, vmr *VmRef, client *Client) (err error) {

--- a/proxmox/content.go
+++ b/proxmox/content.go
@@ -129,13 +129,13 @@ func createFilesList(fileList []interface{}) *[]Content_FileProperties {
 }
 
 // Deletes te specified file from the specified storage.
-func DeleteFile(ctx context.Context, client *Client, node string, content Content_File) (err error) {
+func DeleteFile(ctx context.Context, client *Client, node string, content Content_File) (Task, error) {
+	var err error
 	content.ContentType, err = content.ContentType.toApiValueAndValidate()
 	if err != nil {
-		return
+		return nil, err
 	}
-	_, err = client.DeleteWithTask(ctx, "/nodes/"+node+"/storage/"+content.Storage+"/content"+content.format())
-	return
+	return client.deleteWithTask(ctx, "/nodes/"+node+"/storage/"+content.Storage+"/content"+content.format())
 }
 
 // List all files of the given type in the the specified storage

--- a/proxmox/content_iso.go
+++ b/proxmox/content_iso.go
@@ -48,10 +48,6 @@ func (content ConfigContent_Iso) Validate() (err error) {
 
 // Download an Iso file from a given URL.
 // https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/storage/{storage}/download-url
-func DownloadIsoFromUrl(ctx context.Context, client *Client, content ConfigContent_Iso) (err error) {
-	_, err = client.PostWithTask(ctx, content.mapToApiValues(), "/nodes/"+content.Node+"/storage/"+content.Storage+"/download-url")
-	if err != nil {
-		return err
-	}
-	return nil
+func DownloadIsoFromUrl(ctx context.Context, client *Client, content ConfigContent_Iso) (Task, error) {
+	return client.postWithTask(ctx, content.mapToApiValues(), "/nodes/"+content.Node+"/storage/"+content.Storage+"/download-url")
 }

--- a/proxmox/content_template.go
+++ b/proxmox/content_template.go
@@ -107,9 +107,8 @@ func createTemplateList(templateList []interface{}) *[]TemplateItem {
 }
 
 // Download an LXC template.
-func DownloadLxcTemplate(ctx context.Context, client *Client, content ConfigContent_Template) (err error) {
-	_, err = client.PostWithTask(ctx, content.mapToApiValues(), "/nodes/"+content.Node+"/aplinfo")
-	return
+func DownloadLxcTemplate(ctx context.Context, client *Client, content ConfigContent_Template) (Task, error) {
+	return client.postWithTask(ctx, content.mapToApiValues(), "/nodes/"+content.Node+"/aplinfo")
 }
 
 // List all LXC templates available for download.

--- a/proxmox/session_test.go
+++ b/proxmox/session_test.go
@@ -2,6 +2,8 @@ package proxmox
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestParamsTo(t *testing.T) {
@@ -91,6 +93,43 @@ func TestParamsToWithEmpty(t *testing.T) {
 				t.Errorf("%s: expected `%+v`, got `%+v`",
 					test.name, test.output, output)
 			}
+		})
+	}
+}
+
+func Test_nodeFromUpID_Unsafe(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		output task
+	}{
+		{name: "1",
+			input: "UPID:pve-test:002860A9:051E01C1:67536165:qmmove:102:root@pam:",
+			output: task{
+				id:            "UPID:pve-test:002860A9:051E01C1:67536165:qmmove:102:root@pam:",
+				node:          "pve-test",
+				operationType: "qmmove",
+				user: UserID{
+					Name:  "root",
+					Realm: "pam"}}},
+		{name: "2",
+			input: "UPID:pve:002860A9:051E01C1:67536165:qmshutdown:102:test-user@realm:",
+			output: task{
+				id:            "UPID:pve:002860A9:051E01C1:67536165:qmshutdown:102:test-user@realm:",
+				node:          "pve",
+				operationType: "qmshutdown",
+				user: UserID{
+					Name:  "test-user",
+					Realm: "realm"}}},
+	}
+	for i := range tests {
+		t.Run(tests[i].name, func(t *testing.T) {
+			tmpTask := &task{}
+			tmpTask.mapToSDK_Unsafe(tests[i].input)
+			require.Equal(t, tests[i].output.id, tmpTask.id)
+			require.Equal(t, tests[i].output.node, tmpTask.node)
+			require.Equal(t, tests[i].output.operationType, tmpTask.operationType)
+			require.Equal(t, tests[i].output.user, tmpTask.user)
 		})
 	}
 }


### PR DESCRIPTION
Return a the new `Task` interface when we do something in the API that creates a longer running task in PVE.
Users can await this `Task` with `WaitForCompletion()`.

Closes #388 