### PR TITLE
Fix: Qemu guest migration

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -771,6 +771,7 @@ func (c *Client) SetLxcConfig(ctx context.Context, vmr *VmRef, vmParams map[stri
 }
 
 // MigrateNode - Migrate a VM
+// Deprecated: use VmRef.Migrate() instead
 func (c *Client) MigrateNode(ctx context.Context, vmr *VmRef, newTargetNode NodeName, online bool) (exitStatus interface{}, err error) {
 	reqbody := ParamsToBody(map[string]interface{}{"target": newTargetNode, "online": online, "with-local-disks": true})
 	url := fmt.Sprintf("/nodes/%s/%s/%d/migrate", vmr.node.String(), vmr.vmType, vmr.vmId)

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -41,8 +41,25 @@ type Client struct {
 }
 
 const (
-	Client_Error_Nil string = "client may not be nil"
+	Client_Error_Nil            string = "client may not be nil"
+	Client_Error_NotInitialized string = "client not initialized"
 )
+
+// Checks if the client is initialized and returns an error if not
+func (c *Client) checkInitialized() error {
+	if c == nil {
+		return errors.New(Client_Error_Nil)
+	}
+	if c.session == nil {
+		return errors.New(Client_Error_NotInitialized)
+	}
+	return nil
+}
+
+// provides a fake client to bypass *Client.checkInitialized() during testing
+func fakeClient() *Client {
+	return &Client{session: &Session{}}
+}
 
 const (
 	VmRef_Error_Nil string = "vm reference may not be nil"

--- a/proxmox/client_test.go
+++ b/proxmox/client_test.go
@@ -8,6 +8,27 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func Test_Client_checkInitialized(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  *Client
+		output error
+	}{
+		{name: `nil`,
+			output: errors.New(Client_Error_Nil)},
+		{name: `session nil`,
+			input:  &Client{},
+			output: errors.New(Client_Error_NotInitialized)},
+		{name: `Bypass checkInitialized`,
+			input: fakeClient()},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.output, test.input.checkInitialized())
+		})
+	}
+}
+
 func Test_Client_CheckPermissions(t *testing.T) {
 	type input struct {
 		client *Client

--- a/proxmox/vmref.go
+++ b/proxmox/vmref.go
@@ -94,6 +94,9 @@ func (vmr *VmRef) Migrate(ctx context.Context, c *Client, newNode NodeName, Live
 	if vmr == nil {
 		return errors.New(VmRef_Error_Nil)
 	}
+	if err := c.checkInitialized(); err != nil {
+		return err
+	}
 	if err := newNode.Validate(); err != nil {
 		return err
 	}
@@ -103,6 +106,9 @@ func (vmr *VmRef) Migrate(ctx context.Context, c *Client, newNode NodeName, Live
 func (vmr *VmRef) MigrateNoCheck(ctx context.Context, c *Client, newNode NodeName, LiveMigrate bool) error {
 	if vmr == nil {
 		return errors.New(VmRef_Error_Nil)
+	}
+	if err := c.checkInitialized(); err != nil {
+		return err
 	}
 	return vmr.migrate_Unsafe(ctx, c, newNode, LiveMigrate)
 }

--- a/proxmox/vmref.go
+++ b/proxmox/vmref.go
@@ -90,6 +90,35 @@ func (vmr *VmRef) cloneQemu_Unsafe(ctx context.Context, settings CloneQemuTarget
 		vmType: vmRefQemu}, nil
 }
 
+func (vmr *VmRef) Migrate(ctx context.Context, c *Client, newNode NodeName, LiveMigrate bool) error {
+	if vmr == nil {
+		return errors.New(VmRef_Error_Nil)
+	}
+	if err := newNode.Validate(); err != nil {
+		return err
+	}
+	return vmr.migrate_Unsafe(ctx, c, newNode, LiveMigrate)
+}
+
+func (vmr *VmRef) MigrateNoCheck(ctx context.Context, c *Client, newNode NodeName, LiveMigrate bool) error {
+	if vmr == nil {
+		return errors.New(VmRef_Error_Nil)
+	}
+	return vmr.migrate_Unsafe(ctx, c, newNode, LiveMigrate)
+}
+
+func (vmr *VmRef) migrate_Unsafe(ctx context.Context, c *Client, newNode NodeName, LiveMigrate bool) error {
+	params := map[string]interface{}{
+		"target":           newNode.String(),
+		"with-local-disks": 1,
+	}
+	if LiveMigrate {
+		params["online"] = 1
+	}
+	_, err := c.PostWithTask(ctx, params, "/nodes/"+vmr.node.String()+"/"+vmr.vmType+"/"+vmr.vmId.String()+"/migrate")
+	return err
+}
+
 const (
 	cloneLxcFlagName  string = "hostname"
 	cloneQemuFlagName string = "name"

--- a/proxmox/vmref_test.go
+++ b/proxmox/vmref_test.go
@@ -1,6 +1,7 @@
 package proxmox
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -348,6 +349,68 @@ func Test_CloneQemuTarget_Validate(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			require.Equal(t, test.output, test.input.Validate())
+		})
+	}
+}
+
+func Test_VmRef_Migrate(t *testing.T) {
+	type testInput struct {
+		c   *Client
+		ctx context.Context
+		vmr *VmRef
+	}
+	tests := []struct {
+		name  string
+		input testInput
+	}{
+		{name: `Client nil`,
+			input: testInput{
+				ctx: context.Background(),
+				vmr: &VmRef{}}},
+		{name: `Context nil`,
+			input: testInput{
+				c:   fakeClient(),
+				vmr: &VmRef{}}},
+		{name: `VmRef nil`,
+			input: testInput{
+				c:   fakeClient(),
+				ctx: context.Background()}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.NotPanics(t, func() { test.input.vmr.Migrate(test.input.ctx, test.input.c, "valid", false) })
+			require.Error(t, test.input.vmr.Migrate(test.input.ctx, test.input.c, "valid", false))
+		})
+	}
+}
+
+func Test_VmRef_MigrateNoCheck(t *testing.T) {
+	type testInput struct {
+		c   *Client
+		ctx context.Context
+		vmr *VmRef
+	}
+	tests := []struct {
+		name  string
+		input testInput
+	}{
+		{name: `Client nil`,
+			input: testInput{
+				ctx: context.Background(),
+				vmr: &VmRef{}}},
+		{name: `Context nil`,
+			input: testInput{
+				c:   fakeClient(),
+				vmr: &VmRef{}}},
+		{name: `VmRef nil`,
+			input: testInput{
+				c:   fakeClient(),
+				ctx: context.Background()}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.NotPanics(t, func() { test.input.vmr.MigrateNoCheck(test.input.ctx, test.input.c, "valid", false) })
+			require.Error(t, test.input.vmr.MigrateNoCheck(test.input.ctx, test.input.c, "valid", false))
 		})
 	}
 }


### PR DESCRIPTION
Fixes the bug related to Qemu guest migration.

Deprecated: `*Client.MigrateNode()` to reduce code complexity.
Add: `*VmRef.Migrate()` this version has more validation.
Created: `*Client.checkInitialized()` to help with testing for `nil`,

Closes #403
