### PR TITLE
Lxc SHA1

### DIFF
--- a/proxmox/config_group.go
+++ b/proxmox/config_group.go
@@ -69,6 +69,7 @@ func (config ConfigGroup) Set(ctx context.Context, client *Client) (err error) {
 
 // Updates the specified group
 func (config ConfigGroup) Update(ctx context.Context, client *Client) error {
+	// TODO add digest during update to check if the config has changed
 	config.Validate(false)
 	params := config.mapToApiValues(true)
 	err := client.Put(ctx, params, "/access/groups/"+string(config.Name))

--- a/proxmox/config_pool.go
+++ b/proxmox/config_pool.go
@@ -147,6 +147,7 @@ func (config ConfigPool) SetNoCheck(ctx context.Context, c *Client) error {
 }
 
 func (config ConfigPool) Update(ctx context.Context, c *Client) error {
+	// TODO add digest during update to check if the config has changed
 	if c == nil {
 		return errors.New(Client_Error_Nil)
 	}

--- a/proxmox/config_qemu.go
+++ b/proxmox/config_qemu.go
@@ -513,6 +513,7 @@ func (ConfigQemu) mapToStruct(vmr *VmRef, params map[string]interface{}) (*Confi
 }
 
 func (config ConfigQemu) Update(ctx context.Context, rebootIfNeeded bool, vmr *VmRef, client *Client) (rebootRequired bool, err error) {
+	// TODO add digest during update to check if the config has changed
 	// currentConfig will be mutated
 	currentConfig, err := NewConfigQemuFromApi(ctx, vmr, client)
 	if err != nil {

--- a/proxmox/config_user.go
+++ b/proxmox/config_user.go
@@ -150,6 +150,7 @@ func (config *ConfigUser) SetUser(ctx context.Context, userId UserID, password U
 }
 
 func (config ConfigUser) UpdateUser(ctx context.Context, client *Client) (err error) {
+	// TODO add digest during update to check if the config has changed
 	params := config.mapToApiValues(false)
 	err = client.Put(ctx, params, "/access/users/"+config.User.String())
 	if err != nil {

--- a/proxmox/type_digest.go
+++ b/proxmox/type_digest.go
@@ -1,0 +1,26 @@
+package proxmox
+
+import (
+	"crypto/sha1"
+	"strconv"
+)
+
+// stores a SHA1 digest as a 40-character hexadecimal string
+type digest string
+
+func (d digest) String() string {
+	return string(d)
+}
+
+func (d digest) sha1() [sha1.Size]byte {
+	if len(d) != sha1.Size*2 {
+		return [sha1.Size]byte{}
+	}
+	var digest [sha1.Size]byte
+	for i := range sha1.Size {
+		// Convert hex to byte
+		b, _ := strconv.ParseUint(string(d[i*2])+string(d[i*2+1]), 16, 8)
+		digest[i] = byte(b)
+	}
+	return digest
+}


### PR DESCRIPTION
add a `digest` type to set the digest during update, this ensures no concurrent changes are happening.