### PR TITLE
feature/import-from: add import-from feature to disks on create

### DIFF
--- a/proxmox/config_qemu_disk_ide.go
+++ b/proxmox/config_qemu_disk_ide.go
@@ -21,6 +21,7 @@ type QemuIdeDisk struct {
 	Storage         string            `json:"storage"`
 	syntax          diskSyntaxEnum
 	WorldWideName   QemuWorldWideName `json:"wwn"`
+	ImportFrom      string            `json:"import-from,omitempty"`
 }
 
 func (disk *QemuIdeDisk) convertDataStructure() *qemuDisk {
@@ -42,6 +43,7 @@ func (disk *QemuIdeDisk) convertDataStructure() *qemuDisk {
 		Storage:         disk.Storage,
 		Type:            ide,
 		WorldWideName:   disk.WorldWideName,
+		ImportFrom:      disk.ImportFrom,
 	}
 }
 

--- a/proxmox/config_qemu_disk_ide.go
+++ b/proxmox/config_qemu_disk_ide.go
@@ -21,7 +21,7 @@ type QemuIdeDisk struct {
 	Storage         string            `json:"storage"`
 	syntax          diskSyntaxEnum
 	WorldWideName   QemuWorldWideName `json:"wwn"`
-	ImportFrom      string            `json:"import-from,omitempty"`
+	ImportFrom      string            `json:"import_from,omitempty"`
 }
 
 func (disk *QemuIdeDisk) convertDataStructure() *qemuDisk {

--- a/proxmox/config_qemu_disk_sata.go
+++ b/proxmox/config_qemu_disk_sata.go
@@ -21,7 +21,7 @@ type QemuSataDisk struct {
 	Storage         string            `json:"storage"`
 	syntax          diskSyntaxEnum
 	WorldWideName   QemuWorldWideName `json:"wwn"`
-	ImportFrom      string            `json:"import-from,omitempty"`
+	ImportFrom      string            `json:"import_from,omitempty"`
 }
 
 func (disk *QemuSataDisk) convertDataStructure() *qemuDisk {

--- a/proxmox/config_qemu_disk_sata.go
+++ b/proxmox/config_qemu_disk_sata.go
@@ -21,6 +21,7 @@ type QemuSataDisk struct {
 	Storage         string            `json:"storage"`
 	syntax          diskSyntaxEnum
 	WorldWideName   QemuWorldWideName `json:"wwn"`
+	ImportFrom      string            `json:"import-from,omitempty"`
 }
 
 func (disk *QemuSataDisk) convertDataStructure() *qemuDisk {
@@ -42,6 +43,7 @@ func (disk *QemuSataDisk) convertDataStructure() *qemuDisk {
 		Storage:         disk.Storage,
 		Type:            sata,
 		WorldWideName:   disk.WorldWideName,
+		ImportFrom:      disk.ImportFrom,
 	}
 }
 

--- a/proxmox/config_qemu_disk_scsi.go
+++ b/proxmox/config_qemu_disk_scsi.go
@@ -23,6 +23,7 @@ type QemuScsiDisk struct {
 	Storage         string            `json:"storage"`
 	syntax          diskSyntaxEnum
 	WorldWideName   QemuWorldWideName `json:"wwn"`
+	ImportFrom      string            `json:"import-from,omitempty"`
 }
 
 func (disk *QemuScsiDisk) convertDataStructure() *qemuDisk {
@@ -46,6 +47,7 @@ func (disk *QemuScsiDisk) convertDataStructure() *qemuDisk {
 		fileSyntax:      disk.syntax,
 		Type:            scsi,
 		WorldWideName:   disk.WorldWideName,
+		ImportFrom:      disk.ImportFrom,
 	}
 }
 

--- a/proxmox/config_qemu_disk_scsi.go
+++ b/proxmox/config_qemu_disk_scsi.go
@@ -23,7 +23,7 @@ type QemuScsiDisk struct {
 	Storage         string            `json:"storage"`
 	syntax          diskSyntaxEnum
 	WorldWideName   QemuWorldWideName `json:"wwn"`
-	ImportFrom      string            `json:"import-from,omitempty"`
+	ImportFrom      string            `json:"import_from,omitempty"`
 }
 
 func (disk *QemuScsiDisk) convertDataStructure() *qemuDisk {

--- a/proxmox/config_qemu_disk_virtio.go
+++ b/proxmox/config_qemu_disk_virtio.go
@@ -22,6 +22,7 @@ type QemuVirtIODisk struct {
 	Storage         string            `json:"storage"`
 	syntax          diskSyntaxEnum
 	WorldWideName   QemuWorldWideName `json:"wwn"`
+	ImportFrom      string            `json:"import-from,omitempty"`
 }
 
 func (disk *QemuVirtIODisk) convertDataStructure() *qemuDisk {
@@ -44,6 +45,7 @@ func (disk *QemuVirtIODisk) convertDataStructure() *qemuDisk {
 		Storage:         disk.Storage,
 		Type:            virtIO,
 		WorldWideName:   disk.WorldWideName,
+		ImportFrom:      disk.ImportFrom,
 	}
 }
 

--- a/proxmox/config_qemu_disk_virtio.go
+++ b/proxmox/config_qemu_disk_virtio.go
@@ -22,7 +22,7 @@ type QemuVirtIODisk struct {
 	Storage         string            `json:"storage"`
 	syntax          diskSyntaxEnum
 	WorldWideName   QemuWorldWideName `json:"wwn"`
-	ImportFrom      string            `json:"import-from,omitempty"`
+	ImportFrom      string            `json:"import_from,omitempty"`
 }
 
 func (disk *QemuVirtIODisk) convertDataStructure() *qemuDisk {


### PR DESCRIPTION
# TL;DR; 

This PR implements the `import-from` option in Proxmox/Qemu VM creation with disks (scsi, ide, virtio,sata).
If the `import-from` option is set in the input `JSON` the only other required option is `storage`.

I am rather new to Golang, so please do point out any problems I might have missed. 

---

## Why?

Stumbled upon this when trying to replicate my current Ansible workflow in OpenTofu.
I was using prebuilt cloud images with clou-init preinstalled to have faster VM creation and no need to build custom iso-images.

The workflow:
1. Create VM
2. Import cloud-img
3. Expand disk from image to desired size
4. Boot

Then noticed that downstream in [terraform-provider-proxmox](https://github.com/Telmate/terraform-provider-proxmox) the  feature `import-from` for disks was implemented in `2.x` versions that were never published. It seems to be removed now in `3.x`, see https://github.com/Telmate/terraform-provider-proxmox/issues/1236.

[This comment](https://github.com/Telmate/terraform-provider-proxmox/issues/1236#issuecomment-2628006405) pointed out the need for upstream changes. 

---

## How? 

I simply added the field `ImportFrom` with the json mapper `import-from` (as in orig. docs of API) to the structs:
- `qemuDisk` - `proxmox/config_qemu_disk.go`
- `QemuIdeDisk` - `proxmox/config_qemu_disk_ide.go`
- `QemuSataDisk` - `proxmox/config_qemu_disk_sata.go`
- `QemuScsiDisk` - `proxmox/config_qemu_disk_scsi.go`
- `QemuVirtIODisk` - `proxmox/config_qemu_disk_virtio.go`

The mapping to API values had to be changed, as the API expects a specific pattern:

From API docs: `Use STORAGE_ID:0 and the 'import-from' parameter to import from an existing volume.`
See `proxmox/config_qemu_disk.go` l.259-261.

The validation had to change as the otherwise required `size` and `format` are not needed here.
See `proxmox/config_qemu_disk.go` l.530-537.

## Tests

I tested the changes with a running test cluster and the following `vm.json`

`./proxmox-api-go -insecure createQemu 888 pve-1 < vm.json`

```json
{
  "memory": {
    "capacity": 3072,
    "balloon": 0
  },
  "cpu": {
    "cores": 2
  },
  "bios": "seabios",
  "scsihw": "virtio-scsi-pci",
  "ostype": "l26",
  "name": "go-test",
  "disks": {
    "scsi": {
      "0": {
        "disk": {
          "storage": "vms-data",
          "import-from": "/var/lib/vz/template/iso/ubuntu-22.04-server-cloudimg-amd64.img"
        }
      }
    },
    "ide": {
      "0": {
        "disk": {
          "storage": "vms-data",
          "import-from": "/var/lib/vz/template/iso/ubuntu-22.04-server-cloudimg-amd64.img"
        }
      }
    },
    "sata": {
      "0": {
        "disk": {
          "storage": "vms-data",
          "import-from": "/var/lib/vz/template/iso/ubuntu-22.04-server-cloudimg-amd64.img"
        }
      }
    },
    "virtio": {
      "0": {
        "disk": {
          "storage": "vms-data",
          "import-from": "/var/lib/vz/template/iso/ubuntu-22.04-server-cloudimg-amd64.img"
        }
      }
    }
  },
  "bootdisk": "scsi0"
}
```

Got the VM created as expected:

![image](https://github.com/user-attachments/assets/23d2945d-8b51-4c32-a3e7-a5b892c63edb)

