### PR TITLE
Lxc: features

### DIFF
--- a/proxmox/config_lxc__features.go
+++ b/proxmox/config_lxc__features.go
@@ -33,14 +33,14 @@ func (config LxcFeatures) mapToApiUpdate(current LxcFeatures, params map[string]
 	return ""
 }
 
-func (config LxcFeatures) Validate(Privileged bool) error {
+func (config LxcFeatures) Validate(privileged bool) error {
 	if config.Privileged != nil && config.Unprivileged != nil {
 		return errors.New(LxcFeatures_Error_MutuallyExclusive)
 	}
-	if config.Privileged != nil && !Privileged {
+	if config.Privileged != nil && !privileged {
 		return errors.New(LxcFeatures_Error_PrivilegedInUnprivileged)
 	}
-	if config.Unprivileged != nil && Privileged {
+	if config.Unprivileged != nil && privileged {
 		return errors.New(LxcFeatures_Error_UnprivilegedInPrivileged)
 	}
 	return nil

--- a/proxmox/config_lxc__features.go
+++ b/proxmox/config_lxc__features.go
@@ -1,59 +1,49 @@
 package proxmox
 
-import "strings"
+import (
+	"errors"
+	"strings"
+)
 
 type LxcFeatures struct {
-	CreateDeviceNodes *bool `json:"create_device_nodes,omitempty"`
-	FUSE              *bool `json:"fuse,omitempty"`
-	KeyCtl            *bool `json:"keyctl,omitempty"`
-	NFS               *bool `json:"nfs,omitempty"`
-	Nesting           *bool `json:"nesting,omitempty"`
-	SMB               *bool `json:"smb,omitempty"`
+	Privileged   *PrivilegedFeatures   `json:"privileged,omitempty"`   // Mutually exclusive with Unprivileged
+	Unprivileged *UnprivilegedFeatures `json:"unprivileged,omitempty"` // Mutually exclusive with Privileged
 }
 
+const (
+	LxcFeatures_Error_MutuallyExclusive        = "privileged and unprivileged features are mutually exclusive"
+	LxcFeatures_Error_PrivilegedInUnprivileged = "privileged features cannot be set in unprivileged containers"
+	LxcFeatures_Error_UnprivilegedInPrivileged = "unprivileged features cannot be set in privileged containers"
+)
+
 func (config LxcFeatures) mapToApiCreate(params map[string]any) {
-	var usedConfig lxcFeatures
-	usedConfig = config.mapToApiIntermediary_Unsafe(usedConfig)
-	if v := usedConfig.String(); v != "" {
-		params[lxcApiKeyFeatures] = v[1:]
+	if config.Privileged != nil {
+		config.Privileged.mapToApiCreate(params)
+	} else if config.Unprivileged != nil {
+		config.Unprivileged.mapToApiCreate(params)
 	}
 }
 
 func (config LxcFeatures) mapToApiUpdate(current LxcFeatures, params map[string]interface{}) string {
-	var usedConfig, currentConfig lxcFeatures
-	usedConfig = current.mapToApiIntermediary_Unsafe(usedConfig)
-	currentConfig = usedConfig
-	usedConfig = config.mapToApiIntermediary_Unsafe(usedConfig)
-	if usedConfig == currentConfig {
-		return ""
+	if config.Privileged != nil && current.Privileged != nil {
+		return config.Privileged.mapToApiUpdate(*current.Privileged, params)
+	} else if config.Unprivileged != nil && current.Unprivileged != nil {
+		return config.Unprivileged.mapToApiUpdate(*current.Unprivileged, params)
 	}
-	if v := usedConfig.String(); v != "" {
-		params[lxcApiKeyFeatures] = v[1:]
-		return ""
-	}
-	return "," + lxcApiKeyFeatures
+	return ""
 }
 
-func (config LxcFeatures) mapToApiIntermediary_Unsafe(usedConfig lxcFeatures) lxcFeatures {
-	if config.CreateDeviceNodes != nil {
-		usedConfig[lxcFeaturesCreateDeviceNodes] = *config.CreateDeviceNodes
+func (config LxcFeatures) Validate(Privileged bool) error {
+	if config.Privileged != nil && config.Unprivileged != nil {
+		return errors.New(LxcFeatures_Error_MutuallyExclusive)
 	}
-	if config.FUSE != nil {
-		usedConfig[lxcFeaturesFUSE] = *config.FUSE
+	if config.Privileged != nil && !Privileged {
+		return errors.New(LxcFeatures_Error_PrivilegedInUnprivileged)
 	}
-	if config.KeyCtl != nil {
-		usedConfig[lxcFeaturesKeyCtl] = *config.KeyCtl
+	if config.Unprivileged != nil && Privileged {
+		return errors.New(LxcFeatures_Error_UnprivilegedInPrivileged)
 	}
-	if config.NFS != nil {
-		usedConfig[lxcFeaturesNFS] = *config.NFS
-	}
-	if config.Nesting != nil {
-		usedConfig[lxcFeaturesNesting] = *config.Nesting
-	}
-	if config.SMB != nil {
-		usedConfig[lxcFeaturesSMB] = *config.SMB
-	}
-	return usedConfig
+	return nil
 }
 
 type lxcFeatures [lxcFeaturesLength]bool
@@ -91,6 +81,102 @@ func (features lxcFeatures) String() (settings string) { // String is for fmt.St
 		settings += ",nesting=1"
 	}
 	return
+}
+
+type PrivilegedFeatures struct {
+	CreateDeviceNodes *bool `json:"create_device_nodes,omitempty"` // Never nil when returned
+	FUSE              *bool `json:"fuse,omitempty"`                // Never nil when returned
+	NFS               *bool `json:"nfs,omitempty"`                 // Never nil when returned
+	Nesting           *bool `json:"nesting,omitempty"`             // Never nil when returned
+	SMB               *bool `json:"smb,omitempty"`                 // Never nil when returned
+}
+
+func (config PrivilegedFeatures) mapToApiCreate(params map[string]any) {
+	var usedConfig lxcFeatures
+	usedConfig = config.mapToApiIntermediary(usedConfig)
+	if v := usedConfig.String(); v != "" {
+		params[lxcApiKeyFeatures] = v[1:]
+	}
+}
+
+func (config PrivilegedFeatures) mapToApiUpdate(current PrivilegedFeatures, params map[string]any) string {
+	var usedConfig, currentConfig lxcFeatures
+	usedConfig = current.mapToApiIntermediary(usedConfig)
+	currentConfig = usedConfig
+	usedConfig = config.mapToApiIntermediary(usedConfig)
+	if usedConfig == currentConfig {
+		return ""
+	}
+	if v := usedConfig.String(); v != "" {
+		params[lxcApiKeyFeatures] = v[1:]
+		return ""
+	}
+	return "," + lxcApiKeyFeatures
+}
+
+func (config PrivilegedFeatures) mapToApiIntermediary(usedConfig lxcFeatures) lxcFeatures {
+	if config.CreateDeviceNodes != nil {
+		usedConfig[lxcFeaturesCreateDeviceNodes] = *config.CreateDeviceNodes
+	}
+	if config.FUSE != nil {
+		usedConfig[lxcFeaturesFUSE] = *config.FUSE
+	}
+	if config.NFS != nil {
+		usedConfig[lxcFeaturesNFS] = *config.NFS
+	}
+	if config.Nesting != nil {
+		usedConfig[lxcFeaturesNesting] = *config.Nesting
+	}
+	if config.SMB != nil {
+		usedConfig[lxcFeaturesSMB] = *config.SMB
+	}
+	return usedConfig
+}
+
+type UnprivilegedFeatures struct {
+	CreateDeviceNodes *bool `json:"create_device_nodes,omitempty"` // Never nil when returned
+	FUSE              *bool `json:"fuse,omitempty"`                // Never nil when returned
+	KeyCtl            *bool `json:"keyctl,omitempty"`              // Never nil when returned
+	Nesting           *bool `json:"nesting,omitempty"`             // Never nil when returned
+}
+
+func (config UnprivilegedFeatures) mapToApiCreate(params map[string]any) {
+	var usedConfig lxcFeatures
+	usedConfig = config.mapToApiIntermediary(usedConfig)
+	if v := usedConfig.String(); v != "" {
+		params[lxcApiKeyFeatures] = v[1:]
+	}
+}
+
+func (config UnprivilegedFeatures) mapToApiUpdate(current UnprivilegedFeatures, params map[string]any) string {
+	var usedConfig, currentConfig lxcFeatures
+	usedConfig = current.mapToApiIntermediary(usedConfig)
+	currentConfig = usedConfig
+	usedConfig = config.mapToApiIntermediary(usedConfig)
+	if usedConfig == currentConfig {
+		return ""
+	}
+	if v := usedConfig.String(); v != "" {
+		params[lxcApiKeyFeatures] = v[1:]
+		return ""
+	}
+	return "," + lxcApiKeyFeatures
+}
+
+func (config UnprivilegedFeatures) mapToApiIntermediary(usedConfig lxcFeatures) lxcFeatures {
+	if config.CreateDeviceNodes != nil {
+		usedConfig[lxcFeaturesCreateDeviceNodes] = *config.CreateDeviceNodes
+	}
+	if config.FUSE != nil {
+		usedConfig[lxcFeaturesFUSE] = *config.FUSE
+	}
+	if config.KeyCtl != nil {
+		usedConfig[lxcFeaturesKeyCtl] = *config.KeyCtl
+	}
+	if config.Nesting != nil {
+		usedConfig[lxcFeaturesNesting] = *config.Nesting
+	}
+	return usedConfig
 }
 
 func (raw RawConfigLXC) Features() *LxcFeatures {
@@ -134,11 +220,19 @@ func (raw RawConfigLXC) Features() *LxcFeatures {
 	if !set {
 		return nil
 	}
+	if raw.isPrivileged() {
+		return &LxcFeatures{
+			Privileged: &PrivilegedFeatures{
+				CreateDeviceNodes: &features[lxcFeaturesCreateDeviceNodes],
+				FUSE:              &features[lxcFeaturesFUSE],
+				NFS:               &features[lxcFeaturesNFS],
+				Nesting:           &features[lxcFeaturesNesting],
+				SMB:               &features[lxcFeaturesSMB]}}
+	}
 	return &LxcFeatures{
-		CreateDeviceNodes: &features[lxcFeaturesCreateDeviceNodes],
-		FUSE:              &features[lxcFeaturesFUSE],
-		KeyCtl:            &features[lxcFeaturesKeyCtl],
-		NFS:               &features[lxcFeaturesNFS],
-		Nesting:           &features[lxcFeaturesNesting],
-		SMB:               &features[lxcFeaturesSMB]}
+		Unprivileged: &UnprivilegedFeatures{
+			KeyCtl:            &features[lxcFeaturesKeyCtl],
+			CreateDeviceNodes: &features[lxcFeaturesCreateDeviceNodes],
+			FUSE:              &features[lxcFeaturesFUSE],
+			Nesting:           &features[lxcFeaturesNesting]}}
 }

--- a/proxmox/config_lxc_new.go
+++ b/proxmox/config_lxc_new.go
@@ -123,9 +123,7 @@ func (config ConfigLXC) mapToApiCreate() (map[string]any, PoolName) {
 		pool = *config.Pool
 		params[lxcApiKeyPool] = string(pool)
 	}
-	if config.Privileged == nil {
-		params[lxcApiKeyUnprivileged] = 1
-	} else if !*config.Privileged {
+	if config.Privileged == nil || !*config.Privileged {
 		params[lxcApiKeyUnprivileged] = 1
 	}
 	if config.Swap != nil {

--- a/proxmox/config_lxc_new.go
+++ b/proxmox/config_lxc_new.go
@@ -394,7 +394,7 @@ func (raw RawConfigLXC) isPrivileged() bool {
 	if v, isSet := raw[lxcApiKeyUnprivileged]; isSet {
 		return v.(float64) == 0
 	}
-	return true
+	return true // when privileged the API does not return the key at all, so we assume it is privileged
 }
 
 func (raw RawConfigLXC) Swap() *LxcSwap {

--- a/proxmox/config_lxc_new.go
+++ b/proxmox/config_lxc_new.go
@@ -291,11 +291,11 @@ func (config ConfigLXC) validateCreate() (err error) {
 		return
 	}
 	if config.Features != nil {
-		priviledge := lxcDefaultPrivilege
+		privilege := lxcDefaultPrivilege
 		if config.Privileged != nil {
-			priviledge = *config.Privileged
+			privilege = *config.Privileged
 		}
-		if err = config.Features.Validate(priviledge); err != nil {
+		if err = config.Features.Validate(privilege); err != nil {
 			return
 		}
 	}

--- a/proxmox/config_lxc_new.go
+++ b/proxmox/config_lxc_new.go
@@ -296,8 +296,10 @@ func (config ConfigLXC) validateCreate() (err error) {
 }
 
 func (config ConfigLXC) validateUpdate(current ConfigLXC) (err error) {
-	if err = config.BootMount.Validate(current.BootMount); err != nil {
-		return
+	if config.BootMount != nil {
+		if err = config.BootMount.Validate(current.BootMount); err != nil {
+			return
+		}
 	}
 	return config.Networks.Validate(current.Networks)
 }

--- a/proxmox/config_lxc_new.go
+++ b/proxmox/config_lxc_new.go
@@ -292,12 +292,26 @@ func (config ConfigLXC) validateCreate() (err error) {
 	if err = config.CreateOptions.Validate(); err != nil {
 		return
 	}
+	if config.Features != nil {
+		priviledge := lxcDefaultPrivileged
+		if config.Privileged != nil {
+			priviledge = *config.Privileged
+		}
+		if err = config.Features.Validate(priviledge); err != nil {
+			return
+		}
+	}
 	return config.Networks.Validate(nil)
 }
 
 func (config ConfigLXC) validateUpdate(current ConfigLXC) (err error) {
 	if config.BootMount != nil {
 		if err = config.BootMount.Validate(current.BootMount); err != nil {
+			return
+		}
+	}
+	if config.Features != nil {
+		if err = config.Features.Validate(*current.Privileged); err != nil {
 			return
 		}
 	}

--- a/proxmox/config_lxc_new.go
+++ b/proxmox/config_lxc_new.go
@@ -39,7 +39,7 @@ type ConfigLXC struct {
 }
 
 const (
-	lxcDefaultPrivileged bool = false
+	lxcDefaultPrivilege bool = false
 )
 
 const (
@@ -293,7 +293,7 @@ func (config ConfigLXC) validateCreate() (err error) {
 		return
 	}
 	if config.Features != nil {
-		priviledge := lxcDefaultPrivileged
+		priviledge := lxcDefaultPrivilege
 		if config.Privileged != nil {
 			priviledge = *config.Privileged
 		}

--- a/proxmox/config_lxc_new_test.go
+++ b/proxmox/config_lxc_new_test.go
@@ -1257,7 +1257,7 @@ func Test_ConfigLXC_Validate(t *testing.T) {
 			},
 			invalid: testType{
 				create: []test{
-					{name: `priviledge default errors.New(LxcFeatures_Error_PrivilegedInUnprivileged)`,
+					{name: `privilege default errors.New(LxcFeatures_Error_PrivilegedInUnprivileged)`,
 						input: baseConfig(ConfigLXC{Features: &LxcFeatures{
 							Privileged: &PrivilegedFeatures{}}}),
 						err: errors.New(LxcFeatures_Error_PrivilegedInUnprivileged)},

--- a/proxmox/config_lxc_new_test.go
+++ b/proxmox/config_lxc_new_test.go
@@ -17,14 +17,20 @@ func Test_CpuArchitecture_String(t *testing.T) {
 }
 
 func Test_ConfigLXC_mapToAPI(t *testing.T) {
-	feature := func(value bool) *LxcFeatures {
-		return &LxcFeatures{
+	featuresPrivileged := func(value bool) *LxcFeatures {
+		return &LxcFeatures{Privileged: &PrivilegedFeatures{
+			CreateDeviceNodes: util.Pointer(value),
+			FUSE:              util.Pointer(value),
+			NFS:               util.Pointer(value),
+			Nesting:           util.Pointer(value),
+			SMB:               util.Pointer(value)}}
+	}
+	featuresUnprivileged := func(value bool) *LxcFeatures {
+		return &LxcFeatures{Unprivileged: &UnprivilegedFeatures{
 			CreateDeviceNodes: util.Pointer(value),
 			FUSE:              util.Pointer(value),
 			KeyCtl:            util.Pointer(value),
-			NFS:               util.Pointer(value),
-			Nesting:           util.Pointer(value),
-			SMB:               util.Pointer(value)}
+			Nesting:           util.Pointer(value)}}
 	}
 	parseIP := func(rawIP string) netip.Addr {
 		ip, err := netip.ParseAddr(rawIP)
@@ -473,85 +479,153 @@ func Test_ConfigLXC_mapToAPI(t *testing.T) {
 						SearchDomain: util.Pointer("example.com")}},
 					output: map[string]any{}}}},
 		{category: `Features`,
+			create: []test{
+				{name: `all false Privileged`,
+					config: ConfigLXC{Features: featuresPrivileged(false)},
+					output: map[string]any{}},
+				{name: `all false Unprivileged`,
+					config: ConfigLXC{Features: featuresUnprivileged(false)},
+					output: map[string]any{}}},
 			createUpdate: []test{
-				{name: `CreateDeviceNodes`,
-					config:        ConfigLXC{Features: &LxcFeatures{CreateDeviceNodes: util.Pointer(true)}},
-					currentConfig: ConfigLXC{Features: feature(false)},
-					output:        map[string]any{"features": "mknod=1"}},
-				{name: `FUSE`,
-					config:        ConfigLXC{Features: &LxcFeatures{FUSE: util.Pointer(true)}},
-					currentConfig: ConfigLXC{Features: feature(false)},
-					output:        map[string]any{"features": "fuse=1"}},
-				{name: `KeyCtl`,
-					config:        ConfigLXC{Features: &LxcFeatures{KeyCtl: util.Pointer(true)}},
-					currentConfig: ConfigLXC{Features: feature(false)},
-					output:        map[string]any{"features": "keyctl=1"}},
-				{name: `NFS`,
-					config:        ConfigLXC{Features: &LxcFeatures{NFS: util.Pointer(true)}},
-					currentConfig: ConfigLXC{Features: feature(false)},
-					output:        map[string]any{"features": "mount=nfs"}},
-				{name: `smb`,
-					config:        ConfigLXC{Features: &LxcFeatures{SMB: util.Pointer(true)}},
-					currentConfig: ConfigLXC{Features: feature(false)},
-					output:        map[string]any{"features": "mount=cifs"}},
-				{name: `Nesting`,
-					config:        ConfigLXC{Features: &LxcFeatures{Nesting: util.Pointer(true)}},
-					currentConfig: ConfigLXC{Features: feature(false)},
-					output:        map[string]any{"features": "nesting=1"}},
-				{name: `NFS and SMB`,
-					config:        ConfigLXC{Features: &LxcFeatures{NFS: util.Pointer(true), SMB: util.Pointer(true)}},
-					currentConfig: ConfigLXC{Features: feature(false)},
-					output:        map[string]any{"features": "mount=nfs;cifs"}},
-				{name: `delete no effect false`,
-					config:        ConfigLXC{Features: feature(false)},
-					currentConfig: ConfigLXC{Features: feature(false)},
-					output:        map[string]any{}}},
+				{name: `CreateDeviceNodes Privileged`,
+					config: ConfigLXC{Features: &LxcFeatures{Privileged: &PrivilegedFeatures{
+						CreateDeviceNodes: util.Pointer(true)}}},
+					output: map[string]any{"features": "mknod=1"}},
+				{name: `CreateDeviceNodes Unprivileged`,
+					config: ConfigLXC{Features: &LxcFeatures{Unprivileged: &UnprivilegedFeatures{
+						CreateDeviceNodes: util.Pointer(true)}}},
+					output: map[string]any{"features": "mknod=1"}},
+				{name: `FUSE Privileged`,
+					config: ConfigLXC{Features: &LxcFeatures{Privileged: &PrivilegedFeatures{
+						FUSE: util.Pointer(true)}}},
+					output: map[string]any{"features": "fuse=1"}},
+				{name: `FUSE Unprivileged`,
+					config: ConfigLXC{Features: &LxcFeatures{Unprivileged: &UnprivilegedFeatures{
+						FUSE: util.Pointer(true)}}},
+					output: map[string]any{"features": "fuse=1"}},
+				{name: `KeyCtl Unprivileged`,
+					config: ConfigLXC{Features: &LxcFeatures{Unprivileged: &UnprivilegedFeatures{
+						KeyCtl: util.Pointer(true)}}},
+					output: map[string]any{"features": "keyctl=1"}},
+				{name: `NFS Privileged`,
+					config: ConfigLXC{Features: &LxcFeatures{Privileged: &PrivilegedFeatures{
+						NFS: util.Pointer(true)}}},
+					output: map[string]any{"features": "mount=nfs"}},
+				{name: `SMB Privileged`,
+					config: ConfigLXC{Features: &LxcFeatures{Privileged: &PrivilegedFeatures{
+						SMB: util.Pointer(true)}}},
+					output: map[string]any{"features": "mount=cifs"}},
+				{name: `Nesting Privileged`,
+					config: ConfigLXC{Features: &LxcFeatures{Privileged: &PrivilegedFeatures{
+						Nesting: util.Pointer(true)}}},
+					output: map[string]any{"features": "nesting=1"}},
+				{name: `Nesting Unprivileged`,
+					config: ConfigLXC{Features: &LxcFeatures{Unprivileged: &UnprivilegedFeatures{
+						Nesting: util.Pointer(true)}}},
+					output: map[string]any{"features": "nesting=1"}},
+				{name: `NFS and SMB Privileged`,
+					config: ConfigLXC{Features: &LxcFeatures{Privileged: &PrivilegedFeatures{
+						NFS: util.Pointer(true), SMB: util.Pointer(true)}}},
+					output: map[string]any{"features": "mount=nfs;cifs"}},
+				{name: `delete no effect false Privileged`,
+					config:        ConfigLXC{Features: featuresPrivileged(false)},
+					currentConfig: ConfigLXC{Features: featuresPrivileged(false)},
+					output:        map[string]any{}},
+				{name: `delete no effect false Unprivileged`,
+					config:        ConfigLXC{Features: featuresUnprivileged(false)},
+					currentConfig: ConfigLXC{Features: featuresUnprivileged(false)},
+					output:        map[string]any{}},
+				{name: `only top-level set, no effect`,
+					config:        ConfigLXC{Features: &LxcFeatures{}},
+					currentConfig: ConfigLXC{Features: &LxcFeatures{}},
+					output:        map[string]any{}},
+			},
 			update: []test{
-				{name: `CreateDeviceNodes false`,
-					config:        ConfigLXC{Features: &LxcFeatures{CreateDeviceNodes: util.Pointer(false)}},
-					currentConfig: ConfigLXC{Features: feature(true)},
-					output:        map[string]any{"features": "fuse=1,keyctl=1,mount=nfs;cifs,nesting=1"}},
-				{name: `FUSE false`,
-					config:        ConfigLXC{Features: &LxcFeatures{FUSE: util.Pointer(false)}},
-					currentConfig: ConfigLXC{Features: feature(true)},
-					output:        map[string]any{"features": "mknod=1,keyctl=1,mount=nfs;cifs,nesting=1"}},
-				{name: `KeyCtl false`,
-					config:        ConfigLXC{Features: &LxcFeatures{KeyCtl: util.Pointer(false)}},
-					currentConfig: ConfigLXC{Features: feature(true)},
-					output:        map[string]any{"features": "mknod=1,fuse=1,mount=nfs;cifs,nesting=1"}},
-				{name: `NFS false`,
-					config:        ConfigLXC{Features: &LxcFeatures{NFS: util.Pointer(false)}},
-					currentConfig: ConfigLXC{Features: feature(true)},
-					output:        map[string]any{"features": "mknod=1,fuse=1,keyctl=1,mount=cifs,nesting=1"}},
-				{name: `SMB false`,
-					config:        ConfigLXC{Features: &LxcFeatures{SMB: util.Pointer(false)}},
-					currentConfig: ConfigLXC{Features: feature(true)},
-					output:        map[string]any{"features": "mknod=1,fuse=1,keyctl=1,mount=nfs,nesting=1"}},
-				{name: `Nesting false`,
-					config:        ConfigLXC{Features: &LxcFeatures{Nesting: util.Pointer(false)}},
-					currentConfig: ConfigLXC{Features: feature(true)},
-					output:        map[string]any{"features": "mknod=1,fuse=1,keyctl=1,mount=nfs;cifs"}},
-				{name: `delete`,
-					config: ConfigLXC{Features: feature(false)},
-					currentConfig: ConfigLXC{Features: &LxcFeatures{
+				{name: `CreateDeviceNodes false Privileged`,
+					config: ConfigLXC{Features: &LxcFeatures{Privileged: &PrivilegedFeatures{
+						CreateDeviceNodes: util.Pointer(false)}}},
+					currentConfig: ConfigLXC{Features: featuresPrivileged(true)},
+					output:        map[string]any{"features": "fuse=1,mount=nfs;cifs,nesting=1"}},
+				{name: `CreateDeviceNodes false Unprivileged`,
+					config: ConfigLXC{Features: &LxcFeatures{Unprivileged: &UnprivilegedFeatures{
+						CreateDeviceNodes: util.Pointer(false)}}},
+					currentConfig: ConfigLXC{Features: featuresUnprivileged(true)},
+					output:        map[string]any{"features": "fuse=1,keyctl=1,nesting=1"}},
+				{name: `FUSE false Privileged`,
+					config: ConfigLXC{Features: &LxcFeatures{Privileged: &PrivilegedFeatures{
+						FUSE: util.Pointer(false)}}},
+					currentConfig: ConfigLXC{Features: featuresPrivileged(true)},
+					output:        map[string]any{"features": "mknod=1,mount=nfs;cifs,nesting=1"}},
+				{name: `FUSE false Unprivileged`,
+					config: ConfigLXC{Features: &LxcFeatures{Unprivileged: &UnprivilegedFeatures{
+						FUSE: util.Pointer(false)}}},
+					currentConfig: ConfigLXC{Features: featuresUnprivileged(true)},
+					output:        map[string]any{"features": "mknod=1,keyctl=1,nesting=1"}},
+				{name: `KeyCtl false Unprivileged`,
+					config: ConfigLXC{Features: &LxcFeatures{Unprivileged: &UnprivilegedFeatures{
+						KeyCtl: util.Pointer(false)}}},
+					currentConfig: ConfigLXC{Features: featuresUnprivileged(true)},
+					output:        map[string]any{"features": "mknod=1,fuse=1,nesting=1"}},
+				{name: `NFS false Privileged`,
+					config: ConfigLXC{Features: &LxcFeatures{Privileged: &PrivilegedFeatures{
+						NFS: util.Pointer(false)}}},
+					currentConfig: ConfigLXC{Features: featuresPrivileged(true)},
+					output:        map[string]any{"features": "mknod=1,fuse=1,mount=cifs,nesting=1"}},
+				{name: `SMB false Privileged`,
+					config: ConfigLXC{Features: &LxcFeatures{Privileged: &PrivilegedFeatures{
+						SMB: util.Pointer(false)}}},
+					currentConfig: ConfigLXC{Features: featuresPrivileged(true)},
+					output:        map[string]any{"features": "mknod=1,fuse=1,mount=nfs,nesting=1"}},
+				{name: `Nesting false Privileged`,
+					config: ConfigLXC{Features: &LxcFeatures{Privileged: &PrivilegedFeatures{
+						Nesting: util.Pointer(false)}}},
+					currentConfig: ConfigLXC{Features: featuresPrivileged(true)},
+					output:        map[string]any{"features": "mknod=1,fuse=1,mount=nfs;cifs"}},
+				{name: `Nesting false Unprivileged`,
+					config: ConfigLXC{Features: &LxcFeatures{Unprivileged: &UnprivilegedFeatures{
+						Nesting: util.Pointer(false)}}},
+					currentConfig: ConfigLXC{Features: featuresUnprivileged(true)},
+					output:        map[string]any{"features": "mknod=1,fuse=1,keyctl=1"}},
+				{name: `delete Privileged`,
+					config: ConfigLXC{Features: featuresPrivileged(false)},
+					currentConfig: ConfigLXC{Features: &LxcFeatures{Privileged: &PrivilegedFeatures{
+						CreateDeviceNodes: util.Pointer(true),
+						FUSE:              util.Pointer(false),
+						NFS:               util.Pointer(false),
+						Nesting:           util.Pointer(true),
+						SMB:               util.Pointer(true)}}},
+					output: map[string]any{"delete": "features"}},
+				{name: `delete Unprivileged`,
+					config: ConfigLXC{Features: featuresUnprivileged(false)},
+					currentConfig: ConfigLXC{Features: &LxcFeatures{Unprivileged: &UnprivilegedFeatures{
 						CreateDeviceNodes: util.Pointer(true),
 						FUSE:              util.Pointer(false),
 						KeyCtl:            util.Pointer(true),
-						NFS:               util.Pointer(false),
-						Nesting:           util.Pointer(true),
-						SMB:               util.Pointer(true)}},
+						Nesting:           util.Pointer(true)}}},
 					output: map[string]any{"delete": "features"}},
-				{name: `delete no effect nil`,
-					config:        ConfigLXC{Features: feature(false)},
+				{name: `delete no effect nil Privileged`,
+					config:        ConfigLXC{Features: featuresPrivileged(false)},
 					currentConfig: ConfigLXC{Features: nil},
 					output:        map[string]any{}},
-				{name: `same true`,
-					config:        ConfigLXC{Features: feature(true)},
-					currentConfig: ConfigLXC{Features: feature(true)},
+				{name: `delete no effect nil Unprivileged`,
+					config:        ConfigLXC{Features: featuresUnprivileged(false)},
+					currentConfig: ConfigLXC{Features: nil},
 					output:        map[string]any{}},
-				{name: `same true`,
-					config:        ConfigLXC{Features: feature(false)},
-					currentConfig: ConfigLXC{Features: feature(false)},
+				{name: `same false Privileged`,
+					config:        ConfigLXC{Features: featuresPrivileged(false)},
+					currentConfig: ConfigLXC{Features: featuresPrivileged(false)},
+					output:        map[string]any{}},
+				{name: `same false Unprivileged`,
+					config:        ConfigLXC{Features: featuresUnprivileged(false)},
+					currentConfig: ConfigLXC{Features: featuresUnprivileged(false)},
+					output:        map[string]any{}},
+				{name: `same true Privileged`,
+					config:        ConfigLXC{Features: featuresPrivileged(true)},
+					currentConfig: ConfigLXC{Features: featuresPrivileged(true)},
+					output:        map[string]any{}},
+				{name: `same true Unprivileged`,
+					config:        ConfigLXC{Features: featuresUnprivileged(true)},
+					currentConfig: ConfigLXC{Features: featuresUnprivileged(true)},
 					output:        map[string]any{}}}},
 		{category: `ID`,
 			create: []test{
@@ -1155,6 +1229,68 @@ func Test_ConfigLXC_Validate(t *testing.T) {
 							CreateOptions: &LxcCreateOptions{
 								OsTemplate: &LxcTemplate{Storage: "local"}}},
 						err: errors.New(LxcTemplate_Error_FileMissing)}}}},
+		{category: `Features`,
+			valid: testType{
+				create: []test{
+					{name: `privileged`,
+						input: baseConfig(ConfigLXC{Privileged: util.Pointer(true),
+							Features: &LxcFeatures{
+								Privileged: &PrivilegedFeatures{}}})},
+					{name: `unprivileged`,
+						input: baseConfig(ConfigLXC{Privileged: util.Pointer(false),
+							Features: &LxcFeatures{
+								Unprivileged: &UnprivilegedFeatures{}}})},
+				},
+				update: []test{
+					{name: `privileged`,
+						input: baseConfig(ConfigLXC{
+							Features: &LxcFeatures{
+								Privileged: &PrivilegedFeatures{}}}),
+						current: &ConfigLXC{Privileged: util.Pointer(true)}},
+					{name: `unprivileged`,
+						input: baseConfig(ConfigLXC{
+							Features: &LxcFeatures{
+								Unprivileged: &UnprivilegedFeatures{}}}),
+						current: &ConfigLXC{Privileged: util.Pointer(false)},
+					},
+				},
+			},
+			invalid: testType{
+				create: []test{
+					{name: `priviledge default errors.New(LxcFeatures_Error_PrivilegedInUnprivileged)`,
+						input: baseConfig(ConfigLXC{Features: &LxcFeatures{
+							Privileged: &PrivilegedFeatures{}}}),
+						err: errors.New(LxcFeatures_Error_PrivilegedInUnprivileged)},
+					{name: `errors.New(LxcFeatures_Error_PrivilegedInUnprivileged)`,
+						input: baseConfig(ConfigLXC{Privileged: util.Pointer(false),
+							Features: &LxcFeatures{
+								Privileged: &PrivilegedFeatures{}}}),
+						err: errors.New(LxcFeatures_Error_PrivilegedInUnprivileged)},
+					{name: `errors.New(LxcFeatures_Error_UnprivilegedInPrivileged)`,
+						input: baseConfig(ConfigLXC{Privileged: util.Pointer(true),
+							Features: &LxcFeatures{
+								Unprivileged: &UnprivilegedFeatures{}}}),
+						err: errors.New(LxcFeatures_Error_UnprivilegedInPrivileged)}},
+				createUpdate: []test{
+					{name: `errors.New(LxcFeatures_Error_MutuallyExclusive)`,
+						input: baseConfig(ConfigLXC{Features: &LxcFeatures{
+							Privileged:   &PrivilegedFeatures{},
+							Unprivileged: &UnprivilegedFeatures{}}}),
+						current: &ConfigLXC{Privileged: util.Pointer(false)},
+						err:     errors.New(LxcFeatures_Error_MutuallyExclusive)}},
+				update: []test{
+					{name: `errors.New(LxcFeatures_Error_PrivilegedInUnprivileged)`,
+						input: ConfigLXC{Features: &LxcFeatures{
+							Privileged: &PrivilegedFeatures{}}},
+						current: &ConfigLXC{Privileged: util.Pointer(false)},
+						err:     errors.New(LxcFeatures_Error_PrivilegedInUnprivileged)},
+					{name: `errors.New(LxcFeatures_Error_UnprivilegedInPrivileged)`,
+						input: ConfigLXC{Features: &LxcFeatures{
+							Unprivileged: &UnprivilegedFeatures{}}},
+						current: &ConfigLXC{Privileged: util.Pointer(true)},
+						err:     errors.New(LxcFeatures_Error_UnprivilegedInPrivileged)}},
+			},
+		},
 		{category: `ID`,
 			valid: testType{
 				createUpdate: []test{
@@ -1634,78 +1770,108 @@ func Test_RawConfigLXC_ALL(t *testing.T) {
 						SearchDomain: util.Pointer("example.com")}})}}},
 		{category: `Features`,
 			tests: []test{
-				{name: `CreateDeviceNodes`,
-					input: map[string]any{"features": "mknod=1"},
-					output: baseConfig(ConfigLXC{Features: &LxcFeatures{
+				{name: `CreateDeviceNodes Privileged`,
+					input: map[string]any{"features": string("mknod=1")},
+					output: baseConfig(ConfigLXC{Features: &LxcFeatures{Privileged: &PrivilegedFeatures{
 						CreateDeviceNodes: util.Pointer(true),
 						FUSE:              util.Pointer(false),
-						KeyCtl:            util.Pointer(false),
 						NFS:               util.Pointer(false),
 						Nesting:           util.Pointer(false),
-						SMB:               util.Pointer(false)}})},
-				{name: `FUSE`,
-					input: map[string]any{"features": "fuse=1"},
-					output: baseConfig(ConfigLXC{Features: &LxcFeatures{
+						SMB:               util.Pointer(false)}}})},
+				{name: `CreateDeviceNodes Unrivileged`,
+					input: map[string]any{
+						"features":     string("mknod=1"),
+						"unprivileged": float64(1)},
+					output: baseConfig(ConfigLXC{
+						Features: &LxcFeatures{Unprivileged: &UnprivilegedFeatures{
+							CreateDeviceNodes: util.Pointer(true),
+							FUSE:              util.Pointer(false),
+							KeyCtl:            util.Pointer(false),
+							Nesting:           util.Pointer(false)}},
+						Privileged: util.Pointer(false)})},
+				{name: `FUSE Privileged`,
+					input: map[string]any{"features": string("fuse=1")},
+					output: baseConfig(ConfigLXC{Features: &LxcFeatures{Privileged: &PrivilegedFeatures{
 						CreateDeviceNodes: util.Pointer(false),
 						FUSE:              util.Pointer(true),
-						KeyCtl:            util.Pointer(false),
 						NFS:               util.Pointer(false),
 						Nesting:           util.Pointer(false),
-						SMB:               util.Pointer(false)}})},
-				{name: `KeyCtl`,
-					input: map[string]any{"features": "keyctl=1"},
-					output: baseConfig(ConfigLXC{Features: &LxcFeatures{
+						SMB:               util.Pointer(false)}}})},
+				{name: `FUSE Unrivileged`,
+					input: map[string]any{
+						"features":     string("fuse=1"),
+						"unprivileged": float64(1)},
+					output: baseConfig(ConfigLXC{
+						Features: &LxcFeatures{Unprivileged: &UnprivilegedFeatures{
+							CreateDeviceNodes: util.Pointer(false),
+							FUSE:              util.Pointer(true),
+							KeyCtl:            util.Pointer(false),
+							Nesting:           util.Pointer(false)}},
+						Privileged: util.Pointer(false)})},
+				{name: `KeyCtl Unrivileged`,
+					input: map[string]any{
+						"features":     string("keyctl=1"),
+						"unprivileged": float64(1)},
+					output: baseConfig(ConfigLXC{
+						Features: &LxcFeatures{Unprivileged: &UnprivilegedFeatures{
+							CreateDeviceNodes: util.Pointer(false),
+							FUSE:              util.Pointer(false),
+							KeyCtl:            util.Pointer(true),
+							Nesting:           util.Pointer(false)}},
+						Privileged: util.Pointer(false)})},
+				{name: `NFS Privileged`,
+					input: map[string]any{"features": string("mount=nfs")},
+					output: baseConfig(ConfigLXC{Features: &LxcFeatures{Privileged: &PrivilegedFeatures{
 						CreateDeviceNodes: util.Pointer(false),
 						FUSE:              util.Pointer(false),
-						KeyCtl:            util.Pointer(true),
-						NFS:               util.Pointer(false),
-						Nesting:           util.Pointer(false),
-						SMB:               util.Pointer(false)}})},
-				{name: `NFS`,
-					input: map[string]any{"features": "mount=nfs"},
-					output: baseConfig(ConfigLXC{Features: &LxcFeatures{
-						CreateDeviceNodes: util.Pointer(false),
-						FUSE:              util.Pointer(false),
-						KeyCtl:            util.Pointer(false),
 						NFS:               util.Pointer(true),
 						Nesting:           util.Pointer(false),
-						SMB:               util.Pointer(false)}})},
-				{name: `NFS and SMB`,
-					input: map[string]any{"features": "mount=nfs;cifs"},
-					output: baseConfig(ConfigLXC{Features: &LxcFeatures{
+						SMB:               util.Pointer(false)}}})},
+				{name: `NFS and SMB Privileged`,
+					input: map[string]any{
+						"features":     string("mount=nfs;cifs"),
+						"unprivileged": float64(0)},
+					output: baseConfig(ConfigLXC{Features: &LxcFeatures{Privileged: &PrivilegedFeatures{
 						CreateDeviceNodes: util.Pointer(false),
 						FUSE:              util.Pointer(false),
-						KeyCtl:            util.Pointer(false),
 						NFS:               util.Pointer(true),
 						Nesting:           util.Pointer(false),
-						SMB:               util.Pointer(true)}})},
-				{name: `Nesting`,
-					input: map[string]any{"features": "nesting=1"},
-					output: baseConfig(ConfigLXC{Features: &LxcFeatures{
+						SMB:               util.Pointer(true)}}})},
+				{name: `Nesting Privileged`,
+					input: map[string]any{"features": string("nesting=1")},
+					output: baseConfig(ConfigLXC{Features: &LxcFeatures{Privileged: &PrivilegedFeatures{
 						CreateDeviceNodes: util.Pointer(false),
 						FUSE:              util.Pointer(false),
-						KeyCtl:            util.Pointer(false),
 						NFS:               util.Pointer(false),
 						Nesting:           util.Pointer(true),
-						SMB:               util.Pointer(false)}})},
-				{name: `SMB`,
-					input: map[string]any{"features": "mount=cifs"},
-					output: baseConfig(ConfigLXC{Features: &LxcFeatures{
+						SMB:               util.Pointer(false)}}})},
+				{name: `Nesting Unrivileged`,
+					input: map[string]any{
+						"features":     string("nesting=1"),
+						"unprivileged": float64(1)},
+					output: baseConfig(ConfigLXC{
+						Features: &LxcFeatures{Unprivileged: &UnprivilegedFeatures{
+							CreateDeviceNodes: util.Pointer(false),
+							FUSE:              util.Pointer(false),
+							KeyCtl:            util.Pointer(false),
+							Nesting:           util.Pointer(true)}},
+						Privileged: util.Pointer(false)})},
+				{name: `SMB Privileged`,
+					input: map[string]any{"features": string("mount=cifs")},
+					output: baseConfig(ConfigLXC{Features: &LxcFeatures{Privileged: &PrivilegedFeatures{
 						CreateDeviceNodes: util.Pointer(false),
 						FUSE:              util.Pointer(false),
-						KeyCtl:            util.Pointer(false),
 						NFS:               util.Pointer(false),
 						Nesting:           util.Pointer(false),
-						SMB:               util.Pointer(true)}})},
-				{name: `SMB and NFS`,
-					input: map[string]any{"features": "mount=cifs;nfs"},
-					output: baseConfig(ConfigLXC{Features: &LxcFeatures{
+						SMB:               util.Pointer(true)}}})},
+				{name: `SMB and NFS Privileged`,
+					input: map[string]any{"features": string("mount=cifs;nfs")},
+					output: baseConfig(ConfigLXC{Features: &LxcFeatures{Privileged: &PrivilegedFeatures{
 						CreateDeviceNodes: util.Pointer(false),
 						FUSE:              util.Pointer(false),
-						KeyCtl:            util.Pointer(false),
 						NFS:               util.Pointer(true),
 						Nesting:           util.Pointer(false),
-						SMB:               util.Pointer(true)}})}}},
+						SMB:               util.Pointer(true)}}})}}},
 		{category: `ID`,
 			tests: []test{
 				{name: `set`,

--- a/proxmox/config_lxc_new_test.go
+++ b/proxmox/config_lxc_new_test.go
@@ -1778,7 +1778,7 @@ func Test_RawConfigLXC_ALL(t *testing.T) {
 						NFS:               util.Pointer(false),
 						Nesting:           util.Pointer(false),
 						SMB:               util.Pointer(false)}}})},
-				{name: `CreateDeviceNodes Unrivileged`,
+				{name: `CreateDeviceNodes Unprivileged`,
 					input: map[string]any{
 						"features":     string("mknod=1"),
 						"unprivileged": float64(1)},
@@ -1797,7 +1797,7 @@ func Test_RawConfigLXC_ALL(t *testing.T) {
 						NFS:               util.Pointer(false),
 						Nesting:           util.Pointer(false),
 						SMB:               util.Pointer(false)}}})},
-				{name: `FUSE Unrivileged`,
+				{name: `FUSE Unprivileged`,
 					input: map[string]any{
 						"features":     string("fuse=1"),
 						"unprivileged": float64(1)},
@@ -1808,7 +1808,7 @@ func Test_RawConfigLXC_ALL(t *testing.T) {
 							KeyCtl:            util.Pointer(false),
 							Nesting:           util.Pointer(false)}},
 						Privileged: util.Pointer(false)})},
-				{name: `KeyCtl Unrivileged`,
+				{name: `KeyCtl Unprivileged`,
 					input: map[string]any{
 						"features":     string("keyctl=1"),
 						"unprivileged": float64(1)},
@@ -1845,7 +1845,7 @@ func Test_RawConfigLXC_ALL(t *testing.T) {
 						NFS:               util.Pointer(false),
 						Nesting:           util.Pointer(true),
 						SMB:               util.Pointer(false)}}})},
-				{name: `Nesting Unrivileged`,
+				{name: `Nesting Unprivileged`,
 					input: map[string]any{
 						"features":     string("nesting=1"),
 						"unprivileged": float64(1)},


### PR DESCRIPTION
Make the privilege of an LXC guest default to false when none specified.
Fix panic when `BootMount` is `nil`.
Split LXC features in privileged and unprivileged section, better reflecting which options are available.