### PR TITLE
Optional GuestID during creation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,47 +203,12 @@ cloneQemu JSON Sample:
 
 ```json
 {
-  "name": "golang2.test.com",
-  "description": "Test proxmox-api-go clone",
-  "storage": "local",
-  "memory": {
-    "capacity": 2048
-  },
-  "cores": 2,
-  "sockets": 1,
-  "fullclone": 1
-}
-```
-
-cloneQemu cloud-init JSON Sample:
-
-```json
-{
-  "name": "cloudinit.test.com",
-  "description": "Test proxmox-api-go clone",
-  "storage": "local",
-  "memory": {
-    "capacity": 2048
-  },
-  "cores": 2,
-  "sockets": 1,
-  "cloudinit": {
-    "ipconfig": {
-      "0": {
-        "ip4": {
-          "address": "10.0.2.17/24",
-          "gateway": "10.0.2.2"
-        }
-      }
-    },
-    "sshkeys": [
-      "..."
-    ],
-    "dns": {
-      "nameservers": [
-        "8.8.8.8"
-      ]
-    }
+  "full": {
+    "node": "pve-latest",
+    "name": "golang2.test.com",
+    "pool": "my-pool",
+    "storage": "local-zfs",
+    "format": "raw"
   }
 }
 ```

--- a/cli/command/get/id/get-id-next.go
+++ b/cli/command/get/id/get-id-next.go
@@ -13,7 +13,7 @@ var id_nextCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		c := cli.NewClient()
-		id, err := c.GetNextID(cli.Context(), 0)
+		id, err := c.GetNextID(cli.Context(), nil)
 		if err != nil {
 			return
 		}

