### PR TITLE
Async Task Interface for long running functions

### DIFF
--- a/cli/command/content/iso/download.go
+++ b/cli/command/content/iso/download.go
@@ -24,8 +24,11 @@ var iso_downloadCmd = &cobra.Command{
 		if err != nil {
 			return
 		}
-		err = proxmox.DownloadIsoFromUrl(cli.Context(), c, config)
+		task, err := proxmox.DownloadIsoFromUrl(cli.Context(), c, config)
 		if err != nil {
+			return
+		}
+		if err = task.WaitForCompletion(); err != nil {
 			return
 		}
 		cli.PrintItemCreated(isoCmd.OutOrStdout(), config.Filename, "ISO file")

--- a/cli/command/content/template/download.go
+++ b/cli/command/content/template/download.go
@@ -21,8 +21,11 @@ var template_downloadCmd = &cobra.Command{
 		if err != nil {
 			return
 		}
-		err = proxmox.DownloadLxcTemplate(cli.Context(), c, config)
+		task, err := proxmox.DownloadLxcTemplate(cli.Context(), c, config)
 		if err != nil {
+			return
+		}
+		if err = task.WaitForCompletion(); err != nil {
 			return
 		}
 		cli.PrintItemCreated(templateCmd.OutOrStdout(), config.Template, "LXC Template")

--- a/cli/command/create/create-snapshot.go
+++ b/cli/command/create/create-snapshot.go
@@ -29,8 +29,11 @@ var (
 			if err != nil {
 				return
 			}
-			err = config.Create(cli.Context(), client, vmr)
+			task, err := config.Create(cli.Context(), client, vmr)
 			if err != nil {
+				return
+			}
+			if err = task.WaitForCompletion(); err != nil {
 				return
 			}
 			cli.PrintItemCreated(CreateCmd.OutOrStdout(), snapName, "Snapshot")

--- a/cli/command/delete/delete-file.go
+++ b/cli/command/delete/delete-file.go
@@ -16,12 +16,15 @@ var delete_fileCmd = &cobra.Command{
 		if Type.Validate() != nil {
 			return
 		}
-		err = proxmox.DeleteFile(cli.Context(), c, args[0], proxmox.Content_File{
+		task, err := proxmox.DeleteFile(cli.Context(), c, args[0], proxmox.Content_File{
 			Storage:     args[1],
 			ContentType: Type,
 			FilePath:    args[3],
 		})
 		if err != nil {
+			return
+		}
+		if err = task.WaitForCompletion(); err != nil {
 			return
 		}
 		cli.PrintItemDeleted(deleteCmd.OutOrStdout(), args[3], "File")

--- a/cli/command/delete/delete.go
+++ b/cli/command/delete/delete.go
@@ -22,9 +22,14 @@ func deleteID(ctx context.Context, args []string, IDtype string) (err error) {
 	var exitStatus string
 	id := cli.RequiredIDset(args, 0, IDtype+"ID")
 	c := cli.NewClient()
+	var task proxmox.Task
 	switch IDtype {
 	case "AcmeAccount":
-		exitStatus, err = c.DeleteAcmeAccount(ctx, id)
+		task, err = c.DeleteAcmeAccount(ctx, id)
+		if err != nil {
+			return
+		}
+		err = task.WaitForCompletion()
 	case "Group":
 		err = proxmox.GroupName(id).Delete(ctx, c)
 	case "MetricServer":

--- a/internal/atomicerror/atomicerror.go
+++ b/internal/atomicerror/atomicerror.go
@@ -1,0 +1,33 @@
+package atomicerror
+
+import (
+	"sync"
+)
+
+// AtomicError is a structure that allows for safe error handling in concurrent environments.
+type AtomicError struct {
+	once  sync.Once
+	mutex sync.RWMutex
+	value error
+}
+
+// New initializes and returns a new AtomicError.
+func New() *AtomicError {
+	return &AtomicError{}
+}
+
+// Set sets the error value of the AtomicError.
+func (ae *AtomicError) Set(err error) {
+	ae.once.Do(func() {
+		ae.mutex.Lock()
+		ae.value = err
+		ae.mutex.Unlock()
+	})
+}
+
+// Get returns the error value of the AtomicError.
+func (ae *AtomicError) Get() error {
+	ae.mutex.RLock()
+	defer ae.mutex.RUnlock()
+	return ae.value
+}

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -1,0 +1,28 @@
+package notify
+
+import "sync"
+
+// Channel is a structure that mimics a context for cancellation.
+type Channel struct {
+	doneCh chan struct{}
+	once   sync.Once
+}
+
+// New initializes and returns a new Channel.
+func New() *Channel {
+	return &Channel{
+		doneCh: make(chan struct{}),
+	}
+}
+
+// Done returns a channel that gets closed when Close() is called.
+func (c *Channel) Done() <-chan struct{} {
+	return c.doneCh
+}
+
+// Close safely closes the channel, ensuring it is closed only once.
+func (c *Channel) Close() {
+	c.once.Do(func() {
+		close(c.doneCh)
+	})
+}

--- a/main.go
+++ b/main.go
@@ -299,8 +299,9 @@ func main() {
 			}
 		}
 
-		vmr, err := sourceVmr.CloneQemu(ctx, *config, c)
+		vmr, task, err := sourceVmr.CloneQemu(ctx, *config, c)
 		failError(err)
+		failError(task.WaitForCompletion())
 		log.Println("Created guest with ID: " + vmr.VmId().String())
 
 	case "createQemuSnapshot":

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -38,6 +38,11 @@ type Client struct {
 	version            *Version
 	versionMutex       sync.Mutex
 	guestCreationMutex sync.Mutex
+	Features           *FeatureFlags
+}
+
+type FeatureFlags struct {
+	AsyncTask bool
 }
 
 type clientInterface interface {

--- a/proxmox/content.go
+++ b/proxmox/content.go
@@ -129,13 +129,13 @@ func createFilesList(fileList []interface{}) *[]Content_FileProperties {
 }
 
 // Deletes te specified file from the specified storage.
-func DeleteFile(ctx context.Context, client *Client, node string, content Content_File) (err error) {
+func DeleteFile(ctx context.Context, client *Client, node string, content Content_File) (Task, error) {
+	var err error
 	content.ContentType, err = content.ContentType.toApiValueAndValidate()
 	if err != nil {
-		return
+		return nil, err
 	}
-	_, err = client.DeleteWithTask(ctx, "/nodes/"+node+"/storage/"+content.Storage+"/content"+content.format())
-	return
+	return client.deleteWithTask(ctx, "/nodes/"+node+"/storage/"+content.Storage+"/content"+content.format())
 }
 
 // List all files of the given type in the the specified storage

--- a/proxmox/content_iso.go
+++ b/proxmox/content_iso.go
@@ -48,10 +48,10 @@ func (content ConfigContent_Iso) Validate() (err error) {
 
 // Download an Iso file from a given URL.
 // https://pve.proxmox.com/pve-docs/api-viewer/#/nodes/{node}/storage/{storage}/download-url
-func DownloadIsoFromUrl(ctx context.Context, client *Client, content ConfigContent_Iso) (err error) {
-	_, err = client.PostWithTask(ctx, content.mapToApiValues(), "/nodes/"+content.Node+"/storage/"+content.Storage+"/download-url")
+func DownloadIsoFromUrl(ctx context.Context, client *Client, content ConfigContent_Iso) (Task, error) {
+	task, err := client.postWithTask(ctx, content.mapToApiValues(), "/nodes/"+content.Node+"/storage/"+content.Storage+"/download-url")
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return nil
+	return task, nil
 }

--- a/proxmox/content_template.go
+++ b/proxmox/content_template.go
@@ -107,9 +107,8 @@ func createTemplateList(templateList []interface{}) *[]TemplateItem {
 }
 
 // Download an LXC template.
-func DownloadLxcTemplate(ctx context.Context, client *Client, content ConfigContent_Template) (err error) {
-	_, err = client.PostWithTask(ctx, content.mapToApiValues(), "/nodes/"+content.Node+"/aplinfo")
-	return
+func DownloadLxcTemplate(ctx context.Context, client *Client, content ConfigContent_Template) (Task, error) {
+	return client.postWithTask(ctx, content.mapToApiValues(), "/nodes/"+content.Node+"/aplinfo")
 }
 
 // List all LXC templates available for download.

--- a/proxmox/task.go
+++ b/proxmox/task.go
@@ -1,0 +1,461 @@
+package proxmox
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	atomicError "github.com/Telmate/proxmox-api-go/internal/atomicerror"
+	"github.com/Telmate/proxmox-api-go/internal/notify"
+)
+
+func (c *Client) taskResponse(ctx context.Context, resp *http.Response) (Task, error) {
+	var jbody map[string]interface{}
+	var err error
+	if err = decodeResponse(resp, &jbody); err != nil {
+		return &task{}, err
+	}
+	if v, isSet := jbody["errors"]; isSet {
+		errJSON, _ := json.MarshalIndent(v, "", "  ")
+		return &task{}, fmt.Errorf("error: %s", errJSON)
+	}
+	if v, isSet := jbody["data"]; isSet && v != nil {
+		return newTask(ctx, &client{c: c}, v.(string), taskPollingInterval), nil
+	}
+	return &task{}, nil
+}
+
+const (
+	logChunkSize        uint   = 510
+	logChunkSizeString  string = "510"
+	taskPollingInterval        = 1 * time.Second
+)
+
+type Task interface {
+	// The context that was inherited from the original API call.
+	// To cancel the task, cancel the context.
+	// You can also cancel the task by calling the Cancel() method.
+
+	// Cancels the task.
+	Cancel() error
+
+	// Returns true if the task has ended, and an error if an error occurred.
+	Ended() (bool, error)
+
+	// Returns the time the task ended. If the task has not ended, the zero time is returned.
+	EndTime() time.Time
+
+	// Returns the exit status of the task. If the task has not ended, an empty string is returned.
+	ExitStatus() string
+
+	// Returns the ID of the task.
+	ID() string
+
+	// Returns the current log of the task.
+	Log() []string
+
+	// Inputs the log into the provided channel.
+	LogStream(log chan<- string) error
+
+	// Returns the node the task was executed on.
+	Node() string
+
+	// Returns the operation type of the task.
+	OperationType() string
+
+	// Returns the process ID of the task.
+	ProcessID() uint
+
+	// Returns the time the task started.
+	// If the task has not started, the zero time is returned.
+	StartTime() time.Time
+
+	// Returns the status of the task.
+	Status() string
+
+	// Returns the user that started the task.
+	User() UserID
+
+	// Blocks until the task is completed, or returned an error.
+	WaitForCompletion() error
+}
+
+type task struct {
+	id            string
+	node          string
+	operationType string
+	status        map[string]interface{}
+	statusMutex   sync.Mutex
+	user          UserID
+	client        clientInterface
+
+	pollingInterval time.Duration
+
+	// ctx is the context that is inherited from the original api call.
+	ctx context.Context
+
+	logCache sync.Map
+
+	// This channel is open by default and closed when the task ends.
+	closingCh *notify.Channel
+
+	// While statusCh is open, the status ha not been fetched yet.
+	statusCh *notify.Channel
+
+	// While logCh is open, the log has not been fetched yet.
+	logCh *notify.Channel
+
+	// err is the error that is stored when an error occurs in the status loop.
+	err atomicError.AtomicError
+
+	fetchLog   sync.Once
+	cancelTask sync.Mutex
+}
+
+const (
+	taskApiKeyEndTime    = "endtime"
+	taskApiKeyExitStatus = "exitstatus"
+	taskApiKeyProcessID  = "pid"
+	taskApiKeyStartTime  = "starttime"
+	taskApiKeyStatus     = "status"
+)
+
+func (t *task) Cancel() error {
+	if t.id == "" {
+		return nil
+	}
+	return t.cancel(nil)
+}
+
+func (t *task) Ended() (bool, error) {
+	if t.id == "" {
+		return true, nil
+	}
+	<-t.statusCh.Done()
+	return t.ended()
+}
+
+func (t *task) EndTime() time.Time {
+	if t.id == "" {
+		return time.Time{}
+	}
+	<-t.statusCh.Done()
+	t.statusMutex.Lock()
+	defer t.statusMutex.Unlock()
+	if v, isSet := t.status[taskApiKeyEndTime]; isSet {
+		return time.Unix(int64(v.(float64)), 0)
+	}
+	return time.Time{}
+}
+
+func (t *task) ExitStatus() string {
+	if t.id == "" {
+		return ""
+	}
+	<-t.statusCh.Done()
+	t.statusMutex.Lock()
+	defer t.statusMutex.Unlock()
+	if v, isSet := t.status[taskApiKeyExitStatus]; isSet {
+		return v.(string)
+	}
+	return ""
+}
+
+func (t *task) ID() string {
+	return t.id
+}
+
+func (t *task) Log() []string {
+	if t.id == "" {
+		return nil
+	}
+	t.startLogFetcher()
+	localLog := make(map[int]string)
+	<-t.closingCh.Done()
+	t.logCache.Range(func(key, value interface{}) bool {
+		localLog[key.(int)] = value.(string)
+		return true // continue iteration
+	})
+	logArray := make([]string, len(localLog))
+	for i := int(0); i < int(len(localLog)); i++ {
+		logArray[i] = localLog[i]
+	}
+	return logArray
+}
+
+func (t *task) LogStream(out chan<- string) error {
+	if t.id == "" {
+		return nil
+	}
+	t.startLogFetcher()
+	var index uint
+	var v interface{}
+	var ok bool
+	for {
+		select {
+		case <-t.closingCh.Done():
+			return t.err.Get()
+		default:
+			v, ok = t.logCache.Load(index)
+			if !ok {
+				time.Sleep(t.pollingInterval)
+				continue
+			}
+			out <- v.(string)
+			index++
+		}
+	}
+}
+
+func (t *task) Node() string {
+	return t.node
+}
+
+func (t *task) OperationType() string {
+	return t.operationType
+}
+
+func (t *task) ProcessID() uint {
+	if t.id == "" {
+		return 0
+	}
+	<-t.statusCh.Done()
+	t.statusMutex.Lock()
+	defer t.statusMutex.Unlock()
+	if v, isSet := t.status[taskApiKeyProcessID]; isSet {
+		return uint(v.(float64))
+	}
+	return 0
+}
+
+func (t *task) StartTime() time.Time {
+	if t.id == "" {
+		return time.Time{}
+	}
+	<-t.statusCh.Done()
+	t.statusMutex.Lock()
+	defer t.statusMutex.Unlock()
+	if v, isSet := t.status[taskApiKeyStartTime]; isSet {
+		return time.Unix(int64(v.(float64)), 0)
+	}
+	return time.Time{}
+}
+
+func (t *task) Status() string {
+	if t.id == "" {
+		return ""
+	}
+	<-t.statusCh.Done()
+	t.statusMutex.Lock()
+	defer t.statusMutex.Unlock()
+	if v, isSet := t.status[taskApiKeyStatus]; isSet {
+		return v.(string)
+	}
+	return ""
+}
+
+func (t *task) User() UserID {
+	return t.user
+}
+
+func (t *task) WaitForCompletion() (err error) {
+	if t.id == "" { // if we didn't get a task ID, the function that instantiated the task should be changed to not return a task.
+		return nil
+	}
+	// t.startStatusFetcher()
+	var ended bool
+	for {
+		ended, err = t.ended()
+		if err != nil {
+			return err
+		}
+		if ended {
+			return nil
+		}
+		time.Sleep(t.pollingInterval)
+	}
+}
+
+func newTask(ctx context.Context, c clientInterface, upID string, pollingInterval time.Duration) *task {
+	t := &task{
+		client:          c,
+		closingCh:       notify.New(),
+		ctx:             ctx,
+		logCh:           notify.New(),
+		pollingInterval: pollingInterval,
+		statusCh:        notify.New()}
+	t.mapToSDK_Unsafe(upID)
+	go func() { // Wait for the context to be canceled, so it can cancel the task.
+		select {
+		case <-t.ctx.Done():
+			_ = t.cancel(t.ctx.Err())
+			return
+		case <-t.closingCh.Done():
+			return
+		}
+	}()
+	go func() { // Start the status fetcher, which periodically fetches the status from the API and stores it in the status field.
+		var err error
+		var gotFirstStatus bool
+		for {
+			var params map[string]interface{}
+			params, err = t.client.getItemConfig(t.ctx, "/nodes/"+t.node+"/tasks/"+t.id+"/status", "", "", nil)
+			if err != nil {
+				t.setError(err)
+				return
+			}
+			status := params["data"].(map[string]interface{})
+			t.statusMutex.Lock()
+			t.status = status
+			t.statusMutex.Unlock()
+			if !gotFirstStatus { // Close the channel to indicate that the status has been fetched for the first time.
+				t.statusCh.Close()
+				gotFirstStatus = true
+			}
+			if v, isSet := status[taskApiKeyExitStatus]; isSet {
+				exitStatus := v.(string)
+				if !strings.HasPrefix(exitStatus, "OK") && !strings.HasPrefix(exitStatus, "WARNINGS") {
+					t.setError(errors.New(exitStatus))
+					return
+				}
+				t.closingCh.Close()
+				return
+			}
+			select {
+			case <-t.closingCh.Done():
+				return
+			case <-time.After(t.pollingInterval):
+			}
+		}
+	}()
+	return t
+}
+
+// Cancels the task and closes the control channel.
+func (t *task) cancel(previousErr error) (err error) {
+	t.cancelTask.Lock()
+	defer t.cancelTask.Unlock()
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	err = t.client.delete(ctx, "/nodes/"+t.node+"/tasks/"+t.id)
+	if err != nil {
+		if previousErr != nil {
+			err = fmt.Errorf("%s: %w", previousErr, err)
+		}
+		t.setError(err)
+		return
+	}
+	t.closingCh.Close()
+	t.logCh.Close()
+	t.statusCh.Close()
+	return
+}
+
+// Returns true if the task has ended, and an error if an error occurred.
+func (t *task) ended() (bool, error) {
+	select {
+	case <-t.closingCh.Done():
+		return true, t.err.Get()
+	default:
+		return false, nil
+	}
+}
+
+// Set the error and close the control channel.
+// Also closes the status and log channels to prevent blocking when users try to get data from the task.
+func (t *task) setError(err error) {
+	t.err.Set(err)
+	// Close the channel to stop the goroutines.
+	t.closingCh.Close()
+	// Close the channels to prevent blocking when users try to get data from task.
+	t.logCh.Close()
+	t.statusCh.Close()
+}
+
+// retrieves a chunk of the log from the API, parses and stores it in the log cache.
+func (t *task) addLogChunkToCache(start uint) (total, cacheLen uint, err error) {
+	// The GUI uses a limit of 510. Not sure if going higher causes issues.
+	// Therefor we will also request the log in chunks of 510.
+	var params map[string]interface{}
+	params, err = t.client.getItemList(t.ctx, "/nodes/"+t.node+"/tasks/"+t.id+"/log?start="+strconv.FormatUint(uint64(start), 10)+"&limit="+logChunkSizeString)
+	if err != nil {
+		return
+	}
+	total = uint(params["total"].(float64))
+	logEntries := params["data"].([]interface{})
+	if len(logEntries) == 0 {
+		return total, start, nil
+	}
+	startInt := int(start) // Convert to int for the loop, so we don't have to convert it every iteration.
+	for i := range logEntries {
+		t.logCache.Store(i+startInt, logEntries[i].(map[string]interface{})["t"].(string))
+	}
+	cacheLen = uint(len(logEntries)) + start
+	return
+}
+
+// Starts the log fetcher if it hasn't been started yet.
+// The log fetcher is the goroutine that fetches the log from the API and stores it in the log cache.
+func (t *task) startLogFetcher() {
+	t.fetchLog.Do(func() {
+		// t.awaitTermination()
+		go func() {
+			var total, cacheLen uint
+			var err error
+			var gotFirstLog bool
+			for {
+				select {
+				case <-t.closingCh.Done():
+					if t.err.Get() != nil {
+						return
+					}
+					for { // Fetch the log one last time before returning to ensure we have all the logs.
+						cacheLen, total, err = t.addLogChunkToCache(cacheLen)
+						if err != nil {
+							t.setError(err)
+							return
+						}
+						if !gotFirstLog {
+							t.logCh.Close()
+						}
+						if total == cacheLen {
+							return
+						}
+					}
+				default:
+					// Fetch new log lines from the API
+					cacheLen, total, err = t.addLogChunkToCache(cacheLen)
+					if err != nil {
+						t.setError(err)
+					}
+					if !gotFirstLog {
+						t.logCh.Close()
+						gotFirstLog = true
+					}
+					if total == cacheLen {
+						time.Sleep(t.pollingInterval)
+					}
+				}
+			}
+		}()
+	})
+}
+
+// UPID:pve-test:002860A9:051E01C1:67536165:qmmove:102:root@pam:
+// Requires the caller to ensure (t *task) is not nil, or it will panic.
+// parse the UPID string and map it to the task struct.
+func (t *task) mapToSDK_Unsafe(upID string) {
+	t.id = upID
+	indexA := strings.Index(upID[5:], ":") + 5
+	t.node = upID[5:indexA]
+	indexB := strings.Index(upID[indexA+28:], ":") + indexA + 28
+	t.operationType = upID[indexA+28 : indexB]
+	indexA = strings.Index(upID[indexB+1:], ":") + indexB + 1 + 1 // +1 because we are skipping a field
+	t.user = UserID{}.mapToStruct(upID[indexA : strings.Index(upID[indexA:], ":")+indexA])
+}

--- a/proxmox/task.go
+++ b/proxmox/task.go
@@ -66,7 +66,8 @@ type Task interface {
 	Log() []string
 
 	// Inputs the log into the provided channel.
-	LogStream(log chan<- string) error
+	// TODO add more tests for this functionality.
+	_LogStream(log chan<- string) error
 
 	// Returns the node the task was executed on.
 	Node() string
@@ -197,7 +198,7 @@ func (t *task) Log() []string {
 	return logArray
 }
 
-func (t *task) LogStream(out chan<- string) error {
+func (t *task) _LogStream(out chan<- string) error {
 	if t.id == "" {
 		return nil
 	}
@@ -488,7 +489,7 @@ func (d *dummyTask) ID() string {
 func (d *dummyTask) Log() []string {
 	return []string{}
 }
-func (d *dummyTask) LogStream(log chan<- string) error {
+func (d *dummyTask) _LogStream(log chan<- string) error {
 	return nil
 }
 func (d *dummyTask) Node() string {

--- a/proxmox/task.go
+++ b/proxmox/task.go
@@ -41,10 +41,12 @@ const (
 	taskPollingInterval        = 1 * time.Second
 )
 
+// Only `WaitForCompletion()` is required to be used.
+// For now all other functionality is opt-in with feature flag with exception of `WaitForCompletion()`.
+// The context that was inherited from the original API call.
+// To cancel the task, cancel the context.
+// You can also cancel the task by calling the Cancel() method.
 type Task interface {
-	// The context that was inherited from the original API call.
-	// To cancel the task, cancel the context.
-	// You can also cancel the task by calling the Cancel() method.
 
 	// Cancels the task.
 	Cancel() error

--- a/proxmox/task_test.go
+++ b/proxmox/task_test.go
@@ -2,6 +2,7 @@ package proxmox
 
 import (
 	"context"
+	"errors"
 	"runtime"
 	"testing"
 	"time"
@@ -9,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Test if the status is returned correctly.
 func Test_task_Status(t *testing.T) {
 	initialGoroutines := runtime.NumGoroutine()
 	statusChannel := make(chan func() (map[string]interface{}, error))
@@ -59,6 +61,7 @@ func Test_task_Status(t *testing.T) {
 	cancel()
 }
 
+// Test if the log is returned correctly.
 func Test_task_Logs(t *testing.T) {
 	initialGoroutines := runtime.NumGoroutine()
 	statusChannel := make(chan func() (map[string]interface{}, error))
@@ -143,6 +146,83 @@ func Test_task_Logs(t *testing.T) {
 	ended, err := task.Ended()
 	require.True(t, ended)
 	require.NoError(t, err)
+
+	finalGoroutines := runtime.NumGoroutine()
+	if finalGoroutines > initialGoroutines {
+		t.Errorf("Potential goroutine leak: initial = %d, final = %d", initialGoroutines, finalGoroutines)
+	} else {
+		t.Log("No goroutine leaks detected")
+	}
+	cancel()
+}
+
+// Test if all go routines are cleaned up after an error occurs.
+func Test_task_Log_error(t *testing.T) {
+	initialGoroutines := runtime.NumGoroutine()
+	statusChannel := make(chan func() (map[string]interface{}, error))
+	logChannel := make(chan func() (map[string]interface{}, error))
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &mocClient{
+		getItemConfigFunc: func(ctx context.Context, url, text, message string, errorStrings []string) (map[string]interface{}, error) {
+			// Block until data is sent into the channel
+			select {
+			case f := <-statusChannel:
+				return f()
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		},
+		getItemListFunc: func(ctx context.Context, url string) (map[string]interface{}, error) {
+			// Block until data is sent into the channel
+			select {
+			case f := <-logChannel:
+				return f()
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		},
+	}
+	task := newTask(ctx, c, "UPID:pve-test:002860A9:051E01C1:67536165:qmmove:102:root@pam:", 10*time.Millisecond)
+
+	go func() {
+		statusChannel <- func() (map[string]interface{}, error) {
+			return map[string]interface{}{
+				"data": map[string]interface{}{
+					"status": "running"}}, nil
+		}
+		logChannel <- func() (map[string]interface{}, error) {
+			return map[string]interface{}{
+				"total": float64(4),
+				"data": []interface{}{
+					map[string]interface{}{"t": "1"},
+					map[string]interface{}{"t": "2"},
+					map[string]interface{}{"t": "3"},
+					map[string]interface{}{"t": "4"},
+				}}, nil
+		}
+	}()
+	time.Sleep(50 * time.Millisecond)
+	require.Equal(t, "running", task.Status())
+	require.Equal(t, []string{
+		"1",
+		"2",
+		"3",
+		"4",
+	}, task.Log())
+
+	go func() {
+		statusChannel <- func() (map[string]interface{}, error) {
+			return map[string]interface{}{
+					"data": map[string]interface{}{
+						"status":             "stopped",
+						taskApiKeyExitStatus: "ERROR"}},
+				errors.New("error status")
+		}
+	}()
+	time.Sleep(50 * time.Millisecond)
+	ended, err := task.Ended()
+	require.True(t, ended)
+	require.Error(t, err)
 
 	finalGoroutines := runtime.NumGoroutine()
 	if finalGoroutines > initialGoroutines {

--- a/proxmox/task_test.go
+++ b/proxmox/task_test.go
@@ -1,0 +1,193 @@
+package proxmox
+
+import (
+	"context"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_task_Status(t *testing.T) {
+	initialGoroutines := runtime.NumGoroutine()
+	funcChannel := make(chan func() (map[string]interface{}, error))
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &mocClient{
+		getItemConfigFunc: func(ctx context.Context, url, text, message string, errorStrings []string) (map[string]interface{}, error) {
+			// Block until data is sent into the channel
+			select {
+			case f := <-funcChannel:
+				return f()
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		}}
+	task := newTask(ctx, c, "UPID:pve-test:002860A9:051E01C1:67536165:qmmove:102:root@pam:", 10*time.Millisecond)
+
+	go func() {
+		require.Equal(t, "running", task.Status())
+	}()
+	funcChannel <- func() (map[string]interface{}, error) {
+		return map[string]interface{}{
+			"data": map[string]interface{}{
+				"status": "running"}}, nil
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	funcChannel <- func() (map[string]interface{}, error) {
+		return map[string]interface{}{
+			"data": map[string]interface{}{
+				"status":             "done",
+				taskApiKeyExitStatus: "OK"}}, nil
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	require.Equal(t, "done", task.Status())
+	ended, _ := task.Ended()
+	require.True(t, ended)
+
+	finalGoroutines := runtime.NumGoroutine()
+	if finalGoroutines > initialGoroutines {
+		t.Errorf("Potential goroutine leak: initial = %d, final = %d", initialGoroutines, finalGoroutines)
+	} else {
+		t.Log("No goroutine leaks detected")
+	}
+	cancel()
+}
+
+func Test_task_Logs(t *testing.T) {
+	initialGoroutines := runtime.NumGoroutine()
+	statusChannel := make(chan func() (map[string]interface{}, error))
+	logChannel := make(chan func() (map[string]interface{}, error))
+	ctx, cancel := context.WithCancel(context.Background())
+	c := &mocClient{
+		getItemConfigFunc: func(ctx context.Context, url, text, message string, errorStrings []string) (map[string]interface{}, error) {
+			// Block until data is sent into the channel
+			select {
+			case f := <-statusChannel:
+				return f()
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		},
+		getItemListFunc: func(ctx context.Context, url string) (map[string]interface{}, error) {
+			// Block until data is sent into the channel
+			select {
+			case f := <-logChannel:
+				return f()
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			}
+		},
+	}
+	task := newTask(ctx, c, "UPID:pve-test:002860A9:051E01C1:67536165:qmmove:102:root@pam:", 10*time.Millisecond)
+
+	go func() {
+		require.Equal(t, "running", task.Status())
+		require.Equal(t, []string{
+			"1",
+			"2",
+			"3",
+			"4",
+		}, task.Log())
+	}()
+
+	statusChannel <- func() (map[string]interface{}, error) {
+		return map[string]interface{}{
+			"data": map[string]interface{}{
+				"status": "running"}}, nil
+	}
+	logChannel <- func() (map[string]interface{}, error) {
+		return map[string]interface{}{
+			"total": float64(4),
+			"data": []interface{}{
+				map[string]interface{}{"t": "1"},
+				map[string]interface{}{"t": "2"},
+				map[string]interface{}{"t": "3"},
+				map[string]interface{}{"t": "4"},
+			}}, nil
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	go func() {
+		require.Equal(t, "done", task.Status())
+		require.Equal(t, []string{
+			"5",
+			"6",
+		}, task.Log())
+	}()
+
+	statusChannel <- func() (map[string]interface{}, error) {
+		return map[string]interface{}{
+			"data": map[string]interface{}{
+				"status":             "done",
+				taskApiKeyExitStatus: "OK"}}, nil
+	}
+	logChannel <- func() (map[string]interface{}, error) {
+		return map[string]interface{}{
+			"total": float64(6),
+			"data": []interface{}{
+				map[string]interface{}{"t": "5"},
+				map[string]interface{}{"t": "6"},
+			}}, nil
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	logChannel <- func() (map[string]interface{}, error) {
+		return map[string]interface{}{
+			"total": float64(6),
+			"data":  []interface{}{}}, nil
+	}
+	time.Sleep(50 * time.Millisecond)
+
+	require.Equal(t, "done", task.Status())
+	ended, _ := task.Ended()
+	require.True(t, ended)
+
+	finalGoroutines := runtime.NumGoroutine()
+	if finalGoroutines > initialGoroutines {
+		t.Errorf("Potential goroutine leak: initial = %d, final = %d", initialGoroutines, finalGoroutines)
+	} else {
+		t.Log("No goroutine leaks detected")
+	}
+	cancel()
+}
+
+func Test_nodeFromUpID_Unsafe(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		output task
+	}{
+		{name: "1",
+			input: "UPID:pve-test:002860A9:051E01C1:67536165:qmmove:102:root@pam:",
+			output: task{
+				id:            "UPID:pve-test:002860A9:051E01C1:67536165:qmmove:102:root@pam:",
+				node:          "pve-test",
+				operationType: "qmmove",
+				user: UserID{
+					Name:  "root",
+					Realm: "pam"}}},
+		{name: "2",
+			input: "UPID:pve:002860A9:051E01C1:67536165:qmshutdown:102:test-user@realm:",
+			output: task{
+				id:            "UPID:pve:002860A9:051E01C1:67536165:qmshutdown:102:test-user@realm:",
+				node:          "pve",
+				operationType: "qmshutdown",
+				user: UserID{
+					Name:  "test-user",
+					Realm: "realm"}}},
+	}
+	for i := range tests {
+		t.Run(tests[i].name, func(t *testing.T) {
+			tmpTask := &task{}
+			tmpTask.mapToSDK_Unsafe(tests[i].input)
+			require.Equal(t, tests[i].output.id, tmpTask.id)
+			require.Equal(t, tests[i].output.node, tmpTask.node)
+			require.Equal(t, tests[i].output.operationType, tmpTask.operationType)
+			require.Equal(t, tests[i].output.user, tmpTask.user)
+		})
+	}
+}

--- a/proxmox/vmref_test.go
+++ b/proxmox/vmref_test.go
@@ -379,7 +379,8 @@ func Test_VmRef_Migrate(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			require.NotPanics(t, func() { test.input.vmr.Migrate(test.input.ctx, test.input.c, "valid", false) })
-			require.Error(t, test.input.vmr.Migrate(test.input.ctx, test.input.c, "valid", false))
+			_, err := test.input.vmr.Migrate(test.input.ctx, test.input.c, "valid", false)
+			require.Error(t, err)
 		})
 	}
 }
@@ -410,7 +411,8 @@ func Test_VmRef_MigrateNoCheck(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			require.NotPanics(t, func() { test.input.vmr.MigrateNoCheck(test.input.ctx, test.input.c, "valid", false) })
-			require.Error(t, test.input.vmr.MigrateNoCheck(test.input.ctx, test.input.c, "valid", false))
+			_, err := test.input.vmr.MigrateNoCheck(test.input.ctx, test.input.c, "valid", false)
+			require.Error(t, err)
 		})
 	}
 }

--- a/test/api/Qemu/qemu_clone_test.go
+++ b/test/api/Qemu/qemu_clone_test.go
@@ -27,7 +27,7 @@ func Test_Clone_Qemu_VM(t *testing.T) {
 	newGuest := _create_clone_vmref()
 
 	sourceVmRef := _create_vmref()
-	_, err := sourceVmRef.CloneQemu(context.Background(), pxapi.CloneQemuTarget{
+	_, task, err := sourceVmRef.CloneQemu(context.Background(), pxapi.CloneQemuTarget{
 		Full: &pxapi.CloneQemuFull{
 			Node: newGuest.Node(),
 			Name: util.Pointer("test-qemu02"),
@@ -35,6 +35,7 @@ func Test_Clone_Qemu_VM(t *testing.T) {
 		},
 	}, Test.GetClient())
 	require.NoError(t, err)
+	require.NoError(t, task.WaitForCompletion())
 }
 
 func Test_Clone_Qemu_VM_To_Different_Storage(t *testing.T) {
@@ -47,7 +48,7 @@ func Test_Clone_Qemu_VM_To_Different_Storage(t *testing.T) {
 	newGuest := _create_clone_vmref()
 
 	sourceVmRef := _create_vmref()
-	_, err := sourceVmRef.CloneQemu(context.Background(), pxapi.CloneQemuTarget{
+	_, task, err := sourceVmRef.CloneQemu(context.Background(), pxapi.CloneQemuTarget{
 		Full: &pxapi.CloneQemuFull{
 			Node:    newGuest.Node(),
 			Name:    util.Pointer("test-qemu02"),
@@ -56,6 +57,7 @@ func Test_Clone_Qemu_VM_To_Different_Storage(t *testing.T) {
 		},
 	}, Test.GetClient())
 	require.NoError(t, err)
+	require.NoError(t, task.WaitForCompletion())
 }
 
 func Test_Qemu_VM_Is_Cloned(t *testing.T) {


### PR DESCRIPTION
Adds a `Task` interface that can be used for asynchronously awaiting the completion of the task.

The async part is enabled with the `Features.AsyncTask` flag in the `Client` struct.

Resolves #388


Supersedes:
Closes #397
Closes #389