### PR TITLE
fix: no error returned when no version obtained from api

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -43,7 +43,7 @@ type Client struct {
 const (
 	Client_Error_Nil            = "client may not be nil"
 	Client_Error_NotInitialized = "client not initialized"
-	CLient_Error_UnableVersion  = "unable to get version"
+	Client_Error_UnableVersion  = "unable to get version"
 )
 
 // Checks if the client is initialized and returns an error if not
@@ -2392,7 +2392,7 @@ func (Version) mapToSDK(params map[string]any) (Version, error) {
 		}
 		return version, nil
 	}
-	return Version{}, errors.New(CLient_Error_UnableVersion)
+	return Version{}, errors.New(Client_Error_UnableVersion)
 }
 
 // return the maximum version, used during testing

--- a/proxmox/client_test.go
+++ b/proxmox/client_test.go
@@ -102,7 +102,7 @@ func Test_Version_mapToSDK(t *testing.T) {
 	}{
 		{name: "unset",
 			input: map[string]any{},
-			err:   errors.New(CLient_Error_UnableVersion)},
+			err:   errors.New(Client_Error_UnableVersion)},
 		{name: "full",
 			input:  map[string]any{"version": "1.2.3"},
 			output: Version{1, 2, 3}},


### PR DESCRIPTION
Return an error when we couldn't obtain the version from the API, instead of setting the version to `0.0.0` causing weird behaviors elsewhere.

Related to: https://github.com/Telmate/terraform-provider-proxmox/issues/1350