### PR TITLE
redefine `nocheck` and `_unsafe`

### DIFF
--- a/proxmox/config_guest.go
+++ b/proxmox/config_guest.go
@@ -184,32 +184,32 @@ func GuestReboot(ctx context.Context, vmr *VmRef, client *Client) (err error) {
 	return
 }
 
-func guestSetPool_Unsafe(ctx context.Context, c *Client, guestID uint, newPool PoolName, currentPool *PoolName, version Version) (err error) {
+func guestSetPoolNoCheck(ctx context.Context, c *Client, guestID uint, newPool PoolName, currentPool *PoolName, version Version) (err error) {
 	if newPool == "" {
 		if *currentPool != "" { // leave pool
-			if err = (*currentPool).removeGuests_Unsafe(ctx, c, []uint{guestID}, version); err != nil {
+			if err = (*currentPool).removeGuestsNoCheck(ctx, c, []uint{guestID}, version); err != nil {
 				return
 			}
 		}
 	} else {
 		if *currentPool == "" { // join pool
 			if version.Smaller(Version{8, 0, 0}) {
-				if err = newPool.addGuests_UnsafeV7(ctx, c, []uint{guestID}); err != nil {
+				if err = newPool.addGuestsNoCheckV7(ctx, c, []uint{guestID}); err != nil {
 					return
 				}
 			} else {
-				newPool.addGuests_UnsafeV8(ctx, c, []uint{guestID})
+				newPool.addGuestsNoCheckV8(ctx, c, []uint{guestID})
 			}
 		} else if newPool != *currentPool { // change pool
 			if version.Smaller(Version{8, 0, 0}) {
-				if err = (*currentPool).removeGuests_Unsafe(ctx, c, []uint{guestID}, version); err != nil {
+				if err = (*currentPool).removeGuestsNoCheck(ctx, c, []uint{guestID}, version); err != nil {
 					return
 				}
-				if err = newPool.addGuests_UnsafeV7(ctx, c, []uint{guestID}); err != nil {
+				if err = newPool.addGuestsNoCheckV7(ctx, c, []uint{guestID}); err != nil {
 					return
 				}
 			} else {
-				if err = newPool.addGuests_UnsafeV8(ctx, c, []uint{guestID}); err != nil {
+				if err = newPool.addGuestsNoCheckV8(ctx, c, []uint{guestID}); err != nil {
 					return
 				}
 			}

--- a/proxmox/config_pool_test.go
+++ b/proxmox/config_pool_test.go
@@ -136,9 +136,9 @@ func Test_ConfigPool_Create(t *testing.T) {
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
-func Test_ConfigPool_Create_Unsafe(t *testing.T) {
+func Test_ConfigPool_CreateNoCheck(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { err = ConfigPool{Name: "test"}.Create_Unsafe(context.Background(), nil) })
+	require.NotPanics(t, func() { err = ConfigPool{Name: "test"}.CreateNoCheck(context.Background(), nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
@@ -160,9 +160,9 @@ func Test_ConfigPool_Set(t *testing.T) {
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
-func Test_ConfigPool_Set_Unsafe(t *testing.T) {
+func Test_ConfigPool_SetNoCheck(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { err = ConfigPool{Name: "test"}.Set_Unsafe(context.Background(), nil) })
+	require.NotPanics(t, func() { err = ConfigPool{Name: "test"}.SetNoCheck(context.Background(), nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
@@ -172,9 +172,9 @@ func Test_ConfigPool_Update(t *testing.T) {
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
-func Test_ConfigPool_Update_Unsafe(t *testing.T) {
+func Test_ConfigPool_UpdateNoCheck(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { err = ConfigPool{Name: "test"}.Update_Unsafe(context.Background(), nil) })
+	require.NotPanics(t, func() { err = ConfigPool{Name: "test"}.UpdateNoCheck(context.Background(), nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
@@ -209,9 +209,9 @@ func Test_PoolName_AddGuests(t *testing.T) {
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
-func Test_PoolName_AddGuests_Unsafe(t *testing.T) {
+func Test_PoolName_AddGuestsNoCheck(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { err = PoolName("test").AddGuests_Unsafe(context.Background(), nil, nil) })
+	require.NotPanics(t, func() { err = PoolName("test").AddGuestsNoCheck(context.Background(), nil, nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
@@ -221,9 +221,9 @@ func Test_PoolName_Delete(t *testing.T) {
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
-func Test_PoolName_Delete_Unsafe(t *testing.T) {
+func Test_PoolName_DeleteNoCheck(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { err = PoolName("test").Delete_Unsafe(context.Background(), nil) })
+	require.NotPanics(t, func() { err = PoolName("test").DeleteNoCheck(context.Background(), nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
@@ -233,9 +233,9 @@ func Test_PoolName_Exists(t *testing.T) {
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
-func Test_PoolName_Exists_Unsafe(t *testing.T) {
+func Test_PoolName_ExistsNoCheck(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { _, err = PoolName("test").Exists_Unsafe(context.Background(), nil) })
+	require.NotPanics(t, func() { _, err = PoolName("test").ExistsNoCheck(context.Background(), nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
@@ -245,9 +245,9 @@ func Test_PoolName_Get(t *testing.T) {
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
-func Test_PoolName_Get_Unsafe(t *testing.T) {
+func Test_PoolName_GetNoCheck(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { _, err = PoolName("test").Get_Unsafe(context.Background(), nil) })
+	require.NotPanics(t, func() { _, err = PoolName("test").GetNoCheck(context.Background(), nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
@@ -306,9 +306,9 @@ func Test_PoolName_RemoveGuests(t *testing.T) {
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
-func Test_PoolName_RemoveGuests_Unsafe(t *testing.T) {
+func Test_PoolName_RemoveGuestsNoCheck(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { err = PoolName("test").RemoveGuests_Unsafe(context.Background(), nil, nil) })
+	require.NotPanics(t, func() { err = PoolName("test").RemoveGuestsNoChecks(context.Background(), nil, nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
@@ -318,9 +318,9 @@ func Test_PoolName_SetGuests(t *testing.T) {
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 
-func Test_PoolName_SetGuests_Unsafe(t *testing.T) {
+func Test_PoolName_SetGuestsNoCheck(t *testing.T) {
 	var err error
-	require.NotPanics(t, func() { err = PoolName("test").SetGuests_Unsafe(context.Background(), nil, nil) })
+	require.NotPanics(t, func() { err = PoolName("test").SetGuestsNoChecks(context.Background(), nil, nil) })
 	require.Equal(t, errors.New(Client_Error_Nil), err)
 }
 

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -573,7 +573,7 @@ func (newConfig ConfigQemu) setAdvanced(ctx context.Context, currentConfig *Conf
 		}
 
 		if newConfig.Pool != nil { // update pool membership
-			guestSetPool_Unsafe(ctx, client, uint(vmr.vmId), *newConfig.Pool, currentConfig.Pool, version)
+			guestSetPoolNoCheck(ctx, client, uint(vmr.vmId), *newConfig.Pool, currentConfig.Pool, version)
 		}
 
 		if stopped { // start vm if it was stopped

--- a/proxmox/snapshot.go
+++ b/proxmox/snapshot.go
@@ -33,11 +33,11 @@ func (config ConfigSnapshot) Create(ctx context.Context, c *Client, vmr *VmRef) 
 	if err = config.Validate(); err != nil {
 		return
 	}
-	return config.Create_Unsafe(ctx, c, vmr)
+	return config.CreateNoCheck(ctx, c, vmr)
 }
 
 // Create a snapshot without validating the input, use ConfigSnapshot.Create() to validate the input.
-func (config ConfigSnapshot) Create_Unsafe(ctx context.Context, c *Client, vmr *VmRef) error {
+func (config ConfigSnapshot) CreateNoCheck(ctx context.Context, c *Client, vmr *VmRef) error {
 	params := config.mapToApiValues()
 	_, err := c.PostWithTask(ctx, params, "/nodes/"+vmr.node.String()+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/")
 	if err != nil {
@@ -156,11 +156,11 @@ func (snap SnapshotName) Delete(ctx context.Context, c *Client, vmr *VmRef) (exi
 		return
 	}
 	// TODO check if snapshot exists
-	return snap.Delete_Unsafe(ctx, c, vmr)
+	return snap.DeleteNoCheck(ctx, c, vmr)
 }
 
 // Deletes the specified snapshot without validating the input, use SnapshotName.Delete() to validate the input.
-func (snap SnapshotName) Delete_Unsafe(ctx context.Context, c *Client, vmr *VmRef) (exitStatus string, err error) {
+func (snap SnapshotName) DeleteNoCheck(ctx context.Context, c *Client, vmr *VmRef) (exitStatus string, err error) {
 	return c.DeleteWithTask(ctx, "/nodes/"+vmr.node.String()+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/"+string(snap))
 }
 
@@ -173,11 +173,11 @@ func (snap SnapshotName) Rollback(ctx context.Context, c *Client, vmr *VmRef) (e
 		return
 	}
 	// TODO check if snapshot exists
-	return snap.Rollback_Unsafe(ctx, c, vmr)
+	return snap.RollbackNoCheck(ctx, c, vmr)
 }
 
 // Rollback to the specified snapshot without validating the input, use SnapshotName.Rollback() to validate the input.
-func (snap SnapshotName) Rollback_Unsafe(ctx context.Context, c *Client, vmr *VmRef) (exitStatus string, err error) {
+func (snap SnapshotName) RollbackNoCheck(ctx context.Context, c *Client, vmr *VmRef) (exitStatus string, err error) {
 	return c.PostWithTask(ctx, nil, "/nodes/"+vmr.node.String()+"/"+vmr.vmType+"/"+strconv.FormatInt(int64(vmr.vmId), 10)+"/snapshot/"+string(snap)+"/rollback")
 }
 
@@ -190,11 +190,11 @@ func (snap SnapshotName) UpdateDescription(ctx context.Context, c *Client, vmr *
 		return
 	}
 	// TODO check if snapshot exists
-	return snap.UpdateDescription_Unsafe(ctx, c, vmr, description)
+	return snap.UpdateDescriptionNoCheck(ctx, c, vmr, description)
 }
 
 // Updates the description of the specified snapshot without validating the input, use SnapshotName.UpdateDescription() to validate the input.
-func (snap SnapshotName) UpdateDescription_Unsafe(ctx context.Context, c *Client, vmr *VmRef, description string) error {
+func (snap SnapshotName) UpdateDescriptionNoCheck(ctx context.Context, c *Client, vmr *VmRef, description string) error {
 	return c.Put(ctx, map[string]interface{}{"description": description}, "/nodes/"+vmr.node.String()+"/"+vmr.vmType+"/"+strconv.Itoa(vmr.vmId)+"/snapshot/"+string(snap)+"/config")
 }
 


### PR DESCRIPTION
`_unsafe` was being used when we where ignoring type safety and API correctness. Now `_unsafe` only indicates ignored type safety and `nocheck` indicates ignored API correctness.