### PR TITLE
Feat: PCI Mdev support

### DIFF
--- a/proxmox/config_qemu_pcie.go
+++ b/proxmox/config_qemu_pcie.go
@@ -109,11 +109,7 @@ type QemuPci struct {
 	Raw     *QemuPciRaw     `json:"raw,omitempty"`
 }
 
-const (
-	QemuPci_Error_MutualExclusive string = "mapping and raw are mutually exclusive"
-	QemuPci_Error_MappedID        string = "mapped id is required during creation"
-	QemuPci_Error_RawID           string = "raw id is required during creation"
-)
+const QemuPci_Error_MutualExclusive string = "mapping and raw are mutually exclusive"
 
 func (config QemuPci) mapToAPI(current *QemuPci) string {
 	var usedConfig qemuPci
@@ -250,69 +246,20 @@ func (config QemuPci) Validate(current QemuPci) error {
 	if config.Delete {
 		return nil
 	}
-	var mutualExclusivity uint8
+	var mutualExclusivity bool
 	if config.Mapping != nil {
-		if config.Mapping.ID != nil {
-			if err := config.Mapping.ID.Validate(); err != nil {
-				return err
-			}
-		} else if current.Mapping == nil || current.Mapping.ID == nil {
-			return errors.New(QemuPci_Error_MappedID)
+		if err := config.Mapping.Validate(current.Mapping); err != nil {
+			return err
 		}
-		if config.Mapping.DeviceID != nil {
-			if err := config.Mapping.DeviceID.Validate(); err != nil {
-				return err
-			}
-		}
-		if config.Mapping.SubDeviceID != nil {
-			if err := config.Mapping.SubDeviceID.Validate(); err != nil {
-				return err
-			}
-		}
-		if config.Mapping.SubVendorID != nil {
-			if err := config.Mapping.SubVendorID.Validate(); err != nil {
-				return err
-			}
-		}
-		if config.Mapping.VendorID != nil {
-			if err := config.Mapping.VendorID.Validate(); err != nil {
-				return err
-			}
-		}
-		mutualExclusivity++
+		mutualExclusivity = true
 	}
 	if config.Raw != nil {
-		if config.Raw.ID != nil {
-			if err := config.Raw.ID.Validate(); err != nil {
-				return err
-			}
-		} else if current.Raw == nil || current.Raw.ID == nil {
-			return errors.New(QemuPci_Error_RawID)
+		if err := config.Raw.Validate(current.Raw); err != nil {
+			return err
 		}
-		if config.Raw.DeviceID != nil {
-			if err := config.Raw.DeviceID.Validate(); err != nil {
-				return err
-			}
+		if mutualExclusivity {
+			return errors.New(QemuPci_Error_MutualExclusive)
 		}
-		if config.Raw.SubDeviceID != nil {
-			if err := config.Raw.SubDeviceID.Validate(); err != nil {
-				return err
-			}
-		}
-		if config.Raw.SubVendorID != nil {
-			if err := config.Raw.SubVendorID.Validate(); err != nil {
-				return err
-			}
-		}
-		if config.Raw.VendorID != nil {
-			if err := config.Raw.VendorID.Validate(); err != nil {
-				return err
-			}
-		}
-		mutualExclusivity++
-	}
-	if mutualExclusivity > 1 {
-		return errors.New(QemuPci_Error_MutualExclusive)
 	}
 	return nil
 }
@@ -387,6 +334,39 @@ type QemuPciMapping struct {
 	VendorID    *PciVendorID          `json:"vendor_id,omitempty"`
 }
 
+const QemuPciMapping_Error_RequiredID string = "mapped id is required during creation"
+
+func (config QemuPciMapping) Validate(current *QemuPciMapping) error {
+	if config.ID != nil {
+		if err := config.ID.Validate(); err != nil {
+			return err
+		}
+	} else if current == nil || current.ID == nil {
+		return errors.New(QemuPciMapping_Error_RequiredID)
+	}
+	if config.DeviceID != nil {
+		if err := config.DeviceID.Validate(); err != nil {
+			return err
+		}
+	}
+	if config.SubDeviceID != nil {
+		if err := config.SubDeviceID.Validate(); err != nil {
+			return err
+		}
+	}
+	if config.SubVendorID != nil {
+		if err := config.SubVendorID.Validate(); err != nil {
+			return err
+		}
+	}
+	if config.VendorID != nil {
+		if err := config.VendorID.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 type QemuPciRaw struct {
 	DeviceID    *PciDeviceID    `json:"device_id,omitempty"`
 	ID          *PciID          `json:"id,omitempty"`
@@ -396,6 +376,39 @@ type QemuPciRaw struct {
 	SubDeviceID *PciSubDeviceID `json:"sub_device_id,omitempty"`
 	SubVendorID *PciSubVendorID `json:"sub_vendor_id,omitempty"`
 	VendorID    *PciVendorID    `json:"vendor_id,omitempty"`
+}
+
+const QemuPciRaw_Error_RequiredID string = "raw id is required during creation"
+
+func (config QemuPciRaw) Validate(current *QemuPciRaw) error {
+	if config.ID != nil {
+		if err := config.ID.Validate(); err != nil {
+			return err
+		}
+	} else if current == nil || current.ID == nil {
+		return errors.New(QemuPciRaw_Error_RequiredID)
+	}
+	if config.DeviceID != nil {
+		if err := config.DeviceID.Validate(); err != nil {
+			return err
+		}
+	}
+	if config.SubDeviceID != nil {
+		if err := config.SubDeviceID.Validate(); err != nil {
+			return err
+		}
+	}
+	if config.SubVendorID != nil {
+		if err := config.SubVendorID.Validate(); err != nil {
+			return err
+		}
+	}
+	if config.VendorID != nil {
+		if err := config.VendorID.Validate(); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Hexadecimal, range 0x0000-0xFFFF, prefixed is optional

--- a/proxmox/config_qemu_pcie_test.go
+++ b/proxmox/config_qemu_pcie_test.go
@@ -60,12 +60,12 @@ func Test_QemuPciDevices_Validate(t *testing.T) {
 					Raw: &QemuPciRaw{
 						ID: util.Pointer(PciID("0000:00:00"))}}}},
 			output: errors.New(QemuPci_Error_MutualExclusive)},
-		{name: `Invalid errors.New(QemuPci_Error_MappedID)`,
+		{name: `Invalid errors.New(QemuPciMapping_Error_RequiredID)`,
 			input: testInput{config: QemuPciDevices{
 				QemuPciID5: QemuPci{
 					Mapping: &QemuPciMapping{}}}},
 			output: errors.New(QemuPciMapping_Error_RequiredID)},
-		{name: `Invalid errors.New(QemuPci_Error_RawID)`,
+		{name: `Invalid errors.New(QemuPciRaw_Error_RequiredID)`,
 			input: testInput{config: QemuPciDevices{
 				QemuPciID6: QemuPci{
 					Raw: &QemuPciRaw{}}}},

--- a/proxmox/config_qemu_pcie_test.go
+++ b/proxmox/config_qemu_pcie_test.go
@@ -83,6 +83,13 @@ func Test_QemuPciDevices_Validate(t *testing.T) {
 						ID:       util.Pointer(ResourceMappingPciID("aaa")),
 						DeviceID: util.Pointer(PciDeviceID("a0%^#"))}}}},
 			output: errors.New(PciDeviceID_Error_Invalid)},
+		{name: `Invalid Mapping errors.New(PciMediatedDevice_Error_Invalid)`,
+			input: testInput{config: QemuPciDevices{
+				QemuPciID8: QemuPci{
+					Mapping: &QemuPciMapping{
+						ID:   util.Pointer(ResourceMappingPciID("aaa")),
+						MDev: util.Pointer(PciMediatedDevice("vendor,-643"))}}}},
+			output: errors.New(PciMediatedDevice_Error_Invalid)},
 		{name: `Invalid Mapping errors.New(PciSubDeviceID_Error_Invalid)`,
 			input: testInput{config: QemuPciDevices{
 				QemuPciID9: QemuPci{
@@ -116,6 +123,13 @@ func Test_QemuPciDevices_Validate(t *testing.T) {
 						ID:       util.Pointer(PciID("0000:00:00")),
 						DeviceID: util.Pointer(PciDeviceID("a0%^#"))}}}},
 			output: errors.New(PciDeviceID_Error_Invalid)},
+		{name: `Invalid Raw errors.New(PciMediatedDevice_Error_Invalid)`,
+			input: testInput{config: QemuPciDevices{
+				QemuPciID13: QemuPci{
+					Raw: &QemuPciRaw{
+						ID:   util.Pointer(PciID("0000:00:00")),
+						MDev: util.Pointer(PciMediatedDevice("vendor,-643"))}}}},
+			output: errors.New(PciMediatedDevice_Error_Invalid)},
 		{name: `Invalid Raw errors.New(PciSubDeviceID_Error_Invalid)`,
 			input: testInput{config: QemuPciDevices{
 				QemuPciID14: QemuPci{
@@ -312,6 +326,25 @@ func Test_PciDeviceID_Validate(t *testing.T) {
 		{name: `Invalid Maximum`,
 			input:  "0x1ffff",
 			output: errors.New(PciDeviceID_Error_Invalid)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.output, test.input.Validate())
+		})
+	}
+}
+
+func Test_PciMediatedDevice_Validate(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  PciMediatedDevice
+		output error
+	}{
+		{name: `Valid`,
+			input: "vendor-643"},
+		{name: `Invalid`,
+			input:  "vendor,-643",
+			output: errors.New(PciMediatedDevice_Error_Invalid)},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/proxmox/config_qemu_pcie_test.go
+++ b/proxmox/config_qemu_pcie_test.go
@@ -64,12 +64,12 @@ func Test_QemuPciDevices_Validate(t *testing.T) {
 			input: testInput{config: QemuPciDevices{
 				QemuPciID5: QemuPci{
 					Mapping: &QemuPciMapping{}}}},
-			output: errors.New(QemuPci_Error_MappedID)},
+			output: errors.New(QemuPciMapping_Error_RequiredID)},
 		{name: `Invalid errors.New(QemuPci_Error_RawID)`,
 			input: testInput{config: QemuPciDevices{
 				QemuPciID6: QemuPci{
 					Raw: &QemuPciRaw{}}}},
-			output: errors.New(QemuPci_Error_RawID)},
+			output: errors.New(QemuPciRaw_Error_RequiredID)},
 		{name: `Invalid errors.New(ResourceMappingPciID_Error_Invalid)`,
 			input: testInput{config: QemuPciDevices{
 				QemuPciID7: QemuPci{
@@ -201,11 +201,11 @@ func Test_QemuPci_Validate(t *testing.T) {
 		{name: `Invalid errors.New(QemuPci_Error_MappedID)`,
 			input: testInput{config: QemuPci{
 				Mapping: &QemuPciMapping{}}},
-			output: errors.New(QemuPci_Error_MappedID)},
+			output: errors.New(QemuPciMapping_Error_RequiredID)},
 		{name: `Invalid errors.New(QemuPci_Error_RawID)`,
 			input: testInput{config: QemuPci{
 				Raw: &QemuPciRaw{}}},
-			output: errors.New(QemuPci_Error_RawID)},
+			output: errors.New(QemuPciRaw_Error_RequiredID)},
 		{name: `Invalid errors.New(ResourceMappingPciID_Error_Invalid)`,
 			input: testInput{config: QemuPci{
 				Mapping: &QemuPciMapping{

--- a/proxmox/config_qemu_test.go
+++ b/proxmox/config_qemu_test.go
@@ -3721,6 +3721,14 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 						QemuPciID14: QemuPci{Mapping: &QemuPciMapping{
 							ID: util.Pointer(ResourceMappingPciID("bbbbb"))}}}},
 					output: map[string]interface{}{"hostpci14": "mapping=aaaaa,rombar=0"}},
+				{name: `MApping.MDev`,
+					config: &ConfigQemu{PciDevices: QemuPciDevices{
+						QemuPciID14: QemuPci{Mapping: &QemuPciMapping{
+							MDev: util.Pointer(PciMediatedDevice("vendor-665"))}}}},
+					currentConfig: ConfigQemu{PciDevices: QemuPciDevices{
+						QemuPciID14: QemuPci{Mapping: &QemuPciMapping{
+							MDev: util.Pointer(PciMediatedDevice(PciMediatedDevice("vendor-000")))}}}},
+					output: map[string]interface{}{"hostpci14": "mapping=,rombar=0,mdev=vendor-665"}},
 				{name: `Mapping.Pci`,
 					config: &ConfigQemu{PciDevices: QemuPciDevices{
 						QemuPciID13: QemuPci{Mapping: &QemuPciMapping{
@@ -3785,6 +3793,14 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 						QemuPciID1: QemuPci{Raw: &QemuPciRaw{
 							ID: util.Pointer(PciID("0000:00:00.1"))}}}},
 					output: map[string]interface{}{"hostpci1": "0000:00:00.0,rombar=0"}},
+				{name: `Raw.MDev`,
+					config: &ConfigQemu{PciDevices: QemuPciDevices{
+						QemuPciID2: QemuPci{Raw: &QemuPciRaw{
+							MDev: util.Pointer(PciMediatedDevice("vendor-665"))}}}},
+					currentConfig: ConfigQemu{PciDevices: QemuPciDevices{
+						QemuPciID2: QemuPci{Raw: &QemuPciRaw{
+							MDev: util.Pointer(PciMediatedDevice("vendor-000"))}}}},
+					output: map[string]interface{}{"hostpci2": ",rombar=0,mdev=vendor-665"}},
 				{name: `Raw.Pci`,
 					config: &ConfigQemu{PciDevices: QemuPciDevices{
 						QemuPciID2: QemuPci{Raw: &QemuPciRaw{
@@ -6743,12 +6759,13 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 		{category: `PciDevices`,
 			tests: []test{
 				{name: `Mapping all`,
-					input: map[string]interface{}{"hostpci0": "mapping=abc,device-id=0xa97f,pcie=1,x-vga=1,rombar=0,sub-device-id=0x61a4,sub-vendor-id=0x98f1,vendor-id=0x4003"},
+					input: map[string]interface{}{"hostpci0": "mapping=abc,device-id=0xa97f,pcie=1,x-vga=1,rombar=0,sub-device-id=0x61a4,sub-vendor-id=0x98f1,vendor-id=0x4003,mdev=vendor-test"},
 					output: baseConfig(ConfigQemu{PciDevices: QemuPciDevices{
 						QemuPciID0: QemuPci{
 							Mapping: &QemuPciMapping{
 								DeviceID:    util.Pointer(PciDeviceID("0xa97f")),
 								ID:          util.Pointer(ResourceMappingPciID("abc")),
+								MDev:        util.Pointer(PciMediatedDevice("vendor-test")),
 								PCIe:        util.Pointer(true),
 								PrimaryGPU:  util.Pointer(true),
 								ROMbar:      util.Pointer(false),
@@ -6771,6 +6788,16 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 						QemuPciID2: QemuPci{
 							Mapping: &QemuPciMapping{
 								ID:         util.Pointer(ResourceMappingPciID("xyz")),
+								PCIe:       util.Pointer(false),
+								PrimaryGPU: util.Pointer(false),
+								ROMbar:     util.Pointer(true)}}}})},
+				{name: `Mapping.MDev`,
+					input: map[string]interface{}{"hostpci3": "mapping=abc,mdev=test"},
+					output: baseConfig(ConfigQemu{PciDevices: QemuPciDevices{
+						QemuPciID3: QemuPci{
+							Mapping: &QemuPciMapping{
+								ID:         util.Pointer(ResourceMappingPciID("abc")),
+								MDev:       util.Pointer(PciMediatedDevice("test")),
 								PCIe:       util.Pointer(false),
 								PrimaryGPU: util.Pointer(false),
 								ROMbar:     util.Pointer(true)}}}})},
@@ -6832,12 +6859,13 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 								ROMbar:     util.Pointer(true),
 								VendorID:   util.Pointer(PciVendorID("0x4003"))}}}})},
 				{name: `Raw all`,
-					input: map[string]interface{}{"hostpci15": "0000:02:05.7,device-id=0xa97f,pcie=1,x-vga=1,rombar=0,sub-device-id=0x61a4,sub-vendor-id=0x98f1,vendor-id=0x4003"},
+					input: map[string]interface{}{"hostpci15": "0000:02:05.7,device-id=0xa97f,pcie=1,x-vga=1,rombar=0,sub-device-id=0x61a4,sub-vendor-id=0x98f1,vendor-id=0x4003,mdev=vendor-test"},
 					output: baseConfig(ConfigQemu{PciDevices: QemuPciDevices{
 						QemuPciID15: QemuPci{
 							Raw: &QemuPciRaw{
 								DeviceID:    util.Pointer(PciDeviceID("0xa97f")),
 								ID:          util.Pointer(PciID("0000:02:05.7")),
+								MDev:        util.Pointer(PciMediatedDevice("vendor-test")),
 								PCIe:        util.Pointer(true),
 								PrimaryGPU:  util.Pointer(true),
 								ROMbar:      util.Pointer(false),
@@ -6860,6 +6888,16 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 						QemuPciID13: QemuPci{
 							Raw: &QemuPciRaw{
 								ID:         util.Pointer(PciID("0001:43:86.5")),
+								PCIe:       util.Pointer(false),
+								PrimaryGPU: util.Pointer(false),
+								ROMbar:     util.Pointer(true)}}}})},
+				{name: `Raw.MDev`,
+					input: map[string]interface{}{"hostpci12": "0000:02:05.7,mdev=test"},
+					output: baseConfig(ConfigQemu{PciDevices: QemuPciDevices{
+						QemuPciID12: QemuPci{
+							Raw: &QemuPciRaw{
+								ID:         util.Pointer(PciID("0000:02:05.7")),
+								MDev:       util.Pointer(PciMediatedDevice("test")),
 								PCIe:       util.Pointer(false),
 								PrimaryGPU: util.Pointer(false),
 								ROMbar:     util.Pointer(true)}}}})},

--- a/proxmox/config_qemu_test.go
+++ b/proxmox/config_qemu_test.go
@@ -8751,13 +8751,13 @@ func Test_ConfigQemu_Validate(t *testing.T) {
 							QemuPciID11: QemuPci{
 								Mapping: &QemuPciMapping{}}}}),
 						current: &ConfigQemu{PciDevices: QemuPciDevices{QemuPciID11: QemuPci{}}},
-						err:     errors.New(QemuPci_Error_MappedID)},
+						err:     errors.New(QemuPciMapping_Error_RequiredID)},
 					{name: `errors.New(QemuPci_Error_RawID)`,
 						input: baseConfig(ConfigQemu{PciDevices: QemuPciDevices{
 							QemuPciID10: QemuPci{
 								Raw: &QemuPciRaw{}}}}),
 						current: &ConfigQemu{PciDevices: QemuPciDevices{QemuPciID10: QemuPci{}}},
-						err:     errors.New(QemuPci_Error_RawID)},
+						err:     errors.New(QemuPciRaw_Error_RequiredID)},
 					{name: `errors.New(ResourceMappingPciID_Error_Invalid`,
 						input: baseConfig(ConfigQemu{PciDevices: QemuPciDevices{
 							QemuPciID9: QemuPci{


### PR DESCRIPTION
Added missing `Validate()` func for `QemuPciMapping` and `QemuPciRaw`.
Added `mdev` property to PCI code.

Closes #401 