--- a/main.go
+++ b/main.go
@@ -224,7 +224,7 @@ func main() {
 		if vmid > 0 {
 			vmr = proxmox.NewVmRef(vmid)
 		} else {
-			nextid, err := c.GetNextID(ctx, 0)
+			nextid, err := c.GetNextID(ctx, nil)
 			failError(err)
 			vmr = proxmox.NewVmRef(nextid)
 		}

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -1889,7 +1889,7 @@ func (c *Client) DeleteNetwork(ctx context.Context, node string, iface string) (
 
 // ApplyNetwork applies the pending network configuration on the passed in node.
 // It returns the body from the API response and any HTTP error the API returns.
-func (c Client) ApplyNetwork(ctx context.Context, node string) (exitStatus string, err error) {
+func (c *Client) ApplyNetwork(ctx context.Context, node string) (exitStatus string, err error) {
 	url := fmt.Sprintf("/nodes/%s/network", node)
 	return c.PutWithTask(ctx, nil, url)
 }

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -27,16 +27,17 @@ const exitStatusSuccess = "OK"
 
 // Client - URL, user and password to specific Proxmox node
 type Client struct {
-	session         *Session
-	ApiUrl          string
-	Username        string
-	Password        string
-	Otp             string
-	TaskTimeout     int
-	permissionMutex *sync.Mutex
-	permissions     map[permissionPath]privileges
-	version         *Version
-	versionMutex    *sync.Mutex
+	session            *Session
+	ApiUrl             string
+	Username           string
+	Password           string
+	Otp                string
+	TaskTimeout        int
+	permissionMutex    *sync.Mutex
+	permissions        map[permissionPath]privileges
+	version            *Version
+	versionMutex       *sync.Mutex
+	guestCreationMutex sync.Mutex
 }
 
 const (
@@ -588,6 +589,7 @@ func (c *Client) DeleteVmParams(ctx context.Context, vmr *VmRef, params map[stri
 	return
 }
 
+// Deprecated use ConfigQemu.Create() instead
 func (c *Client) CreateQemuVm(ctx context.Context, node NodeName, vmParams map[string]interface{}) (exitStatus string, err error) {
 	// Create VM disks first to ensure disks names.
 	createdDisks, createdDisksErr := c.createVMDisks(ctx, node, vmParams)
@@ -654,6 +656,7 @@ func (c *Client) CreateLxcContainer(ctx context.Context, node string, vmParams m
 	return
 }
 
+// Deprecated: use VmRef.CloneLxc() instead
 func (c *Client) CloneLxcContainer(ctx context.Context, vmr *VmRef, vmParams map[string]interface{}) (exitStatus string, err error) {
 	reqbody := ParamsToBody(vmParams)
 	url := fmt.Sprintf("/nodes/%s/lxc/%s/clone", vmr.node, vmParams["vmid"])
@@ -671,6 +674,7 @@ func (c *Client) CloneLxcContainer(ctx context.Context, vmr *VmRef, vmParams map
 	return
 }
 
+// Deprecated: use VmRef.CloneQemu() instead
 func (c *Client) CloneQemuVm(ctx context.Context, vmr *VmRef, vmParams map[string]interface{}) (exitStatus string, err error) {
 	reqbody := ParamsToBody(vmParams)
 	url := fmt.Sprintf("/nodes/%s/qemu/%d/clone", vmr.node, vmr.vmId)

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -52,7 +52,7 @@ const (
 type VmRef struct {
 	vmId    GuestID
 	node    NodeName
-	pool    string
+	pool    PoolName
 	vmType  string
 	haState string
 	haGroup string
@@ -63,7 +63,7 @@ func (vmr *VmRef) SetNode(node string) {
 }
 
 func (vmr *VmRef) SetPool(pool string) {
-	vmr.pool = pool
+	vmr.pool = PoolName(pool)
 }
 
 func (vmr *VmRef) SetVmType(vmType string) {
@@ -82,7 +82,7 @@ func (vmr *VmRef) Node() NodeName {
 	return vmr.node
 }
 
-func (vmr *VmRef) Pool() string {
+func (vmr *VmRef) Pool() PoolName {
 	return vmr.pool
 }
 
@@ -239,7 +239,7 @@ func (c *Client) GetVmInfo(ctx context.Context, vmr *VmRef) (vmInfo map[string]i
 			vmr.vmType = vmInfo["type"].(string)
 			vmr.pool = ""
 			if vmInfo["pool"] != nil {
-				vmr.pool = vmInfo["pool"].(string)
+				vmr.pool = PoolName(vmInfo["pool"].(string))
 			}
 			if vmInfo["hastate"] != nil {
 				vmr.haState = vmInfo["hastate"].(string)
@@ -272,7 +272,7 @@ func (c *Client) GetVmRefsByName(ctx context.Context, vmName string) (vmrs []*Vm
 			vmr.vmType = vm["type"].(string)
 			vmr.pool = ""
 			if vm["pool"] != nil {
-				vmr.pool = vm["pool"].(string)
+				vmr.pool = PoolName(vm["pool"].(string))
 			}
 			if vm["hastate"] != nil {
 				vmr.haState = vm["hastate"].(string)
@@ -301,7 +301,7 @@ func (c *Client) GetVmRefById(ctx context.Context, ID GuestID) (vmr *VmRef, err 
 			vmr.vmType = vm["type"].(string)
 			vmr.pool = ""
 			if vm["pool"] != nil {
-				vmr.pool = vm["pool"].(string)
+				vmr.pool = PoolName(vm["pool"].(string))
 			}
 			if vm["hastate"] != nil {
 				vmr.haState = vm["hastate"].(string)
@@ -1518,7 +1518,7 @@ func getStorageAndVolumeName(
 // Still used by Terraform. Deprecated: use ConfigQemu.Update() instead
 func (c *Client) UpdateVMPool(ctx context.Context, vmr *VmRef, pool string) (exitStatus interface{}, err error) {
 	// Same pool
-	if vmr.pool == pool {
+	if vmr.pool == PoolName(pool) {
 		return
 	}
 

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -33,10 +33,10 @@ type Client struct {
 	Password           string
 	Otp                string
 	TaskTimeout        int
-	permissionMutex    *sync.Mutex
+	permissionMutex    sync.Mutex
 	permissions        map[permissionPath]privileges
 	version            *Version
-	versionMutex       *sync.Mutex
+	versionMutex       sync.Mutex
 	guestCreationMutex sync.Mutex
 }
 
@@ -115,7 +115,7 @@ func NewClient(apiUrl string, hclient *http.Client, http_headers string, tls *tl
 		return nil, err
 	}
 	if err_s == nil {
-		client = &Client{session: sess, ApiUrl: apiUrl, TaskTimeout: taskTimeout, versionMutex: &sync.Mutex{}, permissionMutex: &sync.Mutex{}, permissions: make(map[permissionPath]privileges)}
+		client = &Client{session: sess, ApiUrl: apiUrl, TaskTimeout: taskTimeout, permissions: make(map[permissionPath]privileges)}
 	}
 
 	return client, err_s

--- a/proxmox/client_test.go
+++ b/proxmox/client_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,25 +19,26 @@ func Test_Client_CheckPermissions(t *testing.T) {
 		output error
 	}{
 		{"nil client", input{nil, []Permission{}}, errors.New(Client_Error_Nil)},
-		{"user root@pam", input{util.Pointer((Client{Username: "root@pam"})), []Permission{}}, nil},
+		{"user root@pam", input{&Client{Username: "root@pam"}, []Permission{}}, nil},
 		{name: "direct permissions",
-			input: input{util.Pointer(Client{permissions: map[permissionPath]privileges{
-				"/access/pve": {UserModify: privilegeTrue},
-			}}), []Permission{
-				{Category: PermissionCategory_Access, Item: "pve", Privileges: Privileges{UserModify: true}}}}},
+			input: input{
+				client: &Client{permissions: map[permissionPath]privileges{
+					"/access/pve": {UserModify: privilegeTrue}}},
+				perms: []Permission{
+					{Category: PermissionCategory_Access, Item: "pve", Privileges: Privileges{UserModify: true}}}}},
 		{name: "propagate permissions",
-			input: input{util.Pointer(Client{permissions: map[permissionPath]privileges{
-				"/access": {UserModify: privilegePropagate},
-			}}), []Permission{
-				{Category: PermissionCategory_Access, Item: "pve", Privileges: Privileges{UserModify: true}}}}},
+			input: input{
+				client: &Client{permissions: map[permissionPath]privileges{
+					"/access": {UserModify: privilegePropagate}}},
+				perms: []Permission{
+					{Category: PermissionCategory_Access, Item: "pve", Privileges: Privileges{UserModify: true}}}}},
 		{name: "missing permissions",
-			input: input{util.Pointer(Client{permissions: map[permissionPath]privileges{
-				"/": {UserModify: privilegeTrue},
-			}}), []Permission{
-				{Category: PermissionCategory_Root, Privileges: Privileges{PoolAllocate: true}},
-			}},
-			output: Permission{Category: PermissionCategory_Root, Privileges: Privileges{PoolAllocate: true}}.error(),
-		},
+			input: input{
+				client: &Client{permissions: map[permissionPath]privileges{
+					"/": {UserModify: privilegeTrue}}},
+				perms: []Permission{
+					{Category: PermissionCategory_Root, Privileges: Privileges{PoolAllocate: true}}}},
+			output: Permission{Category: PermissionCategory_Root, Privileges: Privileges{PoolAllocate: true}}.error()},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/proxmox/client_test.go
+++ b/proxmox/client_test.go
@@ -3,17 +3,13 @@ package proxmox
 import (
 	"context"
 	"errors"
-	"sync"
 	"testing"
 
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_Client_CheckPermissions(t *testing.T) {
-	pointerClient := func(c Client) *Client {
-		c.permissionMutex = &sync.Mutex{}
-		return &c
-	}
 	type input struct {
 		client *Client
 		perms  []Permission
@@ -24,19 +20,19 @@ func Test_Client_CheckPermissions(t *testing.T) {
 		output error
 	}{
 		{"nil client", input{nil, []Permission{}}, errors.New(Client_Error_Nil)},
-		{"user root@pam", input{pointerClient(Client{Username: "root@pam"}), []Permission{}}, nil},
+		{"user root@pam", input{util.Pointer((Client{Username: "root@pam"})), []Permission{}}, nil},
 		{name: "direct permissions",
-			input: input{pointerClient(Client{permissions: map[permissionPath]privileges{
+			input: input{util.Pointer(Client{permissions: map[permissionPath]privileges{
 				"/access/pve": {UserModify: privilegeTrue},
 			}}), []Permission{
 				{Category: PermissionCategory_Access, Item: "pve", Privileges: Privileges{UserModify: true}}}}},
 		{name: "propagate permissions",
-			input: input{pointerClient(Client{permissions: map[permissionPath]privileges{
+			input: input{util.Pointer(Client{permissions: map[permissionPath]privileges{
 				"/access": {UserModify: privilegePropagate},
 			}}), []Permission{
 				{Category: PermissionCategory_Access, Item: "pve", Privileges: Privileges{UserModify: true}}}}},
 		{name: "missing permissions",
-			input: input{pointerClient(Client{permissions: map[permissionPath]privileges{
+			input: input{util.Pointer(Client{permissions: map[permissionPath]privileges{
 				"/": {UserModify: privilegeTrue},
 			}}), []Permission{
 				{Category: PermissionCategory_Root, Privileges: Privileges{PoolAllocate: true}},

--- a/proxmox/config_guest.go
+++ b/proxmox/config_guest.go
@@ -212,13 +212,13 @@ func GuestReboot(ctx context.Context, vmr *VmRef, client *Client) (err error) {
 
 func guestSetPoolNoCheck(ctx context.Context, c *Client, guestID uint, newPool PoolName, currentPool *PoolName, version Version) (err error) {
 	if newPool == "" {
-		if *currentPool != "" { // leave pool
+		if currentPool != nil && *currentPool != "" { // leave pool
 			if err = (*currentPool).removeGuestsNoCheck(ctx, c, []uint{guestID}, version); err != nil {
 				return
 			}
 		}
 	} else {
-		if *currentPool == "" { // join pool
+		if currentPool == nil || *currentPool == "" { // join pool
 			if version.Smaller(Version{8, 0, 0}) {
 				if err = newPool.addGuestsNoCheckV7(ctx, c, []uint{guestID}); err != nil {
 					return

--- a/proxmox/config_guest.go
+++ b/proxmox/config_guest.go
@@ -3,8 +3,10 @@ package proxmox
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/netip"
 	"strconv"
+	"strings"
 )
 
 // All code LXC and Qemu have in common should be placed here.
@@ -291,4 +293,28 @@ func pendingGuestConfigFromApi(ctx context.Context, vmr *VmRef, client *Client) 
 		return nil, err
 	}
 	return client.GetItemConfigInterfaceArray(ctx, "/nodes/"+vmr.node.String()+"/"+vmr.vmType+"/"+vmr.vmId.String()+"/pending", "Guest", "PENDING CONFIG")
+}
+
+const guest_ApiError_AlreadyExists string = "config file already exists"
+
+// Keep trying to create/clone a VM until we get a unique ID
+func guestCreateLoop(ctx context.Context, idKey, url string, params map[string]interface{}, c *Client) (GuestID, error) {
+	c.guestCreationMutex.Lock()
+	defer c.guestCreationMutex.Unlock()
+	for {
+		guestID, err := c.GetNextIdNoCheck(ctx, nil)
+		if err != nil {
+			return 0, err
+		}
+		params[idKey] = int(guestID)
+		var exitStatus string
+		exitStatus, err = c.PostWithTask(ctx, params, url)
+		if err != nil {
+			if !strings.Contains(err.Error(), guest_ApiError_AlreadyExists) {
+				return 0, fmt.Errorf("error creating Guest: %v, error status: %s (params: %v)", err, exitStatus, params)
+			}
+		} else {
+			return guestID, nil
+		}
+	}
 }

--- a/proxmox/config_lxc.go
+++ b/proxmox/config_lxc.go
@@ -353,6 +353,7 @@ func (config ConfigLxc) CreateLxc(ctx context.Context, vmr *VmRef, client *Clien
 	return
 }
 
+// Deprecated: use VmRef.CloneLxc() instead
 func (config ConfigLxc) CloneLxc(ctx context.Context, vmr *VmRef, client *Client) (err error) {
 	vmr.SetVmType("lxc")
 

--- a/proxmox/config_pool.go
+++ b/proxmox/config_pool.go
@@ -445,6 +445,10 @@ func (pool PoolName) setGuestsNoCheck(ctx context.Context, c *Client, guestIDs [
 	return pool.addGuestsNoCheck(ctx, c, guestIDs, currentGuests, version)
 }
 
+func (pool PoolName) String() string {
+	return string(pool)
+}
+
 func (config PoolName) Validate() error {
 	if config == "" {
 		return errors.New(PoolName_Error_Empty)

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -298,8 +298,8 @@ func (ConfigQemu) mapToStruct(vmr *VmRef, params map[string]interface{}) (*Confi
 			config.Node = &nodeCopy
 		}
 		if vmr.pool != "" {
-		poolCopy := PoolName(vmr.pool)
-		config.Pool = &poolCopy
+			poolCopy := PoolName(vmr.pool)
+			config.Pool = &poolCopy
 		}
 		if vmr.vmId != 0 {
 			idCopy := vmr.vmId
@@ -634,7 +634,7 @@ func (newConfig ConfigQemu) setAdvanced(
 		url := "/nodes/" + newConfig.Node.String() + "/qemu"
 		if newConfig.ID == nil {
 			id, err = guestCreateLoop(ctx, "vmid", url, params, client)
-		if err != nil {
+			if err != nil {
 				return
 			}
 		} else {

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -38,7 +38,7 @@ type ConfigQemu struct {
 	Description     *string               `json:"description,omitempty"`
 	Disks           *QemuStorages         `json:"disks,omitempty"`
 	EFIDisk         QemuDevice            `json:"efidisk,omitempty"`   // TODO should be a struct
-	FullClone       *int                  `json:"fullclone,omitempty"` // TODO should probably be a bool
+	FullClone       *int                  `json:"fullclone,omitempty"` // Deprecated
 	HaGroup         string                `json:"hagroup,omitempty"`
 	HaState         string                `json:"hastate,omitempty"` // TODO should be custom type with enum
 	Hookscript      string                `json:"hookscript,omitempty"`

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -52,8 +52,8 @@ type ConfigQemu struct {
 	Onboot          *bool                 `json:"onboot,omitempty"`
 	Pool            *PoolName             `json:"pool,omitempty"`
 	Protection      *bool                 `json:"protection,omitempty"`
-	QemuDisks       QemuDevices           `json:"disk,omitempty"`    // DEPRECATED use Disks *QemuStorages instead
-	QemuIso         string                `json:"qemuiso,omitempty"` // DEPRECATED use Iso *IsoFile instead
+	QemuDisks       QemuDevices           `json:"disk,omitempty"`    // Deprecated use Disks *QemuStorages instead
+	QemuIso         string                `json:"qemuiso,omitempty"` // Deprecated use Iso *IsoFile instead
 	QemuKVM         *bool                 `json:"kvm,omitempty"`
 	QemuOs          string                `json:"ostype,omitempty"`
 	PciDevices      QemuPciDevices        `json:"pci_devices,omitempty"`

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -26,6 +26,8 @@ type (
 
 // ConfigQemu - Proxmox API QEMU options
 type ConfigQemu struct {
+	ID              *GuestID              `json:"id,omitempty"`   // Required for creation, cannot be changed
+	Node            *NodeName             `json:"node,omitempty"` // Required for creation
 	Agent           *QemuGuestAgent       `json:"agent,omitempty"`
 	Args            string                `json:"args,omitempty"`
 	Bios            string                `json:"bios,omitempty"`
@@ -47,7 +49,6 @@ type ConfigQemu struct {
 	Memory          *QemuMemory           `json:"memory,omitempty"`
 	Name            string                `json:"name,omitempty"` // TODO should be custom type as there are character and length limitations
 	Networks        QemuNetworkInterfaces `json:"networks,omitempty"`
-	Node            NodeName              `json:"node,omitempty"` // Only returned setting it has no effect, set node in the VmRef instead
 	Onboot          *bool                 `json:"onboot,omitempty"`
 	Pool            *PoolName             `json:"pool,omitempty"`
 	Protection      *bool                 `json:"protection,omitempty"`
@@ -69,19 +70,19 @@ type ConfigQemu struct {
 	TPM             *TpmState             `json:"tpm,omitempty"`
 	Tablet          *bool                 `json:"tablet,omitempty"`
 	Tags            *[]Tag                `json:"tags,omitempty"`
-	ID              GuestID               `json:"id,omitempty"`
 }
 
 const (
 	ConfigQemu_Error_UnableToUpdateWithoutReboot string = "unable to update vm without rebooting"
 	ConfigQemu_Error_CpuRequired                 string = "cpu is required during creation"
 	ConfigQemu_Error_MemoryRequired              string = "memory is required during creation"
+	ConfigQemu_Error_NodeRequired                string = "node is required during creation"
 )
 
 // Create - Tell Proxmox API to make the VM
-func (config ConfigQemu) Create(ctx context.Context, vmr *VmRef, client *Client) (err error) {
-	_, err = config.setAdvanced(ctx, nil, false, vmr, client)
-	return
+func (config ConfigQemu) Create(ctx context.Context, client *Client) (*VmRef, error) {
+	_, vmr, err := config.setAdvanced(ctx, nil, false, nil, client)
+	return vmr, err
 }
 
 func (config *ConfigQemu) defaults() {
@@ -138,8 +139,9 @@ func (config ConfigQemu) mapToAPI(currentConfig ConfigQemu, version Version) (re
 
 	params = map[string]interface{}{}
 
-	if config.ID != 0 {
-		params["vmid"] = config.ID
+	var guestID GuestID
+	if config.ID != nil {
+		guestID = *config.ID
 	}
 	if config.Args != "" {
 		params["args"] = config.Args
@@ -219,7 +221,7 @@ func (config ConfigQemu) mapToAPI(currentConfig ConfigQemu, version Version) (re
 	if currentConfig.Disks != nil {
 		if config.Disks != nil {
 			// Create,Update,Delete
-			delete := config.Disks.mapToApiValues(*currentConfig.Disks, config.ID, currentConfig.LinkedVmId, params)
+			delete := config.Disks.mapToApiValues(*currentConfig.Disks, guestID, currentConfig.LinkedVmId, params)
 			if delete != "" {
 				itemsToDelete = AddToList(itemsToDelete, delete)
 			}
@@ -227,7 +229,7 @@ func (config ConfigQemu) mapToAPI(currentConfig ConfigQemu, version Version) (re
 	} else {
 		if config.Disks != nil {
 			// Create
-			config.Disks.mapToApiValues(QemuStorages{}, config.ID, 0, params)
+			config.Disks.mapToApiValues(QemuStorages{}, guestID, 0, params)
 		}
 	}
 
@@ -291,11 +293,17 @@ func (ConfigQemu) mapToStruct(vmr *VmRef, params map[string]interface{}) (*Confi
 	}
 
 	if vmr != nil {
-		config.Node = vmr.node
+		if vmr.node != "" {
+			nodeCopy := vmr.node
+			config.Node = &nodeCopy
+		}
+		if vmr.pool != "" {
 		poolCopy := PoolName(vmr.pool)
 		config.Pool = &poolCopy
+		}
 		if vmr.vmId != 0 {
-			config.ID = vmr.vmId
+			idCopy := vmr.vmId
+			config.ID = &idCopy
 		}
 	}
 
@@ -448,7 +456,8 @@ func (newConfig ConfigQemu) Update(ctx context.Context, rebootIfNeeded bool, vmr
 	if err != nil {
 		return
 	}
-	return newConfig.setAdvanced(ctx, currentConfig, rebootIfNeeded, vmr, client)
+	rebootRequired, _, err = newConfig.setAdvanced(ctx, currentConfig, rebootIfNeeded, vmr, client)
+	return
 }
 
 func (config *ConfigQemu) setVmr(vmr *VmRef) (err error) {
@@ -459,28 +468,33 @@ func (config *ConfigQemu) setVmr(vmr *VmRef) (err error) {
 		return
 	}
 	vmr.SetVmType("qemu")
-	config.ID = vmr.vmId
-	config.Node = vmr.node
+	idCopy := vmr.vmId
+	config.ID = &idCopy
+	config.Node = &vmr.node
 	return
 }
 
 // currentConfig will be mutated
-func (newConfig ConfigQemu) setAdvanced(ctx context.Context, currentConfig *ConfigQemu, rebootIfNeeded bool, vmr *VmRef, client *Client) (rebootRequired bool, err error) {
-	if err = newConfig.setVmr(vmr); err != nil {
-		return
-	}
+func (newConfig ConfigQemu) setAdvanced(
+	ctx context.Context, currentConfig *ConfigQemu, rebootIfNeeded bool, vmr *VmRef, client *Client,
+) (rebootRequired bool, newVMR *VmRef, err error,
+) {
 	var version Version
 	if version, err = client.Version(ctx); err != nil {
 		return
 	}
-	if err = newConfig.Validate(currentConfig, version); err != nil {
-		return
-	}
-
 	var params map[string]interface{}
 	var exitStatus string
 
 	if currentConfig != nil { // Update
+		if vmr != nil {
+			if err = newConfig.setVmr(vmr); err != nil {
+				return
+			}
+		}
+		if err = newConfig.Validate(currentConfig, version); err != nil {
+			return
+		}
 		// TODO implement tmp move and version change
 		url := "/nodes/" + vmr.node.String() + "/" + vmr.vmType + "/" + vmr.vmId.String() + "/config"
 		var itemsToDeleteBeforeUpdate string // this is for items that should be removed before they can be created again e.g. cloud-init disks. (convert to array when needed)
@@ -496,7 +510,7 @@ func (newConfig ConfigQemu) setAdvanced(ctx context.Context, currentConfig *Conf
 				}
 			}
 			if err = resizeDisks(ctx, vmr, client, markedDisks.Resize); err != nil { // increase Disks in size
-				return false, err
+				return false, nil, err
 			}
 			itemsToDeleteBeforeUpdate = newConfig.Disks.cloudInitRemove(*currentConfig.Disks)
 		}
@@ -508,7 +522,7 @@ func (newConfig ConfigQemu) setAdvanced(ctx context.Context, currentConfig *Conf
 				currentConfig.TPM = nil
 			} else if disk != nil { // move
 				if _, err := disk.move(ctx, true, vmr, client); err != nil {
-					return false, err
+					return false, nil, err
 				}
 			}
 		}
@@ -516,7 +530,7 @@ func (newConfig ConfigQemu) setAdvanced(ctx context.Context, currentConfig *Conf
 		if itemsToDeleteBeforeUpdate != "" {
 			err = client.Put(ctx, map[string]interface{}{"delete": itemsToDeleteBeforeUpdate}, url)
 			if err != nil {
-				return false, fmt.Errorf("error updating VM: %v", err)
+				return false, nil, fmt.Errorf("error updating VM: %v", err)
 			}
 			// Deleteing these items can create pending changes
 			rebootRequired, err = GuestHasPendingChanges(ctx, vmr, client)
@@ -531,7 +545,7 @@ func (newConfig ConfigQemu) setAdvanced(ctx context.Context, currentConfig *Conf
 					stopped = true
 					rebootRequired = false
 				} else {
-					return rebootRequired, errors.New(ConfigQemu_Error_UnableToUpdateWithoutReboot)
+					return rebootRequired, nil, errors.New(ConfigQemu_Error_UnableToUpdateWithoutReboot)
 				}
 			}
 		}
@@ -544,14 +558,14 @@ func (newConfig ConfigQemu) setAdvanced(ctx context.Context, currentConfig *Conf
 			}
 		}
 
-		if newConfig.Node != currentConfig.Node { // Migrate VM
-			vmr.node = newConfig.Node
-			_, err = client.MigrateNode(ctx, vmr, newConfig.Node, true)
+		if newConfig.Node != nil && currentConfig.Node != nil && *newConfig.Node != *currentConfig.Node { // Migrate VM
+			vmr.node = *newConfig.Node
+			_, err = client.MigrateNode(ctx, vmr, *newConfig.Node, true)
 			if err != nil {
 				return
 			}
 			// Set node to the node the VM was migrated to
-			vmr.node = newConfig.Node
+			vmr.node = *newConfig.Node
 		}
 
 		rebootRequired, params, err = newConfig.mapToAPI(*currentConfig, version)
@@ -560,7 +574,7 @@ func (newConfig ConfigQemu) setAdvanced(ctx context.Context, currentConfig *Conf
 		}
 		exitStatus, err = client.PutWithTask(ctx, params, url)
 		if err != nil {
-			return false, fmt.Errorf("error updating VM: %v, error status: %s (params: %v)", err, exitStatus, params)
+			return false, nil, fmt.Errorf("error updating VM: %v, error status: %s (params: %v)", err, exitStatus, params)
 		}
 
 		if !rebootRequired && !stopped { // only check if reboot is required if the vm is not already stopped
@@ -586,7 +600,7 @@ func (newConfig ConfigQemu) setAdvanced(ctx context.Context, currentConfig *Conf
 				stopped = false
 				rebootRequired = false
 			} else {
-				return true, nil
+				return true, nil, nil
 			}
 		} else if rebootRequired { // reboot vm if it is running
 			if rebootIfNeeded {
@@ -595,28 +609,52 @@ func (newConfig ConfigQemu) setAdvanced(ctx context.Context, currentConfig *Conf
 				}
 				rebootRequired = false
 			} else {
-				return rebootRequired, nil
+				return rebootRequired, nil, nil
 			}
 		}
 	} else { // Create
+		if err = newConfig.Validate(nil, version); err != nil {
+			return
+		}
 		_, params, err = newConfig.mapToAPI(ConfigQemu{}, version)
 		if err != nil {
 			return
 		}
 		// pool field unsupported by /nodes/%s/vms/%d/config used by update (currentConfig != nil).
 		// To be able to create directly in a configured pool, add pool to mapped params from ConfigQemu, before creating VM
+		var pool PoolName
 		if newConfig.Pool != nil && *newConfig.Pool != "" {
 			params["pool"] = *newConfig.Pool
 		}
-		exitStatus, err = client.CreateQemuVm(ctx, vmr.node, params)
+		var id GuestID
+		var node NodeName
+		if newConfig.Node != nil {
+			node = *newConfig.Node
+		}
+		url := "/nodes/" + newConfig.Node.String() + "/qemu"
+		if newConfig.ID == nil {
+			id, err = guestCreateLoop(ctx, "vmid", url, params, client)
 		if err != nil {
-			return false, fmt.Errorf("error creating VM: %v, error status: %s (params: %v)", err, exitStatus, params)
+				return
+			}
+		} else {
+			params["vmid"] = int(*newConfig.ID)
+			exitStatus, err = client.PostWithTask(ctx, params, url)
+			if err != nil {
+				return false, nil, fmt.Errorf("error creating VM: %v, error status: %s (params: %v)", err, exitStatus, params)
+			}
 		}
 		if err = resizeNewDisks(ctx, vmr, client, newConfig.Disks, nil); err != nil {
 			return
 		}
 		if err = client.insertCachedPermission(ctx, permissionPath(permissionCategory_GuestPath)+"/"+permissionPath(vmr.vmId.String())); err != nil {
 			return
+		}
+		vmr = &VmRef{
+			node:   node,
+			vmId:   id,
+			pool:   pool,
+			vmType: vmRefQemu,
 		}
 	}
 
@@ -628,6 +666,17 @@ func (config ConfigQemu) Validate(current *ConfigQemu, version Version) (err err
 	// TODO test all other use cases
 	// TODO has no context about changes caused by updating the vm
 	if current == nil { // Create
+		if config.ID != nil {
+			if err = config.ID.Validate(); err != nil {
+				return
+			}
+		}
+		if config.Node == nil {
+			return errors.New(ConfigQemu_Error_NodeRequired)
+		}
+		if err = config.Node.Validate(); err != nil {
+			return
+		}
 		if config.CPU == nil {
 			return errors.New(ConfigQemu_Error_CpuRequired)
 		} else {
@@ -663,6 +712,11 @@ func (config ConfigQemu) Validate(current *ConfigQemu, version Version) (err err
 			}
 		}
 	} else { // Update
+		if config.Node != nil {
+			if err = config.Node.Validate(); err != nil {
+				return
+			}
+		}
 		if config.CPU != nil {
 			if err = config.CPU.Validate(current.CPU, version); err != nil {
 				return
@@ -711,11 +765,6 @@ func (config ConfigQemu) Validate(current *ConfigQemu, version Version) (err err
 			return
 		}
 	}
-	if config.ID != 0 {
-		if err = config.ID.Validate(); err != nil {
-			return
-		}
-	}
 	if config.Pool != nil && *config.Pool != "" {
 		if err = config.Pool.Validate(); err != nil {
 			return
@@ -746,6 +795,7 @@ target:proxmox1-xx
 full:1
 storage:xxx
 */
+// Deprecated: use VmRef.CloneQemu() instead
 func (config ConfigQemu) CloneVm(ctx context.Context, sourceVmr *VmRef, vmr *VmRef, client *Client) (err error) {
 	vmr.SetVmType("qemu")
 	var storage string
@@ -826,7 +876,7 @@ func NewConfigQemuFromApi(ctx context.Context, vmr *VmRef, client *Client) (conf
 		return nil, fmt.Errorf("vm locked, could not obtain config")
 	}
 	if v, isSet := vmInfo["pool"]; isSet { // TODO: this is a workaround for the issue that GetVmConfig will not always return the guest info
-		vmr.pool = v.(string)
+		vmr.pool = PoolName(v.(string))
 	}
 	config, err = ConfigQemu{}.mapToStruct(vmr, vmConfig)
 	if err != nil {

--- a/proxmox/config_qemu_disk.go
+++ b/proxmox/config_qemu_disk.go
@@ -718,6 +718,10 @@ func (QemuDiskFormat) Error() error {
 	return fmt.Errorf("format can only be one of the following values: %s,%s,%s,%s,%s,%s,%s", QemuDiskFormat_Cow, QemuDiskFormat_Cloop, QemuDiskFormat_Qcow, QemuDiskFormat_Qcow2, QemuDiskFormat_Qed, QemuDiskFormat_Vmdk, QemuDiskFormat_Raw)
 }
 
+func (format QemuDiskFormat) String() string {
+	return string(format)
+}
+
 func (format QemuDiskFormat) Validate() error {
 	switch format {
 	case QemuDiskFormat_Cow, QemuDiskFormat_Cloop, QemuDiskFormat_Qcow, QemuDiskFormat_Qcow2, QemuDiskFormat_Qed, QemuDiskFormat_Vmdk, QemuDiskFormat_Raw:

--- a/proxmox/vmref.go
+++ b/proxmox/vmref.go
@@ -129,8 +129,8 @@ func (target CloneLxcTarget) mapToAPI() (GuestID, NodeName, PoolName, map[string
 }
 
 type CloneQemuTarget struct {
-	Full   *CloneQemuFull
-	Linked *CloneLinked
+	Full   *CloneQemuFull `json:"full,omitempty"`
+	Linked *CloneLinked   `json:"linked,omitempty"`
 }
 
 const (
@@ -163,10 +163,10 @@ func (target CloneQemuTarget) mapToAPI() (GuestID, NodeName, PoolName, map[strin
 
 // Linked Clone in the same for both LXC and QEMU
 type CloneLinked struct {
-	Node NodeName
-	ID   *GuestID  // Optional
-	Name *string   // Optional // TODO replace one we have a type for it
-	Pool *PoolName // Optional
+	Node NodeName  `json:"node"`
+	ID   *GuestID  `json:"id,omitempty"`   // Optional
+	Name *string   `json:"name,omitempty"` // Optional // TODO replace one we have a type for it
+	Pool *PoolName `json:"pool,omitempty"` // Optional
 }
 
 func (linked CloneLinked) Validate() (err error) {
@@ -194,11 +194,11 @@ func (linked CloneLinked) mapToAPI(nameFlag string) (GuestID, NodeName, PoolName
 }
 
 type CloneLxcFull struct {
-	Node    NodeName
-	ID      *GuestID  // Optional
-	Name    *string   // Optional // TODO replace one we have a type for it
-	Pool    *PoolName // Optional
-	Storage *string   // Optional // TODO replace one we have a type for it
+	Node    NodeName  `json:"node"`
+	ID      *GuestID  `json:"id,omitempty"`      // Optional
+	Name    *string   `json:"name,omitempty"`    // Optional // TODO replace one we have a type for it
+	Pool    *PoolName `json:"pool,omitempty"`    // Optional
+	Storage *string   `json:"storage,omitempty"` // Optional // TODO replace one we have a type for it
 }
 
 func (full CloneLxcFull) Validate() (err error) {
@@ -227,12 +227,12 @@ func (full CloneLxcFull) mapToAPI() (GuestID, NodeName, PoolName, map[string]int
 }
 
 type CloneQemuFull struct {
-	Node          NodeName
-	ID            *GuestID        // Optional
-	Name          *string         // Optional // TODO replace one we have a type for it
-	Pool          *PoolName       // Optional
-	Storage       *string         // Optional // TODO replace one we have a type for it
-	StorageFormat *QemuDiskFormat // Optional
+	Node          NodeName        `json:"node"`
+	ID            *GuestID        `json:"id,omitempty"`      // Optional
+	Name          *string         `json:"name,omitempty"`    // Optional // TODO replace one we have a type for it
+	Pool          *PoolName       `json:"pool,omitempty"`    // Optional
+	Storage       *string         `json:"storage,omitempty"` // Optional // TODO replace one we have a type for it
+	StorageFormat *QemuDiskFormat `json:"format,omitempty"`  // Optional
 }
 
 func (full CloneQemuFull) Validate() (err error) {

--- a/proxmox/vmref.go
+++ b/proxmox/vmref.go
@@ -1,0 +1,296 @@
+package proxmox
+
+import (
+	"context"
+	"errors"
+)
+
+const (
+	vmRefQemu                     string = "qemu"
+	vmRefLXC                      string = "lxc"
+	clone_Error_MutuallyExclusive string = "linked and full clone are mutually exclusive"
+	clone_Error_NoneSet           string = "either linked nor full clone must be set"
+)
+
+// CloneLxc clones a new LXC container by cloning current container
+func (vmr *VmRef) CloneLxc(ctx context.Context, settings CloneLxcTarget, c *Client) (*VmRef, error) {
+	if vmr == nil {
+		return nil, errors.New(VmRef_Error_Nil)
+	}
+	err := settings.Validate()
+	if err != nil {
+		return nil, err
+	}
+	return vmr.cloneLxc_Unsafe(ctx, settings, c)
+}
+
+// CloneLxcNoCheck creates a new LXC container by cloning the current container, without input validation.
+func (vmr *VmRef) CloneLxcNoCheck(ctx context.Context, settings CloneLxcTarget, c *Client) (*VmRef, error) {
+	if vmr == nil {
+		return nil, errors.New(VmRef_Error_Nil)
+	}
+	return vmr.cloneLxc_Unsafe(ctx, settings, c)
+}
+
+func (vmr *VmRef) cloneLxc_Unsafe(ctx context.Context, settings CloneLxcTarget, c *Client) (*VmRef, error) {
+	id, node, pool, params := settings.mapToAPI()
+	var err error
+	url := "/nodes/" + vmr.node.String() + "/lxc/" + vmr.vmId.String() + "/clone"
+	if id == 0 {
+		id, err = guestCreateLoop(ctx, "newid", url, params, c)
+	} else {
+		_, err = c.PostWithTask(ctx, params, url)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &VmRef{
+		vmId:   id,
+		node:   node,
+		pool:   pool,
+		vmType: vmRefLXC}, nil
+}
+
+// CloneQemu creates a new Qemu VM by cloning the current VM.
+func (vmr *VmRef) CloneQemu(ctx context.Context, settings CloneQemuTarget, c *Client) (*VmRef, error) {
+	if vmr == nil {
+		return nil, errors.New(VmRef_Error_Nil)
+	}
+	err := settings.Validate()
+	if err != nil {
+		return nil, err
+	}
+	return vmr.cloneQemu_Unsafe(ctx, settings, c)
+}
+
+// CloneQemuNoCheck creates a new VM by cloning the current VM, without input validation.
+func (vmr *VmRef) CloneQemuNoCheck(ctx context.Context, settings CloneQemuTarget, c *Client) (*VmRef, error) {
+	if vmr == nil {
+		return nil, errors.New(VmRef_Error_Nil)
+	}
+	return vmr.cloneQemu_Unsafe(ctx, settings, c)
+}
+
+func (vmr *VmRef) cloneQemu_Unsafe(ctx context.Context, settings CloneQemuTarget, c *Client) (*VmRef, error) {
+	id, node, pool, params := settings.mapToAPI()
+	var err error
+	url := "/nodes/" + vmr.node.String() + "/qemu/" + vmr.vmId.String() + "/clone"
+	if id == 0 {
+		id, err = guestCreateLoop(ctx, "newid", url, params, c)
+	} else {
+		_, err = c.PostWithTask(ctx, params, url)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &VmRef{
+		vmId:   id,
+		node:   node,
+		pool:   pool,
+		vmType: vmRefQemu}, nil
+}
+
+type CloneLxcTarget struct {
+	Full   *CloneLxcFull
+	Linked *CloneLinked
+}
+
+const (
+	CloneLxcTarget_Error_MutualExclusivity = clone_Error_MutuallyExclusive
+	CloneLxcTarget_Error_NoneSet           = clone_Error_NoneSet
+)
+
+func (target CloneLxcTarget) Validate() error {
+	if target.Full == nil && target.Linked == nil {
+		return errors.New(CloneQemuTarget_Error_NoneSet)
+	}
+	if target.Full != nil && target.Linked != nil {
+		return errors.New(CloneQemuTarget_Error_MutualExclusivity)
+	}
+	if target.Full != nil {
+		return target.Full.Validate()
+	}
+	return target.Linked.Validate()
+}
+
+func (target CloneLxcTarget) mapToAPI() (GuestID, NodeName, PoolName, map[string]interface{}) {
+	if target.Linked != nil {
+		return target.Linked.mapToAPI()
+	}
+	if target.Full != nil {
+		return target.Full.mapToAPI()
+	}
+	return 0, "", "", nil
+}
+
+type CloneQemuTarget struct {
+	Full   *CloneQemuFull
+	Linked *CloneLinked
+}
+
+const (
+	CloneQemuTarget_Error_MutualExclusivity = clone_Error_MutuallyExclusive
+	CloneQemuTarget_Error_NoneSet           = clone_Error_NoneSet
+)
+
+func (target CloneQemuTarget) Validate() error {
+	if target.Full == nil && target.Linked == nil {
+		return errors.New(CloneQemuTarget_Error_NoneSet)
+	}
+	if target.Full != nil && target.Linked != nil {
+		return errors.New(CloneQemuTarget_Error_MutualExclusivity)
+	}
+	if target.Full != nil {
+		return target.Full.Validate()
+	}
+	return target.Linked.Validate()
+}
+
+func (target CloneQemuTarget) mapToAPI() (GuestID, NodeName, PoolName, map[string]interface{}) {
+	if target.Linked != nil {
+		return target.Linked.mapToAPI()
+	}
+	if target.Full != nil {
+		return target.Full.mapToAPI()
+	}
+	return 0, "", "", nil
+}
+
+// Linked Clone in the same for both LXC and QEMU
+type CloneLinked struct {
+	Node NodeName
+	ID   *GuestID  // Optional
+	Name *string   // Optional // TODO replace one we have a type for it
+	Pool *PoolName // Optional
+}
+
+func (linked CloneLinked) Validate() (err error) {
+	if linked.ID != nil {
+		if err = linked.ID.Validate(); err != nil {
+			return
+		}
+	}
+	if linked.Pool != nil {
+		if err = linked.Pool.Validate(); err != nil {
+			return
+		}
+	}
+	return linked.Node.Validate()
+}
+
+func (linked CloneLinked) mapToAPI() (GuestID, NodeName, PoolName, map[string]interface{}) {
+	return cloneSettings{
+		FullClone: false,
+		ID:        linked.ID,
+		Name:      linked.Name,
+		Node:      linked.Node,
+		Pool:      linked.Pool}.mapToAPI()
+}
+
+type CloneLxcFull struct {
+	Node    NodeName
+	ID      *GuestID  // Optional
+	Name    *string   // Optional // TODO replace one we have a type for it
+	Pool    *PoolName // Optional
+	Storage *string   // Optional // TODO replace one we have a type for it
+}
+
+func (full CloneLxcFull) Validate() (err error) {
+	if full.ID != nil {
+		if err = full.ID.Validate(); err != nil {
+			return
+		}
+	}
+	if full.Pool != nil {
+		if err = full.Pool.Validate(); err != nil {
+			return
+		}
+	}
+	return full.Node.Validate()
+}
+
+func (full CloneLxcFull) mapToAPI() (GuestID, NodeName, PoolName, map[string]interface{}) {
+	return cloneSettings{
+		FullClone: true,
+		ID:        full.ID,
+		Name:      full.Name,
+		Node:      full.Node,
+		Pool:      full.Pool,
+		Storage:   full.Storage}.mapToAPI()
+}
+
+type CloneQemuFull struct {
+	Node          NodeName
+	ID            *GuestID        // Optional
+	Name          *string         // Optional // TODO replace one we have a type for it
+	Pool          *PoolName       // Optional
+	Storage       *string         // Optional // TODO replace one we have a type for it
+	StorageFormat *QemuDiskFormat // Optional
+}
+
+func (full CloneQemuFull) Validate() (err error) {
+	if full.ID != nil {
+		if err = full.ID.Validate(); err != nil {
+			return
+		}
+	}
+	if full.Pool != nil {
+		if err = full.Pool.Validate(); err != nil {
+			return
+		}
+	}
+	if full.StorageFormat != nil {
+		if err = full.StorageFormat.Validate(); err != nil {
+			return
+		}
+	}
+	return full.Node.Validate()
+}
+
+func (full CloneQemuFull) mapToAPI() (GuestID, NodeName, PoolName, map[string]interface{}) {
+	return cloneSettings{
+		FullClone:     true,
+		ID:            full.ID,
+		Name:          full.Name,
+		Node:          full.Node,
+		Pool:          full.Pool,
+		Storage:       full.Storage,
+		StorageFormat: full.StorageFormat}.mapToAPI()
+}
+
+type cloneSettings struct {
+	FullClone     bool
+	ID            *GuestID // Optional
+	Name          *string  // Optional // TODO replace one we have a type for it
+	Node          NodeName
+	Pool          *PoolName       // Optional
+	Storage       *string         // Optional // TODO replace one we have a type for it
+	StorageFormat *QemuDiskFormat // Optional
+}
+
+func (clone cloneSettings) mapToAPI() (GuestID, NodeName, PoolName, map[string]interface{}) {
+	params := map[string]interface{}{
+		"target": clone.Node.String(),
+		"full":   clone.FullClone,
+	}
+	var id GuestID
+	if clone.ID != nil {
+		id = *clone.ID
+		params["newid"] = int(id)
+	}
+	if clone.Name != nil {
+		params["name"] = *clone.Name
+	}
+	var pool PoolName
+	if clone.Pool != nil {
+		pool = *clone.Pool
+		params["pool"] = pool.String()
+	}
+	if clone.Storage != nil {
+		params["storage"] = *clone.Storage
+	}
+	if clone.StorageFormat != nil {
+		params["format"] = clone.StorageFormat.String()
+	}
+	return id, clone.Node, pool, params
+}

--- a/proxmox/vmref_test.go
+++ b/proxmox/vmref_test.go
@@ -1,0 +1,353 @@
+package proxmox
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Telmate/proxmox-api-go/internal/util"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_CloneLxcTarget_mapToAPI(t *testing.T) {
+	type testOutput struct {
+		id   GuestID
+		node NodeName
+		pool PoolName
+		api  map[string]interface{}
+	}
+	tests := []struct {
+		name   string
+		input  CloneLxcTarget
+		output testOutput
+	}{
+		{name: `nil`},
+		{name: `Full ID`,
+			input: CloneLxcTarget{Full: &CloneLxcFull{
+				ID: util.Pointer(GuestID(100))}},
+			output: testOutput{
+				id: 100,
+				api: map[string]interface{}{
+					"full":   true,
+					"target": "",
+					"newid":  100}}},
+		{name: `Full Name`,
+			input: CloneLxcTarget{Full: &CloneLxcFull{
+				Name: util.Pointer("test")}},
+			output: testOutput{
+				api: map[string]interface{}{
+					"full":   true,
+					"target": "",
+					"name":   "test"}}},
+		{name: `Full Node`,
+			input: CloneLxcTarget{Full: &CloneLxcFull{
+				Node: "test"}},
+			output: testOutput{
+				node: "test",
+				api: map[string]interface{}{
+					"full":   true,
+					"target": "test"}}},
+		{name: `Full Pool`,
+			input: CloneLxcTarget{Full: &CloneLxcFull{
+				Pool: util.Pointer(PoolName("test"))}},
+			output: testOutput{
+				pool: "test",
+				api: map[string]interface{}{
+					"full":   true,
+					"target": "",
+					"pool":   "test"}}},
+		{name: `Full Storage`,
+			input: CloneLxcTarget{Full: &CloneLxcFull{
+				Storage: util.Pointer("test")}},
+			output: testOutput{
+				api: map[string]interface{}{
+					"full":    true,
+					"target":  "",
+					"storage": "test"}}},
+		{name: `Linked ID`,
+			input: CloneLxcTarget{Linked: &CloneLinked{
+				ID: util.Pointer(GuestID(100))}},
+			output: testOutput{
+				id: 100,
+				api: map[string]interface{}{
+					"full":   false,
+					"target": "",
+					"newid":  100}}},
+		{name: `Linked Name`,
+			input: CloneLxcTarget{Linked: &CloneLinked{
+				Name: util.Pointer("test")}},
+			output: testOutput{
+				api: map[string]interface{}{
+					"full":   false,
+					"target": "",
+					"name":   "test"}}},
+		{name: `Linked Node`,
+			input: CloneLxcTarget{Linked: &CloneLinked{
+				Node: "test"}},
+			output: testOutput{
+				node: "test",
+				api: map[string]interface{}{
+					"full":   false,
+					"target": "test"}}},
+		{name: `Linked Pool`,
+			input: CloneLxcTarget{Linked: &CloneLinked{
+				Pool: util.Pointer(PoolName("test"))}},
+			output: testOutput{
+				pool: "test",
+				api: map[string]interface{}{
+					"full":   false,
+					"target": "",
+					"pool":   "test"}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			id, node, pool, api := test.input.mapToAPI()
+			require.Equal(t, test.output.id, id)
+			require.Equal(t, test.output.node, node)
+			require.Equal(t, test.output.pool, pool)
+			require.Equal(t, test.output.api, api)
+		})
+	}
+}
+
+func Test_CloneLxcTarget_Validate(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  CloneLxcTarget
+		output error
+	}{
+		{name: `Invalid errors.New(CloneLxcTarget_Error_MutualExclusivity)`,
+			input: CloneLxcTarget{
+				Full:   &CloneLxcFull{},
+				Linked: &CloneLinked{}},
+			output: errors.New(CloneLxcTarget_Error_MutualExclusivity)},
+		{name: `Invalid errors.New(CloneLxcTarget_Error_NoneSet)`,
+			input:  CloneLxcTarget{},
+			output: errors.New(CloneLxcTarget_Error_NoneSet)},
+		{name: `Invalid Full Node errors.New(NodeName_Error_Empty)`,
+			input:  CloneLxcTarget{Full: &CloneLxcFull{}},
+			output: errors.New(NodeName_Error_Empty)},
+		{name: `Invalid Full ID errors.New(GuestID_Error_Minimum)`,
+			input: CloneLxcTarget{Full: &CloneLxcFull{
+				ID: util.Pointer(GuestID(99))}},
+			output: errors.New(GuestID_Error_Minimum)},
+		{name: `Invalid Full Name`, // TODO this should be an error
+			input: CloneLxcTarget{Full: &CloneLxcFull{
+				Node: "test",
+				Name: util.Pointer("")}},
+			output: nil},
+		{name: `Invalid Full Pool errors.New(PoolName_Error_Empty)`,
+			input: CloneLxcTarget{Full: &CloneLxcFull{
+				Pool: util.Pointer(PoolName(""))}},
+			output: errors.New(PoolName_Error_Empty)},
+		{name: `Invalid Full Storage`, // TODO this should be an error
+			input: CloneLxcTarget{Full: &CloneLxcFull{
+				Node:    "test",
+				Storage: util.Pointer("")}},
+			output: nil},
+		{name: `Invalid Linked Node errors.New(NodeName_Error_Empty)`,
+			input:  CloneLxcTarget{Linked: &CloneLinked{}},
+			output: errors.New(NodeName_Error_Empty)},
+		{name: `Invalid Linked ID errors.New(GuestID_Error_Minimum)`,
+			input: CloneLxcTarget{Linked: &CloneLinked{
+				ID: util.Pointer(GuestID(99))}},
+			output: errors.New(GuestID_Error_Minimum)},
+		{name: `Invalid Linked Name`, // TODO this should be an error
+			input: CloneLxcTarget{Linked: &CloneLinked{
+				Node: "test",
+				Name: util.Pointer("")}},
+			output: nil},
+		{name: `Invalid Linked Pool errors.New(PoolName_Error_Empty)`,
+			input: CloneLxcTarget{Linked: &CloneLinked{
+				Pool: util.Pointer(PoolName(""))}},
+			output: errors.New(PoolName_Error_Empty)},
+		{name: `Valid Full`,
+			input: CloneLxcTarget{Full: &CloneLxcFull{
+				Node: "test"}}},
+		{name: `Valid Linked`,
+			input: CloneLxcTarget{Linked: &CloneLinked{
+				Node: "test"}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.output, test.input.Validate())
+		})
+	}
+}
+
+func Test_CloneQemuTarget_mapToAPI(t *testing.T) {
+	type testOutput struct {
+		id   GuestID
+		node NodeName
+		pool PoolName
+		api  map[string]interface{}
+	}
+	tests := []struct {
+		name   string
+		input  CloneQemuTarget
+		output testOutput
+	}{
+		{name: `nil`},
+		{name: `Full ID`,
+			input: CloneQemuTarget{Full: &CloneQemuFull{
+				ID: util.Pointer(GuestID(100))}},
+			output: testOutput{
+				id: 100,
+				api: map[string]interface{}{
+					"full":   true,
+					"target": "",
+					"newid":  100}}},
+		{name: `Full Name`,
+			input: CloneQemuTarget{Full: &CloneQemuFull{
+				Name: util.Pointer("test")}},
+			output: testOutput{
+				api: map[string]interface{}{
+					"full":   true,
+					"target": "",
+					"name":   "test"}}},
+		{name: `Full Node`,
+			input: CloneQemuTarget{Full: &CloneQemuFull{
+				Node: "test"}},
+			output: testOutput{
+				node: "test",
+				api: map[string]interface{}{
+					"full":   true,
+					"target": "test"}}},
+		{name: `Full Pool`,
+			input: CloneQemuTarget{Full: &CloneQemuFull{
+				Pool: util.Pointer(PoolName("test"))}},
+			output: testOutput{
+				pool: "test",
+				api: map[string]interface{}{
+					"full":   true,
+					"target": "",
+					"pool":   "test"}}},
+		{name: `Full Storage`,
+			input: CloneQemuTarget{Full: &CloneQemuFull{
+				Storage: util.Pointer("test")}},
+			output: testOutput{
+				api: map[string]interface{}{
+					"full":    true,
+					"target":  "",
+					"storage": "test"}}},
+		{name: `Full StorageFormat`,
+			input: CloneQemuTarget{Full: &CloneQemuFull{
+				StorageFormat: util.Pointer(QemuDiskFormat("test"))}},
+			output: testOutput{
+				api: map[string]interface{}{
+					"full":   true,
+					"target": "",
+					"format": "test"}}},
+		{name: `Linked ID`,
+			input: CloneQemuTarget{Linked: &CloneLinked{
+				ID: util.Pointer(GuestID(100))}},
+			output: testOutput{
+				id: 100,
+				api: map[string]interface{}{
+					"full":   false,
+					"target": "",
+					"newid":  100}}},
+		{name: `Linked Name`,
+			input: CloneQemuTarget{Linked: &CloneLinked{
+				Name: util.Pointer("test")}},
+			output: testOutput{
+				api: map[string]interface{}{
+					"full":   false,
+					"target": "",
+					"name":   "test"}}},
+		{name: `Linked Node`,
+			input: CloneQemuTarget{Linked: &CloneLinked{
+				Node: "test"}},
+			output: testOutput{
+				node: "test",
+				api: map[string]interface{}{
+					"full":   false,
+					"target": "test"}}},
+		{name: `Linked Pool`,
+			input: CloneQemuTarget{Linked: &CloneLinked{
+				Pool: util.Pointer(PoolName("test"))}},
+			output: testOutput{
+				pool: "test",
+				api: map[string]interface{}{
+					"full":   false,
+					"target": "",
+					"pool":   "test"}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			id, node, pool, api := test.input.mapToAPI()
+			require.Equal(t, test.output.id, id)
+			require.Equal(t, test.output.node, node)
+			require.Equal(t, test.output.pool, pool)
+			require.Equal(t, test.output.api, api)
+		})
+	}
+}
+
+func Test_CloneQemuTarget_Validate(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  CloneQemuTarget
+		output error
+	}{
+		{name: `Invalid errors.New(CloneQemuTarget_Error_MutualExclusivity)`,
+			input: CloneQemuTarget{
+				Full:   &CloneQemuFull{},
+				Linked: &CloneLinked{}},
+			output: errors.New(CloneQemuTarget_Error_MutualExclusivity)},
+		{name: `Invalid errors.New(CloneQemuTarget_Error_NoneSet)`,
+			input:  CloneQemuTarget{},
+			output: errors.New(CloneQemuTarget_Error_NoneSet)},
+		{name: `Invalid Full Node errors.New(NodeName_Error_Empty)`,
+			input:  CloneQemuTarget{Full: &CloneQemuFull{}},
+			output: errors.New(NodeName_Error_Empty)},
+		{name: `Invalid Full ID errors.New(GuestID_Error_Minimum)`,
+			input: CloneQemuTarget{Full: &CloneQemuFull{
+				ID: util.Pointer(GuestID(99))}},
+			output: errors.New(GuestID_Error_Minimum)},
+		{name: `Invalid Full Name`, // TODO this should be an error
+			input: CloneQemuTarget{Full: &CloneQemuFull{
+				Node: "test",
+				Name: util.Pointer("")}},
+			output: nil},
+		{name: `Invalid Full Pool errors.New(PoolName_Error_Empty)`,
+			input: CloneQemuTarget{Full: &CloneQemuFull{
+				Pool: util.Pointer(PoolName(""))}},
+			output: errors.New(PoolName_Error_Empty)},
+		{name: `Invalid Full Storage`, // TODO this should be an error
+			input: CloneQemuTarget{Full: &CloneQemuFull{
+				Node:    "test",
+				Storage: util.Pointer("")}},
+			output: nil},
+		{name: `Invalid Full StorageFormat`,
+			input: CloneQemuTarget{Full: &CloneQemuFull{
+				StorageFormat: util.Pointer(QemuDiskFormat(""))}},
+			output: QemuDiskFormat("").Error()},
+		{name: `Invalid Linked Node errors.New(NodeName_Error_Empty)`,
+			input:  CloneQemuTarget{Linked: &CloneLinked{}},
+			output: errors.New(NodeName_Error_Empty)},
+		{name: `Invalid Linked ID errors.New(GuestID_Error_Minimum)`,
+			input: CloneQemuTarget{Linked: &CloneLinked{
+				ID: util.Pointer(GuestID(99))}},
+			output: errors.New(GuestID_Error_Minimum)},
+		{name: `Invalid Linked Name`, // TODO this should be an error
+			input: CloneQemuTarget{Linked: &CloneLinked{
+				Node: "test",
+				Name: util.Pointer("")}},
+			output: nil},
+		{name: `Invalid Linked Pool errors.New(PoolName_Error_Empty)`,
+			input: CloneQemuTarget{Linked: &CloneLinked{
+				Pool: util.Pointer(PoolName(""))}},
+			output: errors.New(PoolName_Error_Empty)},
+		{name: `Valid Full`,
+			input: CloneQemuTarget{Full: &CloneQemuFull{
+				Node: "test"}}},
+		{name: `Valid Linked`,
+			input: CloneQemuTarget{Linked: &CloneLinked{
+				Node: "test"}}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.output, test.input.Validate())
+		})
+	}
+}

--- a/proxmox/vmref_test.go
+++ b/proxmox/vmref_test.go
@@ -35,9 +35,9 @@ func Test_CloneLxcTarget_mapToAPI(t *testing.T) {
 				Name: util.Pointer("test")}},
 			output: testOutput{
 				api: map[string]interface{}{
-					"full":   true,
-					"target": "",
-					"name":   "test"}}},
+					"full":     true,
+					"target":   "",
+					"hostname": "test"}}},
 		{name: `Full Node`,
 			input: CloneLxcTarget{Full: &CloneLxcFull{
 				Node: "test"}},
@@ -77,9 +77,9 @@ func Test_CloneLxcTarget_mapToAPI(t *testing.T) {
 				Name: util.Pointer("test")}},
 			output: testOutput{
 				api: map[string]interface{}{
-					"full":   false,
-					"target": "",
-					"name":   "test"}}},
+					"full":     false,
+					"target":   "",
+					"hostname": "test"}}},
 		{name: `Linked Node`,
 			input: CloneLxcTarget{Linked: &CloneLinked{
 				Node: "test"}},

--- a/test/api/CloudInit/cloudinit_test.go
+++ b/test/api/CloudInit/cloudinit_test.go
@@ -32,7 +32,7 @@ func Test_Cloud_Init_VM(t *testing.T) {
 	config.QemuDisks[0] = disk
 	config.Name = "Base-Image"
 
-	err = config.Create(context.Background(), vmref, Test.GetClient())
+	_, err = config.Create(context.Background(), Test.GetClient())
 	require.NoError(t, err)
 
 	config.Boot = "order=virtio0;ide2;net0"

--- a/test/api/Qemu/qemu_clone_test.go
+++ b/test/api/Qemu/qemu_clone_test.go
@@ -21,7 +21,7 @@ func Test_Clone_Qemu_VM(t *testing.T) {
 	_ = Test.CreateTest()
 	config := _create_vm_spec(false)
 
-	config.Create(context.Background(), _create_vmref(), Test.GetClient())
+	config.Create(context.Background(), Test.GetClient())
 
 	cloneConfig := _create_vm_spec(false)
 
@@ -41,7 +41,7 @@ func Test_Clone_Qemu_VM_To_Different_Storage(t *testing.T) {
 	_ = Test.CreateTest()
 	config := _create_vm_spec(false)
 
-	config.Create(context.Background(), _create_vmref(), Test.GetClient())
+	config.Create(context.Background(), Test.GetClient())
 
 	cloneConfig := _create_vm_spec(false)
 

--- a/test/api/Qemu/qemu_clone_test.go
+++ b/test/api/Qemu/qemu_clone_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/Telmate/proxmox-api-go/internal/util"
 	pxapi "github.com/Telmate/proxmox-api-go/proxmox"
 	api_test "github.com/Telmate/proxmox-api-go/test/api"
 	"github.com/stretchr/testify/require"
@@ -23,17 +24,17 @@ func Test_Clone_Qemu_VM(t *testing.T) {
 
 	config.Create(context.Background(), Test.GetClient())
 
-	cloneConfig := _create_vm_spec(false)
+	newGuest := _create_clone_vmref()
 
-	fullClone := 1
-
-	cloneConfig.Name = "test-qemu02"
-	cloneConfig.FullClone = &fullClone
-
-	err := cloneConfig.CloneVm(context.Background(), _create_vmref(), _create_clone_vmref(), Test.GetClient())
-
+	sourceVmRef := _create_vmref()
+	_, err := sourceVmRef.CloneQemu(context.Background(), pxapi.CloneQemuTarget{
+		Full: &pxapi.CloneQemuFull{
+			Node: newGuest.Node(),
+			Name: util.Pointer("test-qemu02"),
+			ID:   util.Pointer(newGuest.VmId()),
+		},
+	}, Test.GetClient())
 	require.NoError(t, err)
-
 }
 
 func Test_Clone_Qemu_VM_To_Different_Storage(t *testing.T) {
@@ -43,18 +44,18 @@ func Test_Clone_Qemu_VM_To_Different_Storage(t *testing.T) {
 
 	config.Create(context.Background(), Test.GetClient())
 
-	cloneConfig := _create_vm_spec(false)
+	newGuest := _create_clone_vmref()
 
-	fullClone := 1
-
-	cloneConfig.Name = "test-qemu02"
-	cloneConfig.FullClone = &fullClone
-	cloneConfig.Storage = "other-storage"
-
-	err := cloneConfig.CloneVm(context.Background(), _create_vmref(), _create_clone_vmref(), Test.GetClient())
-
+	sourceVmRef := _create_vmref()
+	_, err := sourceVmRef.CloneQemu(context.Background(), pxapi.CloneQemuTarget{
+		Full: &pxapi.CloneQemuFull{
+			Node:    newGuest.Node(),
+			Name:    util.Pointer("test-qemu02"),
+			ID:      util.Pointer(newGuest.VmId()),
+			Storage: util.Pointer("other-storage"),
+		},
+	}, Test.GetClient())
 	require.NoError(t, err)
-
 }
 
 func Test_Qemu_VM_Is_Cloned(t *testing.T) {

--- a/test/api/Qemu/qemu_create_update_delete_test.go
+++ b/test/api/Qemu/qemu_create_update_delete_test.go
@@ -14,7 +14,7 @@ func Test_Create_Qemu_VM(t *testing.T) {
 	_ = Test.CreateTest()
 	config := _create_vm_spec(true)
 
-	err := config.Create(context.Background(), _create_vmref(), Test.GetClient())
+	_, err := config.Create(context.Background(), Test.GetClient())
 	require.NoError(t, err)
 }
 

--- a/test/api/Qemu/qemu_start_test.go
+++ b/test/api/Qemu/qemu_start_test.go
@@ -13,7 +13,7 @@ func Test_Start_Stop_Qemu_VM_Setup(t *testing.T) {
 	_ = Test.CreateTest()
 
 	config := _create_vm_spec(false)
-	config.Create(context.Background(), _create_vmref(), Test.GetClient())
+	config.Create(context.Background(), Test.GetClient())
 }
 
 func Test_Start_Qemu_VM(t *testing.T) {


### PR DESCRIPTION
This pull request makes the `GuestID` optional during creation.
When no `GuestID` is provided we will ask for the next guest ID.
This bring the treading for the guest creation into the client class, ensuring a client instance can't create conflicts with itself.
If a `GuestID` conflict occurs due to the use of multiple systems creating guests in PVE, we will ask again for an available `GuestID` and try to create the guest again. This will happen until the guest is created or we run into some other error.

Due to the complexity of this change it was easier to re-implement the cloning logic for Lxc/Qemu then it was to retrofit the existing code. The old code didn't have test.

All deprecated code has been marked with the deprecation flag and instruction on migrating to the new functions.

Closes #382
