### PR TITLE
Add missing 'EPYC-Milan-v2' cpu type

### DIFF
--- a/proxmox/config_qemu_cpu.go
+++ b/proxmox/config_qemu_cpu.go
@@ -247,6 +247,8 @@ const (
 	cpuType_AmdEPYCIBPB_Lower                 CpuType = "epycibpb"
 	CpuType_AmdEPYCMilan                      CpuType = "EPYC-Milan"
 	cpuType_AmdEPYCMilan_Lower                CpuType = "epycmilan"
+	CpuType_AmdEPYCMilanV2                    CpuType = "EPYC-Milan-v2"
+	cpuType_AmdEPYCMilanV2_Lower              CpuType = "epycmilanv2"
 	CpuType_AmdEPYCRome                       CpuType = "EPYC-Rome"
 	cpuType_AmdEPYCRome_Lower                 CpuType = "epycrome"
 	CpuType_AmdEPYCRomeV2                     CpuType = "EPYC-Rome-v2"
@@ -412,6 +414,7 @@ func (CpuType) cpuV8(cpus map[CpuType]CpuType) {
 	cpus[cpuType_IntelCascadelakeServerV5_Lower] = CpuType_IntelCascadelakeServerV5
 	cpus[cpuType_IntelCooperlake_Lower] = CpuType_IntelCooperlake
 	cpus[cpuType_IntelCooperlakeV2_Lower] = CpuType_IntelCooperlakeV2
+	cpus[cpuType_AmdEPYCMilanV2_Lower] = CpuType_AmdEPYCMilanV2
 	cpus[cpuType_AmdEPYCRomeV2_Lower] = CpuType_AmdEPYCRomeV2
 	cpus[cpuType_AmdEPYCV3_Lower] = CpuType_AmdEPYCV3
 	cpus[cpuType_IntelIcelakeServerV3_Lower] = CpuType_IntelIcelakeServerV3


### PR DESCRIPTION
While initiating our infrastructure, I noticed this CPU-Type missing.
It is documented in the Proxmox documenatation: https://pve.proxmox.com/pve-docs/pve-admin-guide.html#_amd_cpu_types
