### PR TITLE
feat: type `RawConfigQemu`

### DIFF
--- a/proxmox/config_qemu_cloudinit.go
+++ b/proxmox/config_qemu_cloudinit.go
@@ -308,8 +308,8 @@ func (config CloudInitIPv4Config) Validate() error {
 
 type CloudInitIPv6Config struct {
 	Address *IPv6CIDR    `json:"address,omitempty"`
-	DHCP    bool         `json:"dhcp,omitempty"`
 	Gateway *IPv6Address `json:"gateway,omitempty"`
+	DHCP    bool         `json:"dhcp,omitempty"`
 	SLAAC   bool         `json:"slaac,omitempty"`
 }
 

--- a/proxmox/config_qemu_cloudinit.go
+++ b/proxmox/config_qemu_cloudinit.go
@@ -24,18 +24,18 @@ const CloudInit_Error_UpgradePackagesPre8 = "upgradePackages is only available i
 func (config CloudInit) mapToAPI(current *CloudInit, params map[string]interface{}, version Version) (delete string) {
 	if current != nil { // Update
 		if config.Custom != nil {
-			params["cicustom"] = config.Custom.mapToAPI(current.Custom)
+			params[qemuApiKeyCloudInitCustom] = config.Custom.mapToAPI(current.Custom)
 		}
 		if config.Username != nil {
 			tmp := *config.Username
 			if tmp != "" {
-				params["ciuser"] = *config.Username
+				params[qemuApiKeyCloudInitUser] = *config.Username
 			} else {
-				delete += ",ciuser"
+				delete += "," + qemuApiKeyCloudInitUser
 			}
 		}
 		if config.UserPassword != nil && *config.UserPassword == "" {
-			delete += ",cipassword"
+			delete += "," + qemuApiKeyCloudInitPassword
 		}
 		if config.DNS != nil {
 			if current.DNS != nil {
@@ -49,20 +49,20 @@ func (config CloudInit) mapToAPI(current *CloudInit, params map[string]interface
 			if len(*config.PublicSSHkeys) > 0 {
 				tmpKey := sshKeyUrlEncode(*config.PublicSSHkeys)
 				if tmpKey != "" {
-					params["sshkeys"] = tmpKey
+					params[qemuApiKeyCloudInitSshKeys] = tmpKey
 				} else {
-					delete += ",sshkeys"
+					delete += "," + qemuApiKeyCloudInitSshKeys
 				}
 			} else {
-				delete += ",sshkeys"
+				delete += "," + qemuApiKeyCloudInitSshKeys
 			}
 		}
 	} else { // Create
 		if config.Custom != nil {
-			params["cicustom"] = config.Custom.mapToAPI(nil)
+			params[qemuApiKeyCloudInitCustom] = config.Custom.mapToAPI(nil)
 		}
 		if config.Username != nil && *config.Username != "" {
-			params["ciuser"] = *config.Username
+			params[qemuApiKeyCloudInitUser] = *config.Username
 		}
 		if config.DNS != nil {
 			config.DNS.mapToApiCreate(params)
@@ -70,51 +70,51 @@ func (config CloudInit) mapToAPI(current *CloudInit, params map[string]interface
 		config.NetworkInterfaces.mapToAPI(nil, params)
 		if config.PublicSSHkeys != nil && len(*config.PublicSSHkeys) > 0 {
 			if tmpKey := sshKeyUrlEncode(*config.PublicSSHkeys); tmpKey != "" {
-				params["sshkeys"] = tmpKey
+				params[qemuApiKeyCloudInitSshKeys] = tmpKey
 			}
 		}
 	}
 	// Shared
 	if config.UpgradePackages != nil && !version.Smaller(Version{Major: 8}) {
-		params["ciupgrade"] = Btoi(*config.UpgradePackages)
+		params[qemuApiKeyCloudInitUpgrade] = Btoi(*config.UpgradePackages)
 	}
 	if config.UserPassword != nil && *config.UserPassword != "" {
-		params["cipassword"] = *config.UserPassword
+		params[qemuApiKeyCloudInitPassword] = *config.UserPassword
 	}
 	return
 }
 
-func (CloudInit) mapToSDK(params map[string]interface{}) *CloudInit {
+func (raw RawConfigQemu) CloudInit() *CloudInit {
 	ci := CloudInit{}
 	var set bool
-	if v, isSet := params["cicustom"]; isSet {
+	if v, isSet := raw[qemuApiKeyCloudInitCustom]; isSet {
 		ci.Custom = CloudInitCustom{}.mapToSDK(v.(string))
 		set = true
 	}
-	if v, isSet := params["cipassword"]; isSet {
+	if v, isSet := raw[qemuApiKeyCloudInitPassword]; isSet {
 		ci.UserPassword = util.Pointer(v.(string))
 		set = true
 	}
-	if v, isSet := params["ciupgrade"]; isSet {
+	if v, isSet := raw[qemuApiKeyCloudInitUpgrade]; isSet {
 		ci.UpgradePackages = util.Pointer(Itob(int(v.(float64))))
 		set = true
 	}
-	if v, isSet := params["ciuser"]; isSet {
+	if v, isSet := raw[qemuApiKeyCloudInitUser]; isSet {
 		tmp := v.(string)
 		if tmp != "" && tmp != " " {
 			ci.Username = &tmp
 			set = true
 		}
 	}
-	if v, isSet := params["sshkeys"]; isSet {
+	if v, isSet := raw[qemuApiKeyCloudInitSshKeys]; isSet {
 		ci.PublicSSHkeys = util.Pointer(sshKeyUrlDecode(v.(string)))
 		set = true
 	}
-	if v := (GuestDNS{}.mapToSDK(params)); v != nil {
+	if v := (GuestDNS{}.mapToSDK(raw)); v != nil {
 		ci.DNS = v
 		set = true
 	}
-	ci.NetworkInterfaces = CloudInitNetworkInterfaces{}.mapToSDK(params)
+	ci.NetworkInterfaces = CloudInitNetworkInterfaces{}.mapToSDK(raw)
 	if set || len(ci.NetworkInterfaces) > 0 {
 		return &ci
 	}

--- a/proxmox/config_qemu_disk.go
+++ b/proxmox/config_qemu_disk.go
@@ -1073,17 +1073,21 @@ func (storages QemuStorages) mapToApiValues(currentStorages QemuStorages, vmID, 
 	return delete
 }
 
-func (QemuStorages) mapToStruct(params map[string]interface{}, linkedVmId *GuestID) *QemuStorages {
+func (raw RawConfigQemu) Disks() (disks *QemuStorages, linkedID *GuestID) {
+	tmpLinkedID := util.Pointer(GuestID(0))
 	storage := QemuStorages{
-		Ide:    QemuIdeDisks{}.mapToStruct(params, linkedVmId),
-		Sata:   QemuSataDisks{}.mapToStruct(params, linkedVmId),
-		Scsi:   QemuScsiDisks{}.mapToStruct(params, linkedVmId),
-		VirtIO: QemuVirtIODisks{}.mapToStruct(params, linkedVmId),
+		Ide:    raw.disksIde(tmpLinkedID),
+		Sata:   raw.disksSata(tmpLinkedID),
+		Scsi:   raw.disksSCSI(tmpLinkedID),
+		VirtIO: raw.disksVirtIO(tmpLinkedID),
+	}
+	if *tmpLinkedID != 0 {
+		linkedID = tmpLinkedID
 	}
 	if storage.Ide != nil || storage.Sata != nil || storage.Scsi != nil || storage.VirtIO != nil {
-		return &storage
+		return &storage, linkedID
 	}
-	return nil
+	return nil, nil
 }
 
 // mark disk that need to be moved or resized

--- a/proxmox/config_qemu_disk.go
+++ b/proxmox/config_qemu_disk.go
@@ -186,22 +186,15 @@ func (cloudInit QemuCloudInitDisk) Validate() error {
 }
 
 type qemuDisk struct {
-	AsyncIO    QemuDiskAsyncIO
-	Backup     bool
-	Bandwidth  QemuDiskBandwidth
-	Cache      QemuDiskCache
-	Discard    bool
-	Disk       bool // true = disk, false = passthrough
-	EmulateSSD bool // Only set for ide,sata,scsi
+	AsyncIO   QemuDiskAsyncIO
+	Bandwidth QemuDiskBandwidth
+	Cache     QemuDiskCache
 	// TODO custom type
 	File            string         // Only set for Passthrough.
 	fileSyntax      diskSyntaxEnum // private enum to determine the syntax of the file path, as this changes depending on the type of backing storage. ie nfs, lvm, local, etc.
 	Format          QemuDiskFormat // Only set for Disk
 	Id              uint           // Only set for Disk
-	IOThread        bool           // Only set for scsi,virtio
 	LinkedDiskId    *GuestID       // Only set for Disk
-	ReadOnly        bool           // Only set for scsi,virtio
-	Replicate       bool
 	Serial          QemuDiskSerial
 	SizeInKibibytes QemuDiskSize
 	// TODO custom type
@@ -209,6 +202,13 @@ type qemuDisk struct {
 	Type          qemuDiskType
 	WorldWideName QemuWorldWideName
 	ImportFrom    string
+	Backup        bool
+	Discard       bool
+	Disk          bool // true = disk, false = passthrough
+	EmulateSSD    bool // Only set for ide,sata,scsi
+	IOThread      bool // Only set for scsi,virtio
+	ReadOnly      bool // Only set for scsi,virtio
+	Replicate     bool
 }
 
 const (

--- a/proxmox/config_qemu_disk_ide.go
+++ b/proxmox/config_qemu_disk_ide.go
@@ -68,7 +68,7 @@ func (q QemuIdeDisks) listCloudInitDisk() string {
 	return ""
 }
 
-func (disks QemuIdeDisks) mapToApiValues(currentDisks *QemuIdeDisks, vmID, LinkedVmId GuestID, params map[string]interface{}, delete string) string {
+func (disks QemuIdeDisks) mapToApiValues(currentDisks *QemuIdeDisks, vmID GuestID, LinkedVmId GuestID, params map[string]interface{}, delete string) string {
 	tmpCurrentDisks := QemuIdeDisks{}
 	if currentDisks != nil {
 		tmpCurrentDisks = *currentDisks
@@ -93,23 +93,23 @@ func (disks QemuIdeDisks) mapToIntMap() map[uint8]*QemuIdeStorage {
 	}
 }
 
-func (QemuIdeDisks) mapToStruct(params map[string]interface{}, linkedVmId *GuestID) *QemuIdeDisks {
+func (raw RawConfigQemu) disksIde(linkedVmId *GuestID) *QemuIdeDisks {
 	disks := QemuIdeDisks{}
 	var structPopulated bool
-	if _, isSet := params["ide0"]; isSet {
-		disks.Disk_0 = QemuIdeStorage{}.mapToStruct(params["ide0"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskIde+"0"]; isSet {
+		disks.Disk_0 = QemuIdeStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["ide1"]; isSet {
-		disks.Disk_1 = QemuIdeStorage{}.mapToStruct(params["ide1"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskIde+"1"]; isSet {
+		disks.Disk_1 = QemuIdeStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["ide2"]; isSet {
-		disks.Disk_2 = QemuIdeStorage{}.mapToStruct(params["ide2"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskIde+"2"]; isSet {
+		disks.Disk_2 = QemuIdeStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["ide3"]; isSet {
-		disks.Disk_3 = QemuIdeStorage{}.mapToStruct(params["ide3"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskIde+"3"]; isSet {
+		disks.Disk_3 = QemuIdeStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
 	if structPopulated {
@@ -142,7 +142,7 @@ func (disks QemuIdeDisks) selectInitialResize(currentDisks *QemuIdeDisks) (resiz
 			aaa := diskMap[i].Disk.SizeInKibibytes % gibibyte
 			_ = aaa
 			resize = append(resize, qemuDiskResize{
-				Id:              QemuDiskId("ide" + strconv.Itoa(int(i))),
+				Id:              QemuDiskId(qemuPrefixApiKeyDiskIde + strconv.Itoa(int(i))),
 				SizeInKibibytes: diskMap[i].Disk.SizeInKibibytes,
 			})
 		}

--- a/proxmox/config_qemu_disk_ide.go
+++ b/proxmox/config_qemu_disk_ide.go
@@ -7,21 +7,21 @@ import (
 
 type QemuIdeDisk struct {
 	AsyncIO         QemuDiskAsyncIO   `json:"asyncio,omitempty"`
-	Backup          bool              `json:"backup"`
 	Bandwidth       QemuDiskBandwidth `json:"bandwidth,omitempty"`
 	Cache           QemuDiskCache     `json:"cache,omitempty"`
-	Discard         bool              `json:"discard"`
-	EmulateSSD      bool              `json:"emulatessd"`
 	Format          QemuDiskFormat    `json:"format"`
 	Id              uint              `json:"id"`     //Id is only returned and setting it has no effect
 	LinkedDiskId    *GuestID          `json:"linked"` //LinkedClone is only returned and setting it has no effect
-	Replicate       bool              `json:"replicate"`
 	Serial          QemuDiskSerial    `json:"serial,omitempty"`
 	SizeInKibibytes QemuDiskSize      `json:"size"`
 	Storage         string            `json:"storage"`
 	syntax          diskSyntaxEnum
 	WorldWideName   QemuWorldWideName `json:"wwn"`
 	ImportFrom      string            `json:"import_from,omitempty"`
+	Backup          bool              `json:"backup"`
+	Discard         bool              `json:"discard"`
+	EmulateSSD      bool              `json:"emulatessd"`
+	Replicate       bool              `json:"replicate"`
 }
 
 func (disk *QemuIdeDisk) convertDataStructure() *qemuDisk {
@@ -175,16 +175,16 @@ func (disks QemuIdeDisks) validate() (numberOfCloudInitDevices uint8, err error)
 
 type QemuIdePassthrough struct {
 	AsyncIO         QemuDiskAsyncIO   `json:"asyncio,omitempty"`
-	Backup          bool              `json:"backup"`
 	Bandwidth       QemuDiskBandwidth `json:"bandwidth,omitempty"`
 	Cache           QemuDiskCache     `json:"cache,omitempty"`
-	Discard         bool              `json:"discard"`
-	EmulateSSD      bool              `json:"emulatessd"`
 	File            string            `json:"file"`
-	Replicate       bool              `json:"replicate"`
 	Serial          QemuDiskSerial    `json:"serial,omitempty"`
 	SizeInKibibytes QemuDiskSize      `json:"size"` //size is only returned and setting it has no effect
 	WorldWideName   QemuWorldWideName `json:"wwn"`
+	Backup          bool              `json:"backup"`
+	Discard         bool              `json:"discard"`
+	EmulateSSD      bool              `json:"emulatessd"`
+	Replicate       bool              `json:"replicate"`
 }
 
 func (passthrough *QemuIdePassthrough) convertDataStructure() *qemuDisk {

--- a/proxmox/config_qemu_disk_sata.go
+++ b/proxmox/config_qemu_disk_sata.go
@@ -64,7 +64,7 @@ func (q QemuSataDisks) listCloudInitDisk() string {
 	diskMap := q.mapToIntMap()
 	for i := range diskMap {
 		if diskMap[i] != nil && diskMap[i].CloudInit != nil {
-			return "sata" + strconv.Itoa(int(i))
+			return qemuPrefixApiKeyDiskSata + strconv.Itoa(int(i))
 		}
 	}
 	return ""
@@ -97,31 +97,31 @@ func (disks QemuSataDisks) mapToIntMap() map[uint8]*QemuSataStorage {
 	}
 }
 
-func (QemuSataDisks) mapToStruct(params map[string]interface{}, linkedVmId *GuestID) *QemuSataDisks {
+func (raw RawConfigQemu) disksSata(linkedVmId *GuestID) *QemuSataDisks {
 	disks := QemuSataDisks{}
 	var structPopulated bool
-	if _, isSet := params["sata0"]; isSet {
-		disks.Disk_0 = QemuSataStorage{}.mapToStruct(params["sata0"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSata+"0"]; isSet {
+		disks.Disk_0 = QemuSataStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["sata1"]; isSet {
-		disks.Disk_1 = QemuSataStorage{}.mapToStruct(params["sata1"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSata+"1"]; isSet {
+		disks.Disk_1 = QemuSataStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["sata2"]; isSet {
-		disks.Disk_2 = QemuSataStorage{}.mapToStruct(params["sata2"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSata+"2"]; isSet {
+		disks.Disk_2 = QemuSataStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["sata3"]; isSet {
-		disks.Disk_3 = QemuSataStorage{}.mapToStruct(params["sata3"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSata+"3"]; isSet {
+		disks.Disk_3 = QemuSataStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["sata4"]; isSet {
-		disks.Disk_4 = QemuSataStorage{}.mapToStruct(params["sata4"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSata+"4"]; isSet {
+		disks.Disk_4 = QemuSataStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["sata5"]; isSet {
-		disks.Disk_5 = QemuSataStorage{}.mapToStruct(params["sata5"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSata+"5"]; isSet {
+		disks.Disk_5 = QemuSataStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
 	if structPopulated {

--- a/proxmox/config_qemu_disk_sata.go
+++ b/proxmox/config_qemu_disk_sata.go
@@ -7,21 +7,21 @@ import (
 
 type QemuSataDisk struct {
 	AsyncIO         QemuDiskAsyncIO   `json:"asyncio,omitempty"`
-	Backup          bool              `json:"backup"`
 	Bandwidth       QemuDiskBandwidth `json:"bandwidth,omitempty"`
 	Cache           QemuDiskCache     `json:"cache,omitempty"`
-	Discard         bool              `json:"discard"`
-	EmulateSSD      bool              `json:"emulatessd"`
 	Format          QemuDiskFormat    `json:"format"`
 	Id              uint              `json:"id"`     //Id is only returned and setting it has no effect
 	LinkedDiskId    *GuestID          `json:"linked"` //LinkedClone is only returned and setting it has no effect
-	Replicate       bool              `json:"replicate"`
 	Serial          QemuDiskSerial    `json:"serial,omitempty"`
 	SizeInKibibytes QemuDiskSize      `json:"size"`
 	Storage         string            `json:"storage"`
 	syntax          diskSyntaxEnum
 	WorldWideName   QemuWorldWideName `json:"wwn"`
 	ImportFrom      string            `json:"import_from,omitempty"`
+	Backup          bool              `json:"backup"`
+	Discard         bool              `json:"discard"`
+	EmulateSSD      bool              `json:"emulatessd"`
+	Replicate       bool              `json:"replicate"`
 }
 
 func (disk *QemuSataDisk) convertDataStructure() *qemuDisk {
@@ -185,16 +185,16 @@ func (disks QemuSataDisks) validate() (numberOfCloudInitDevices uint8, err error
 
 type QemuSataPassthrough struct {
 	AsyncIO         QemuDiskAsyncIO   `json:"asyncio,omitempty"`
-	Backup          bool              `json:"backup"`
 	Bandwidth       QemuDiskBandwidth `json:"bandwidth,omitempty"`
 	Cache           QemuDiskCache     `json:"cache,omitempty"`
-	Discard         bool              `json:"discard"`
-	EmulateSSD      bool              `json:"emulatessd"`
 	File            string            `json:"file"`
-	Replicate       bool              `json:"replicate"`
 	Serial          QemuDiskSerial    `json:"serial,omitempty"`
 	SizeInKibibytes QemuDiskSize      `json:"size"` //size is only returned and setting it has no effect
 	WorldWideName   QemuWorldWideName `json:"wwn"`
+	Backup          bool              `json:"backup"`
+	Discard         bool              `json:"discard"`
+	EmulateSSD      bool              `json:"emulatessd"`
+	Replicate       bool              `json:"replicate"`
 }
 
 func (passthrough *QemuSataPassthrough) convertDataStructure() *qemuDisk {

--- a/proxmox/config_qemu_disk_scsi.go
+++ b/proxmox/config_qemu_disk_scsi.go
@@ -93,7 +93,7 @@ func (q QemuScsiDisks) listCloudInitDisk() string {
 	diskMap := q.mapToIntMap()
 	for i := range diskMap {
 		if diskMap[i] != nil && diskMap[i].CloudInit != nil {
-			return "scsi" + strconv.Itoa(int(i))
+			return qemuPrefixApiKeyDiskSCSI + strconv.Itoa(int(i))
 		}
 	}
 	return ""
@@ -151,131 +151,131 @@ func (disks QemuScsiDisks) mapToIntMap() map[uint8]*QemuScsiStorage {
 	}
 }
 
-func (QemuScsiDisks) mapToStruct(params map[string]interface{}, linkedVmId *GuestID) *QemuScsiDisks {
+func (raw RawConfigQemu) disksSCSI(linkedVmId *GuestID) *QemuScsiDisks {
 	disks := QemuScsiDisks{}
 	var structPopulated bool
-	if _, isSet := params["scsi0"]; isSet {
-		disks.Disk_0 = QemuScsiStorage{}.mapToStruct(params["scsi0"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"0"]; isSet {
+		disks.Disk_0 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi1"]; isSet {
-		disks.Disk_1 = QemuScsiStorage{}.mapToStruct(params["scsi1"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"1"]; isSet {
+		disks.Disk_1 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi2"]; isSet {
-		disks.Disk_2 = QemuScsiStorage{}.mapToStruct(params["scsi2"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"2"]; isSet {
+		disks.Disk_2 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi3"]; isSet {
-		disks.Disk_3 = QemuScsiStorage{}.mapToStruct(params["scsi3"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"3"]; isSet {
+		disks.Disk_3 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi4"]; isSet {
-		disks.Disk_4 = QemuScsiStorage{}.mapToStruct(params["scsi4"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"4"]; isSet {
+		disks.Disk_4 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi5"]; isSet {
-		disks.Disk_5 = QemuScsiStorage{}.mapToStruct(params["scsi5"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"5"]; isSet {
+		disks.Disk_5 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi6"]; isSet {
-		disks.Disk_6 = QemuScsiStorage{}.mapToStruct(params["scsi6"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"6"]; isSet {
+		disks.Disk_6 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi7"]; isSet {
-		disks.Disk_7 = QemuScsiStorage{}.mapToStruct(params["scsi7"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"7"]; isSet {
+		disks.Disk_7 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi8"]; isSet {
-		disks.Disk_8 = QemuScsiStorage{}.mapToStruct(params["scsi8"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"8"]; isSet {
+		disks.Disk_8 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi9"]; isSet {
-		disks.Disk_9 = QemuScsiStorage{}.mapToStruct(params["scsi9"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"9"]; isSet {
+		disks.Disk_9 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi10"]; isSet {
-		disks.Disk_10 = QemuScsiStorage{}.mapToStruct(params["scsi10"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"10"]; isSet {
+		disks.Disk_10 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi11"]; isSet {
-		disks.Disk_11 = QemuScsiStorage{}.mapToStruct(params["scsi11"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"11"]; isSet {
+		disks.Disk_11 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi12"]; isSet {
-		disks.Disk_12 = QemuScsiStorage{}.mapToStruct(params["scsi12"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"12"]; isSet {
+		disks.Disk_12 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi13"]; isSet {
-		disks.Disk_13 = QemuScsiStorage{}.mapToStruct(params["scsi13"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"13"]; isSet {
+		disks.Disk_13 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi14"]; isSet {
-		disks.Disk_14 = QemuScsiStorage{}.mapToStruct(params["scsi14"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"14"]; isSet {
+		disks.Disk_14 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi15"]; isSet {
-		disks.Disk_15 = QemuScsiStorage{}.mapToStruct(params["scsi15"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"15"]; isSet {
+		disks.Disk_15 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi16"]; isSet {
-		disks.Disk_16 = QemuScsiStorage{}.mapToStruct(params["scsi16"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"16"]; isSet {
+		disks.Disk_16 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi17"]; isSet {
-		disks.Disk_17 = QemuScsiStorage{}.mapToStruct(params["scsi17"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"17"]; isSet {
+		disks.Disk_17 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi18"]; isSet {
-		disks.Disk_18 = QemuScsiStorage{}.mapToStruct(params["scsi18"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"18"]; isSet {
+		disks.Disk_18 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi19"]; isSet {
-		disks.Disk_19 = QemuScsiStorage{}.mapToStruct(params["scsi19"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"19"]; isSet {
+		disks.Disk_19 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi20"]; isSet {
-		disks.Disk_20 = QemuScsiStorage{}.mapToStruct(params["scsi20"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"20"]; isSet {
+		disks.Disk_20 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi21"]; isSet {
-		disks.Disk_21 = QemuScsiStorage{}.mapToStruct(params["scsi21"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"21"]; isSet {
+		disks.Disk_21 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi22"]; isSet {
-		disks.Disk_22 = QemuScsiStorage{}.mapToStruct(params["scsi22"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"22"]; isSet {
+		disks.Disk_22 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi23"]; isSet {
-		disks.Disk_23 = QemuScsiStorage{}.mapToStruct(params["scsi23"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"23"]; isSet {
+		disks.Disk_23 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi24"]; isSet {
-		disks.Disk_24 = QemuScsiStorage{}.mapToStruct(params["scsi24"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"24"]; isSet {
+		disks.Disk_24 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi25"]; isSet {
-		disks.Disk_25 = QemuScsiStorage{}.mapToStruct(params["scsi25"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"25"]; isSet {
+		disks.Disk_25 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi26"]; isSet {
-		disks.Disk_26 = QemuScsiStorage{}.mapToStruct(params["scsi26"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"26"]; isSet {
+		disks.Disk_26 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi27"]; isSet {
-		disks.Disk_27 = QemuScsiStorage{}.mapToStruct(params["scsi27"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"27"]; isSet {
+		disks.Disk_27 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi28"]; isSet {
-		disks.Disk_28 = QemuScsiStorage{}.mapToStruct(params["scsi28"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"28"]; isSet {
+		disks.Disk_28 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi29"]; isSet {
-		disks.Disk_29 = QemuScsiStorage{}.mapToStruct(params["scsi29"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"29"]; isSet {
+		disks.Disk_29 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["scsi30"]; isSet {
-		disks.Disk_30 = QemuScsiStorage{}.mapToStruct(params["scsi30"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskSCSI+"30"]; isSet {
+		disks.Disk_30 = QemuScsiStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
 	if structPopulated {

--- a/proxmox/config_qemu_disk_scsi.go
+++ b/proxmox/config_qemu_disk_scsi.go
@@ -7,23 +7,23 @@ import (
 
 type QemuScsiDisk struct {
 	AsyncIO         QemuDiskAsyncIO   `json:"asyncio,omitempty"`
-	Backup          bool              `json:"backup"`
 	Bandwidth       QemuDiskBandwidth `json:"bandwidth,omitempty"`
 	Cache           QemuDiskCache     `json:"cache,omitempty"`
-	Discard         bool              `json:"discard"`
-	EmulateSSD      bool              `json:"emulatessd"`
 	Format          QemuDiskFormat    `json:"format"`
-	Id              uint              `json:"id"` //Id is only returned and setting it has no effect
-	IOThread        bool              `json:"iothread"`
+	Id              uint              `json:"id"`     //Id is only returned and setting it has no effect
 	LinkedDiskId    *GuestID          `json:"linked"` //LinkedCloneId is only returned and setting it has no effect
-	ReadOnly        bool              `json:"readonly"`
-	Replicate       bool              `json:"replicate"`
 	Serial          QemuDiskSerial    `json:"serial,omitempty"`
 	SizeInKibibytes QemuDiskSize      `json:"size"`
 	Storage         string            `json:"storage"`
 	syntax          diskSyntaxEnum
 	WorldWideName   QemuWorldWideName `json:"wwn"`
 	ImportFrom      string            `json:"import_from,omitempty"`
+	Backup          bool              `json:"backup"`
+	Discard         bool              `json:"discard"`
+	EmulateSSD      bool              `json:"emulatessd"`
+	IOThread        bool              `json:"iothread"`
+	ReadOnly        bool              `json:"readonly"`
+	Replicate       bool              `json:"replicate"`
 }
 
 func (disk *QemuScsiDisk) convertDataStructure() *qemuDisk {
@@ -339,18 +339,18 @@ func (disks QemuScsiDisks) validate() (numberOfCloudInitDevices uint8, err error
 
 type QemuScsiPassthrough struct {
 	AsyncIO         QemuDiskAsyncIO   `json:"asyncio,omitempty"`
-	Backup          bool              `json:"backup"`
 	Bandwidth       QemuDiskBandwidth `json:"bandwidth,omitempty"`
 	Cache           QemuDiskCache     `json:"cache,omitempty"`
-	Discard         bool              `json:"discard"`
-	EmulateSSD      bool              `json:"emulatessd"`
 	File            string            `json:"file"`
-	IOThread        bool              `json:"iothread"`
-	ReadOnly        bool              `json:"readonly"`
-	Replicate       bool              `json:"replicate"`
 	Serial          QemuDiskSerial    `json:"serial,omitempty"`
 	SizeInKibibytes QemuDiskSize      `json:"size"` //size is only returned and setting it has no effect
 	WorldWideName   QemuWorldWideName `json:"wwn"`
+	Backup          bool              `json:"backup"`
+	Discard         bool              `json:"discard"`
+	EmulateSSD      bool              `json:"emulatessd"`
+	IOThread        bool              `json:"iothread"`
+	ReadOnly        bool              `json:"readonly"`
+	Replicate       bool              `json:"replicate"`
 }
 
 func (passthrough *QemuScsiPassthrough) convertDataStructure() *qemuDisk {

--- a/proxmox/config_qemu_disk_virtio.go
+++ b/proxmox/config_qemu_disk_virtio.go
@@ -7,22 +7,22 @@ import (
 
 type QemuVirtIODisk struct {
 	AsyncIO         QemuDiskAsyncIO   `json:"asyncio,omitempty"`
-	Backup          bool              `json:"backup"`
 	Bandwidth       QemuDiskBandwidth `json:"bandwidth,omitempty"`
 	Cache           QemuDiskCache     `json:"cache,omitempty"`
-	Discard         bool              `json:"discard"`
 	Format          QemuDiskFormat    `json:"format"`
-	Id              uint              `json:"id"` //Id is only returned and setting it has no effect
-	IOThread        bool              `json:"iothread"`
+	Id              uint              `json:"id"`     //Id is only returned and setting it has no effect
 	LinkedDiskId    *GuestID          `json:"linked"` //LinkedCloneId is only returned and setting it has no effect
-	ReadOnly        bool              `json:"readonly"`
-	Replicate       bool              `json:"replicate"`
 	Serial          QemuDiskSerial    `json:"serial,omitempty"`
 	SizeInKibibytes QemuDiskSize      `json:"size"`
 	Storage         string            `json:"storage"`
 	syntax          diskSyntaxEnum
 	WorldWideName   QemuWorldWideName `json:"wwn"`
 	ImportFrom      string            `json:"import_from,omitempty"`
+	Backup          bool              `json:"backup"`
+	Discard         bool              `json:"discard"`
+	IOThread        bool              `json:"iothread"`
+	ReadOnly        bool              `json:"readonly"`
+	Replicate       bool              `json:"replicate"`
 }
 
 func (disk *QemuVirtIODisk) convertDataStructure() *qemuDisk {
@@ -247,17 +247,17 @@ func (disks QemuVirtIODisks) validate() (numberOfCloudInitDevices uint8, err err
 
 type QemuVirtIOPassthrough struct {
 	AsyncIO         QemuDiskAsyncIO   `json:"asyncio,omitempty"`
-	Backup          bool              `json:"backup"`
 	Bandwidth       QemuDiskBandwidth `json:"bandwidth,omitempty"`
 	Cache           QemuDiskCache     `json:"cache,omitempty"`
-	Discard         bool              `json:"discard"`
 	File            string            `json:"file"`
-	IOThread        bool              `json:"iothread"`
-	ReadOnly        bool              `json:"readonly"`
-	Replicate       bool              `json:"replicate"`
 	Serial          QemuDiskSerial    `json:"serial,omitempty"`
 	SizeInKibibytes QemuDiskSize      `json:"size"` //size is only returned and setting it has no effect
 	WorldWideName   QemuWorldWideName `json:"wwn"`
+	Backup          bool              `json:"backup"`
+	Discard         bool              `json:"discard"`
+	IOThread        bool              `json:"iothread"`
+	ReadOnly        bool              `json:"readonly"`
+	Replicate       bool              `json:"replicate"`
 }
 
 func (passthrough *QemuVirtIOPassthrough) convertDataStructure() *qemuDisk {

--- a/proxmox/config_qemu_disk_virtio.go
+++ b/proxmox/config_qemu_disk_virtio.go
@@ -76,7 +76,7 @@ func (q QemuVirtIODisks) listCloudInitDisk() string {
 	diskMap := q.mapToIntMap()
 	for i := range diskMap {
 		if diskMap[i] != nil && diskMap[i].CloudInit != nil {
-			return "virtio" + strconv.Itoa(int(i))
+			return qemuPrefixApiKeyDiskVirtIO + strconv.Itoa(int(i))
 		}
 	}
 	return ""
@@ -119,71 +119,71 @@ func (disks QemuVirtIODisks) mapToIntMap() map[uint8]*QemuVirtIOStorage {
 	}
 }
 
-func (QemuVirtIODisks) mapToStruct(params map[string]interface{}, linkedVmId *GuestID) *QemuVirtIODisks {
+func (raw RawConfigQemu) disksVirtIO(linkedVmId *GuestID) *QemuVirtIODisks {
 	disks := QemuVirtIODisks{}
 	var structPopulated bool
-	if _, isSet := params["virtio0"]; isSet {
-		disks.Disk_0 = QemuVirtIOStorage{}.mapToStruct(params["virtio0"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskVirtIO+"0"]; isSet {
+		disks.Disk_0 = QemuVirtIOStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["virtio1"]; isSet {
-		disks.Disk_1 = QemuVirtIOStorage{}.mapToStruct(params["virtio1"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskVirtIO+"1"]; isSet {
+		disks.Disk_1 = QemuVirtIOStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["virtio2"]; isSet {
-		disks.Disk_2 = QemuVirtIOStorage{}.mapToStruct(params["virtio2"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskVirtIO+"2"]; isSet {
+		disks.Disk_2 = QemuVirtIOStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["virtio3"]; isSet {
-		disks.Disk_3 = QemuVirtIOStorage{}.mapToStruct(params["virtio3"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskVirtIO+"3"]; isSet {
+		disks.Disk_3 = QemuVirtIOStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["virtio4"]; isSet {
-		disks.Disk_4 = QemuVirtIOStorage{}.mapToStruct(params["virtio4"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskVirtIO+"4"]; isSet {
+		disks.Disk_4 = QemuVirtIOStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["virtio5"]; isSet {
-		disks.Disk_5 = QemuVirtIOStorage{}.mapToStruct(params["virtio5"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskVirtIO+"5"]; isSet {
+		disks.Disk_5 = QemuVirtIOStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["virtio6"]; isSet {
-		disks.Disk_6 = QemuVirtIOStorage{}.mapToStruct(params["virtio6"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskVirtIO+"6"]; isSet {
+		disks.Disk_6 = QemuVirtIOStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["virtio7"]; isSet {
-		disks.Disk_7 = QemuVirtIOStorage{}.mapToStruct(params["virtio7"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskVirtIO+"7"]; isSet {
+		disks.Disk_7 = QemuVirtIOStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["virtio8"]; isSet {
-		disks.Disk_8 = QemuVirtIOStorage{}.mapToStruct(params["virtio8"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskVirtIO+"8"]; isSet {
+		disks.Disk_8 = QemuVirtIOStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["virtio9"]; isSet {
-		disks.Disk_9 = QemuVirtIOStorage{}.mapToStruct(params["virtio9"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskVirtIO+"9"]; isSet {
+		disks.Disk_9 = QemuVirtIOStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["virtio10"]; isSet {
-		disks.Disk_10 = QemuVirtIOStorage{}.mapToStruct(params["virtio10"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskVirtIO+"10"]; isSet {
+		disks.Disk_10 = QemuVirtIOStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["virtio11"]; isSet {
-		disks.Disk_11 = QemuVirtIOStorage{}.mapToStruct(params["virtio11"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskVirtIO+"11"]; isSet {
+		disks.Disk_11 = QemuVirtIOStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["virtio12"]; isSet {
-		disks.Disk_12 = QemuVirtIOStorage{}.mapToStruct(params["virtio12"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskVirtIO+"12"]; isSet {
+		disks.Disk_12 = QemuVirtIOStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["virtio13"]; isSet {
-		disks.Disk_13 = QemuVirtIOStorage{}.mapToStruct(params["virtio13"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskVirtIO+"13"]; isSet {
+		disks.Disk_13 = QemuVirtIOStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["virtio14"]; isSet {
-		disks.Disk_14 = QemuVirtIOStorage{}.mapToStruct(params["virtio14"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskVirtIO+"14"]; isSet {
+		disks.Disk_14 = QemuVirtIOStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
-	if _, isSet := params["virtio15"]; isSet {
-		disks.Disk_15 = QemuVirtIOStorage{}.mapToStruct(params["virtio15"].(string), linkedVmId)
+	if v, isSet := raw[qemuPrefixApiKeyDiskVirtIO+"15"]; isSet {
+		disks.Disk_15 = QemuVirtIOStorage{}.mapToStruct(v.(string), linkedVmId)
 		structPopulated = true
 	}
 	if structPopulated {

--- a/proxmox/config_qemu_guestagent.go
+++ b/proxmox/config_qemu_guestagent.go
@@ -47,23 +47,27 @@ func (newSetting QemuGuestAgent) mapToAPI(currentSettings *QemuGuestAgent) strin
 	return tmpEnable + params
 }
 
-func (QemuGuestAgent) mapToSDK(params string) *QemuGuestAgent {
-	config := QemuGuestAgent{}
-	tmpEnable, _ := strconv.ParseBool(params[0:1])
-	config.Enable = &tmpEnable
-	tmpParams := splitStringOfSettings(params)
-	if v, isSet := tmpParams["freeze-fs-on-backup"]; isSet {
-		tmpBool, _ := strconv.ParseBool(v)
-		config.Freeze = &tmpBool
+func (raw RawConfigQemu) Agent() *QemuGuestAgent {
+	if v, isSet := raw[qemuApiKeyGuestAgent]; isSet {
+		params := v.(string)
+		config := QemuGuestAgent{}
+		tmpEnable, _ := strconv.ParseBool(params[0:1])
+		config.Enable = &tmpEnable
+		tmpParams := splitStringOfSettings(params)
+		if v, isSet := tmpParams["freeze-fs-on-backup"]; isSet {
+			tmpBool, _ := strconv.ParseBool(v)
+			config.Freeze = &tmpBool
+		}
+		if v, isSet := tmpParams["fstrim_cloned_disks"]; isSet {
+			tmpBool, _ := strconv.ParseBool(v)
+			config.FsTrim = &tmpBool
+		}
+		if v, isSet := tmpParams["type"]; isSet {
+			config.Type = util.Pointer(QemuGuestAgentType(v))
+		}
+		return &config
 	}
-	if v, isSet := tmpParams["fstrim_cloned_disks"]; isSet {
-		tmpBool, _ := strconv.ParseBool(v)
-		config.FsTrim = &tmpBool
-	}
-	if v, isSet := tmpParams["type"]; isSet {
-		config.Type = util.Pointer(QemuGuestAgentType(v))
-	}
-	return &config
+	return nil
 }
 
 func (setting QemuGuestAgent) Validate() error {

--- a/proxmox/config_qemu_memory.go
+++ b/proxmox/config_qemu_memory.go
@@ -21,57 +21,57 @@ const (
 func (config QemuMemory) mapToAPI(current *QemuMemory, params map[string]interface{}) string {
 	if current == nil { // create
 		if config.CapacityMiB != nil {
-			params["memory"] = *config.CapacityMiB
+			params[qemuApiKeyMemoryCapacity] = *config.CapacityMiB
 		}
 		if config.MinimumCapacityMiB != nil {
-			params["balloon"] = *config.MinimumCapacityMiB
+			params[qemuApiKeyMemoryBallooning] = *config.MinimumCapacityMiB
 			if config.CapacityMiB == nil {
-				params["memory"] = *config.MinimumCapacityMiB
+				params[qemuApiKeyMemoryCapacity] = *config.MinimumCapacityMiB
 			}
 		}
 		if config.Shares != nil {
 			if *config.Shares > 0 {
-				params["shares"] = *config.Shares
+				params[qemuApiKeyMemoryShares] = *config.Shares
 			}
 		}
 		return ""
 	}
 	// update
 	if config.CapacityMiB != nil {
-		params["memory"] = *config.CapacityMiB
+		params[qemuApiKeyMemoryCapacity] = *config.CapacityMiB
 		if config.MinimumCapacityMiB == nil && current.MinimumCapacityMiB != nil && uint32(*current.MinimumCapacityMiB) > uint32(*config.CapacityMiB) {
-			params["balloon"] = *config.CapacityMiB
-			return ",shares"
+			params[qemuApiKeyMemoryBallooning] = *config.CapacityMiB
+			return "," + qemuApiKeyMemoryShares
 		}
 	}
 	if config.MinimumCapacityMiB != nil {
-		params["balloon"] = *config.MinimumCapacityMiB
+		params[qemuApiKeyMemoryBallooning] = *config.MinimumCapacityMiB
 		if *config.MinimumCapacityMiB == 0 {
-			return ",shares"
+			return "," + qemuApiKeyMemoryShares
 		}
 	}
 	if config.Shares != nil {
 		if *config.Shares == 0 {
-			return ",shares"
+			return "," + qemuApiKeyMemoryShares
 		}
-		params["shares"] = *config.Shares
+		params[qemuApiKeyMemoryShares] = *config.Shares
 	}
 	return ""
 }
 
-func (QemuMemory) mapToSDK(params map[string]interface{}) *QemuMemory {
+func (raw RawConfigQemu) Memory() *QemuMemory {
 	config := QemuMemory{}
-	if v, isSet := params["memory"]; isSet {
+	if v, isSet := raw[qemuApiKeyMemoryCapacity]; isSet {
 		tmp, _ := parse.Uint(v)
 		tmpIntermediate := QemuMemoryCapacity(tmp)
 		config.CapacityMiB = &tmpIntermediate
 	}
-	if v, isSet := params["balloon"]; isSet {
+	if v, isSet := raw[qemuApiKeyMemoryBallooning]; isSet {
 		tmp, _ := parse.Uint(v)
 		tmpIntermediate := QemuMemoryBalloonCapacity(tmp)
 		config.MinimumCapacityMiB = &tmpIntermediate
 	}
-	if v, isSet := params["shares"]; isSet {
+	if v, isSet := raw[qemuApiKeyMemoryShares]; isSet {
 		tmp, _ := parse.Uint(v)
 		tmpIntermediate := QemuMemoryShares(tmp)
 		config.Shares = &tmpIntermediate

--- a/proxmox/config_qemu_network.go
+++ b/proxmox/config_qemu_network.go
@@ -361,24 +361,24 @@ func (config QemuNetworkInterfaces) mapToAPI(current QemuNetworkInterfaces, para
 	for i, e := range config {
 		if v, isSet := current[i]; isSet { // Update
 			if e.Delete {
-				delete += ",net" + i.String()
+				delete += "," + qemuPrefixApiKeyNetwork + i.String()
 				continue
 			}
-			params["net"+i.String()] = e.mapToApi(&v)
+			params[qemuPrefixApiKeyNetwork+i.String()] = e.mapToApi(&v)
 		} else { // Create
 			if e.Delete {
 				continue
 			}
-			params["net"+i.String()] = e.mapToApi(nil)
+			params[qemuPrefixApiKeyNetwork+i.String()] = e.mapToApi(nil)
 		}
 	}
 	return
 }
 
-func (QemuNetworkInterfaces) mapToSDK(params map[string]interface{}) QemuNetworkInterfaces {
+func (raw RawConfigQemu) Networks() QemuNetworkInterfaces {
 	interfaces := QemuNetworkInterfaces{}
 	for i := uint8(0); i < QemuNetworkInterfacesAmount; i++ {
-		if rawInterface, isSet := params["net"+strconv.Itoa(int(i))]; isSet {
+		if rawInterface, isSet := raw[qemuPrefixApiKeyNetwork+strconv.Itoa(int(i))]; isSet {
 			interfaces[QemuNetworkInterfaceID(i)] = QemuNetworkInterface{}.mapToSDK(rawInterface.(string))
 		}
 	}

--- a/proxmox/config_qemu_pcie.go
+++ b/proxmox/config_qemu_pcie.go
@@ -17,24 +17,24 @@ func (config QemuPciDevices) mapToAPI(current QemuPciDevices, params map[string]
 	for i, e := range config {
 		if v, isSet := current[i]; isSet {
 			if e.Delete {
-				builder.WriteString(",hostpci" + i.String())
+				builder.WriteString("," + qemuPrefixApiKeyPCI + i.String())
 				continue
 			}
-			params["hostpci"+i.String()] = e.mapToAPI(&v)
+			params[qemuPrefixApiKeyPCI+i.String()] = e.mapToAPI(&v)
 		} else {
 			if e.Delete {
 				continue
 			}
-			params["hostpci"+i.String()] = e.mapToAPI(nil)
+			params[qemuPrefixApiKeyPCI+i.String()] = e.mapToAPI(nil)
 		}
 	}
 	return builder.String()
 }
 
-func (QemuPciDevices) mapToSDK(params map[string]interface{}) QemuPciDevices {
+func (raw RawConfigQemu) PciDevices() QemuPciDevices {
 	pciList := make(QemuPciDevices)
 	for i := QemuPciID(0); i < QemuPciID(QemuPciDevicesAmount); i++ {
-		if v, isSet := params["hostpci"+i.String()]; isSet {
+		if v, isSet := raw[qemuPrefixApiKeyPCI+i.String()]; isSet {
 			pciList[i] = QemuPci{}.mapToSDK(v.(string))
 		}
 	}

--- a/proxmox/config_qemu_serial.go
+++ b/proxmox/config_qemu_serial.go
@@ -28,9 +28,9 @@ func (id SerialID) Validate() error {
 }
 
 type SerialInterface struct {
-	Delete bool       `json:"delete,omitempty"` // If true, the serial adapter will be removed.
 	Path   SerialPath `json:"path,omitempty"`   // Path to the serial device. Mutually exclusive with socket.
 	Socket bool       `json:"socket,omitempty"` // If true, the serial device is a socket. Mutually exclusive with path.
+	Delete bool       `json:"delete,omitempty"` // If true, the serial adapter will be removed.
 }
 
 const (

--- a/proxmox/config_qemu_serial.go
+++ b/proxmox/config_qemu_serial.go
@@ -45,7 +45,7 @@ func (port SerialInterface) mapToAPI(id SerialID, params map[string]interface{})
 	if !port.Socket {
 		tmpPath = string(port.Path)
 	}
-	params["serial"+id.String()] = tmpPath
+	params[qemuPrefixApiKeySerial+id.String()] = tmpPath
 }
 
 func (SerialInterface) mapToSDK(v string) SerialInterface {
@@ -83,7 +83,7 @@ func (config SerialInterfaces) mapToAPI(current SerialInterfaces, params map[str
 		for id, port := range config {
 			if _, ok := current[id]; ok {
 				if port.Delete {
-					delete += ",serial" + id.String()
+					delete += "," + qemuPrefixApiKeySerial + id.String()
 					continue
 				}
 				if current[id].Path != port.Path || current[id].Socket != port.Socket {
@@ -104,18 +104,18 @@ func (config SerialInterfaces) mapToAPI(current SerialInterfaces, params map[str
 	return
 }
 
-func (SerialInterfaces) mapToSDK(params map[string]interface{}) SerialInterfaces {
+func (raw RawConfigQemu) Serials() SerialInterfaces {
 	Serials := SerialInterfaces{}
-	if v, isSet := params["serial0"]; isSet {
+	if v, isSet := raw[qemuPrefixApiKeySerial+"0"]; isSet {
 		Serials[SerialID0] = SerialInterface{}.mapToSDK(v.(string))
 	}
-	if v, isSet := params["serial1"]; isSet {
+	if v, isSet := raw[qemuPrefixApiKeySerial+"1"]; isSet {
 		Serials[SerialID1] = SerialInterface{}.mapToSDK(v.(string))
 	}
-	if v, isSet := params["serial2"]; isSet {
+	if v, isSet := raw[qemuPrefixApiKeySerial+"2"]; isSet {
 		Serials[SerialID2] = SerialInterface{}.mapToSDK(v.(string))
 	}
-	if v, isSet := params["serial3"]; isSet {
+	if v, isSet := raw[qemuPrefixApiKeySerial+"3"]; isSet {
 		Serials[SerialID3] = SerialInterface{}.mapToSDK(v.(string))
 	}
 	if len(Serials) > 0 {

--- a/proxmox/config_qemu_test.go
+++ b/proxmox/config_qemu_test.go
@@ -1167,7 +1167,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"ide3": "test:0/vm-0-disk-23.raw,aio=native,backup=0,replicate=0"}},
 				{name: `Disks.Ide.Disk_X.Disk CHANGE File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Ide: &QemuIdeDisks{Disk_3: &QemuIdeStorage{Disk: &QemuIdeDisk{
 							AsyncIO:         QemuDiskAsyncIO_IOuring,
 							Format:          QemuDiskFormat_Raw,
@@ -1195,7 +1195,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"ide3": "test:vm-0-disk-23,aio=native,backup=0,replicate=0"}},
 				{name: `Disks.Ide.Disk_X.Disk CHANGE Volume LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Ide: &QemuIdeDisks{Disk_3: &QemuIdeStorage{Disk: &QemuIdeDisk{
 							AsyncIO:         QemuDiskAsyncIO_IOuring,
 							Id:              23,
@@ -1221,7 +1221,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"ide1": "test2:0/vm-0-disk-23.raw,backup=0,replicate=0"}},
 				{name: `Disks.Ide.Disk_X.Disk MIGRATE File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Ide: &QemuIdeDisks{Disk_1: &QemuIdeStorage{Disk: &QemuIdeDisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -1245,7 +1245,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"ide1": "test2:vm-0-disk-23,backup=0,replicate=0"}},
 				{name: `Disks.Ide.Disk_X.Disk MIGRATE Volume LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Ide: &QemuIdeDisks{Disk_1: &QemuIdeStorage{Disk: &QemuIdeDisk{
 							Id:              23,
 							LinkedDiskId:    util.Pointer(GuestID(1)),
@@ -1277,7 +1277,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"ide2": "test:9,backup=0,format=raw,replicate=0"}},
 				{name: `Disks.Ide.Disk_X.Disk RESIZE DOWN Gibibyte File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Ide: &QemuIdeDisks{Disk_2: &QemuIdeStorage{Disk: &QemuIdeDisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -1302,7 +1302,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"ide2": "test:9,backup=0,format=raw,replicate=0"}},
 				{name: `Disks.Ide.Disk_X.Disk RESIZE DOWN Gibibyte Volume LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Ide: &QemuIdeDisks{Disk_2: &QemuIdeStorage{Disk: &QemuIdeDisk{
 							Id:              23,
 							LinkedDiskId:    util.Pointer(GuestID(1)),
@@ -1327,7 +1327,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"ide2": "test:0.001,backup=0,format=raw,replicate=0"}},
 				{name: `Disks.Ide.Disk_X.Disk RESIZE DOWN Kibibyte File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Ide: &QemuIdeDisks{Disk_2: &QemuIdeStorage{Disk: &QemuIdeDisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -1352,7 +1352,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"ide2": "test:0.001,backup=0,format=raw,replicate=0"}},
 				{name: `Disks.Ide.Disk_X.Disk RESIZE DOWN Kibibyte Volume LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Ide: &QemuIdeDisks{Disk_2: &QemuIdeStorage{Disk: &QemuIdeDisk{
 							Id:              23,
 							LinkedDiskId:    util.Pointer(GuestID(1)),
@@ -1377,7 +1377,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{}},
 				{name: `Disks.Ide.Disk_X.Disk RESIZE UP File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 110,
+						LinkedID: util.Pointer(GuestID(110)),
 						Disks: &QemuStorages{Ide: &QemuIdeDisks{Disk_3: &QemuIdeStorage{Disk: &QemuIdeDisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -1401,7 +1401,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{}},
 				{name: `Disks.Ide.Disk_X.Disk RESIZE UP Volume LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 110,
+						LinkedID: util.Pointer(GuestID(110)),
 						Disks: &QemuStorages{Ide: &QemuIdeDisks{Disk_3: &QemuIdeStorage{Disk: &QemuIdeDisk{
 							Id:              23,
 							LinkedDiskId:    util.Pointer(GuestID(1)),
@@ -1432,7 +1432,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"ide1": "test:0/vm-0-disk-23.qcow2,backup=0,replicate=0"}},
 				{name: `Disks.Ide.Disk_X.Disk.Format CHANGE File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Ide: &QemuIdeDisks{Disk_1: &QemuIdeStorage{Disk: &QemuIdeDisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -1458,7 +1458,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{}},
 				{name: `Disks.Ide.Disk_X.Disk.Format CHANGE Volume LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Ide: &QemuIdeDisks{Disk_1: &QemuIdeStorage{Disk: &QemuIdeDisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -1827,7 +1827,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"sata3": "test:0/vm-0-disk-23.raw,aio=native,backup=0,replicate=0"}},
 				{name: `Disks.Sata.Disk_X.Disk CHANGE File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Sata: &QemuSataDisks{Disk_3: &QemuSataStorage{Disk: &QemuSataDisk{
 							AsyncIO:         QemuDiskAsyncIO_IOuring,
 							Format:          QemuDiskFormat_Raw,
@@ -1855,7 +1855,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"sata3": "test:vm-0-disk-23,aio=native,backup=0,replicate=0"}},
 				{name: `Disks.Sata.Disk_X.Disk CHANGE Volume LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Sata: &QemuSataDisks{Disk_3: &QemuSataStorage{Disk: &QemuSataDisk{
 							AsyncIO:         QemuDiskAsyncIO_IOuring,
 							Id:              23,
@@ -1881,7 +1881,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"sata5": "test2:0/vm-0-disk-23.raw,backup=0,replicate=0"}},
 				{name: `Disks.Sata.Disk_X.Disk MIGRATE File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Sata: &QemuSataDisks{Disk_5: &QemuSataStorage{Disk: &QemuSataDisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -1907,7 +1907,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"sata5": "test2:vm-0-disk-23,backup=0,replicate=0"}},
 				{name: `Disks.Sata.Disk_X.Disk MIGRATE File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Sata: &QemuSataDisks{Disk_5: &QemuSataStorage{Disk: &QemuSataDisk{
 							Id:              23,
 							LinkedDiskId:    util.Pointer(GuestID(1)),
@@ -1939,7 +1939,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"sata0": "test:9,backup=0,format=raw,replicate=0"}},
 				{name: `Disks.Sata.Disk_X.Disk RESIZE DOWN Gibibyte File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Sata: &QemuSataDisks{Disk_0: &QemuSataStorage{Disk: &QemuSataDisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -1963,7 +1963,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"sata0": "test:9,backup=0,replicate=0"}},
 				{name: `Disks.Sata.Disk_X.Disk RESIZE DOWN Gibibyte Volume LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Sata: &QemuSataDisks{Disk_0: &QemuSataStorage{Disk: &QemuSataDisk{
 							Id:              23,
 							LinkedDiskId:    util.Pointer(GuestID(1)),
@@ -1987,7 +1987,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"sata0": "test:0.001,backup=0,format=raw,replicate=0"}},
 				{name: `Disks.Sata.Disk_X.Disk RESIZE DOWN Kibibyte File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Sata: &QemuSataDisks{Disk_0: &QemuSataStorage{Disk: &QemuSataDisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -2011,7 +2011,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"sata0": "test:0.001,backup=0,replicate=0"}},
 				{name: `Disks.Sata.Disk_X.Disk RESIZE DOWN Kibibyte Volume LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Sata: &QemuSataDisks{Disk_0: &QemuSataStorage{Disk: &QemuSataDisk{
 							Id:              23,
 							LinkedDiskId:    util.Pointer(GuestID(1)),
@@ -2035,7 +2035,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{}},
 				{name: `Disks.Sata.Disk_X.Disk RESIZE UP File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Sata: &QemuSataDisks{Disk_1: &QemuSataStorage{Disk: &QemuSataDisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -2058,7 +2058,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{}},
 				{name: `Disks.Sata.Disk_X.Disk RESIZE UP Volume LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Sata: &QemuSataDisks{Disk_1: &QemuSataStorage{Disk: &QemuSataDisk{
 							Id:              23,
 							LinkedDiskId:    util.Pointer(GuestID(1)),
@@ -2088,7 +2088,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"sata3": "test:0/vm-0-disk-23.qcow2,backup=0,replicate=0"}},
 				{name: `Disks.Sata.Disk_X.Disk.Format CHANGE File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Sata: &QemuSataDisks{Disk_3: &QemuSataStorage{Disk: &QemuSataDisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -2114,7 +2114,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{}},
 				{name: `Disks.Sata.Disk_X.Disk.Format CHANGE Volume LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Sata: &QemuSataDisks{Disk_3: &QemuSataStorage{Disk: &QemuSataDisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -2491,7 +2491,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"scsi15": "test:0/vm-0-disk-23.raw,aio=native,backup=0,replicate=0"}},
 				{name: `Disks.Scsi.Disk_X.Disk CHANGE File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Scsi: &QemuScsiDisks{Disk_15: &QemuScsiStorage{Disk: &QemuScsiDisk{
 							AsyncIO:         QemuDiskAsyncIO_IOuring,
 							Format:          QemuDiskFormat_Raw,
@@ -2519,7 +2519,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"scsi15": "test:vm-0-disk-23,aio=native,backup=0,replicate=0"}},
 				{name: `Disks.Scsi.Disk_X.Disk CHANGE Volume LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Scsi: &QemuScsiDisks{Disk_15: &QemuScsiStorage{Disk: &QemuScsiDisk{
 							AsyncIO:         QemuDiskAsyncIO_IOuring,
 							Id:              23,
@@ -2545,7 +2545,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"scsi17": "test2:0/vm-0-disk-23.raw,backup=0,replicate=0"}},
 				{name: `Disks.Scsi.Disk_X.Disk MIGRATE File Linked Clone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Scsi: &QemuScsiDisks{Disk_17: &QemuScsiStorage{Disk: &QemuScsiDisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -2569,7 +2569,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"scsi17": "test2:vm-0-disk-23,backup=0,replicate=0"}},
 				{name: `Disks.Scsi.Disk_X.Disk MIGRATE Volume Linked Clone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Scsi: &QemuScsiDisks{Disk_17: &QemuScsiStorage{Disk: &QemuScsiDisk{
 							Id:              23,
 							LinkedDiskId:    util.Pointer(GuestID(1)),
@@ -2601,7 +2601,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"scsi18": "test:9,backup=0,format=raw,replicate=0"}},
 				{name: `Disks.Scsi.Disk_X.Disk RESIZE DOWN Gibibyte File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Scsi: &QemuScsiDisks{Disk_18: &QemuScsiStorage{Disk: &QemuScsiDisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -2626,7 +2626,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"scsi18": "test:9,backup=0,format=raw,replicate=0"}},
 				{name: `Disks.Scsi.Disk_X.Disk RESIZE DOWN Gibibyte Volume LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Scsi: &QemuScsiDisks{Disk_18: &QemuScsiStorage{Disk: &QemuScsiDisk{
 							Id:              23,
 							LinkedDiskId:    util.Pointer(GuestID(1)),
@@ -2651,7 +2651,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"scsi18": "test:0.001,backup=0,format=raw,replicate=0"}},
 				{name: `Disks.Scsi.Disk_X.Disk RESIZE DOWN Kibibyte File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Scsi: &QemuScsiDisks{Disk_18: &QemuScsiStorage{Disk: &QemuScsiDisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -2676,7 +2676,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"scsi18": "test:0.001,backup=0,format=raw,replicate=0"}},
 				{name: `Disks.Scsi.Disk_X.Disk RESIZE DOWN Kibibyte Volume LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Scsi: &QemuScsiDisks{Disk_18: &QemuScsiStorage{Disk: &QemuScsiDisk{
 							Id:              23,
 							LinkedDiskId:    util.Pointer(GuestID(1)),
@@ -2701,7 +2701,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{}},
 				{name: `Disks.Scsi.Disk_X.Disk RESIZE UP File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Scsi: &QemuScsiDisks{Disk_19: &QemuScsiStorage{Disk: &QemuScsiDisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -2727,7 +2727,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{}},
 				{name: `Disks.Scsi.Disk_X.Disk RESIZE UP Volume LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Scsi: &QemuScsiDisks{Disk_19: &QemuScsiStorage{Disk: &QemuScsiDisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -2760,7 +2760,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"scsi21": "test:0/vm-0-disk-23.qcow2,backup=0,replicate=0"}},
 				{name: `Disks.Scsi.Disk_X.Disk.Format CHANGE File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Scsi: &QemuScsiDisks{Disk_21: &QemuScsiStorage{Disk: &QemuScsiDisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -2786,7 +2786,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{}},
 				{name: `Disks.Scsi.Disk_X.Disk.Format CHANGE Volume LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{Scsi: &QemuScsiDisks{Disk_21: &QemuScsiStorage{Disk: &QemuScsiDisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -3173,7 +3173,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"virtio15": "test:0/vm-0-disk-23.raw,aio=native,backup=0,replicate=0"}},
 				{name: `Disks.VirtIO.Disk_X.Disk CHANGE File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{VirtIO: &QemuVirtIODisks{Disk_15: &QemuVirtIOStorage{Disk: &QemuVirtIODisk{
 							AsyncIO:         QemuDiskAsyncIO_IOuring,
 							Format:          QemuDiskFormat_Raw,
@@ -3201,7 +3201,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"virtio15": "test:vm-0-disk-23,aio=native,backup=0,replicate=0"}},
 				{name: `Disks.VirtIO.Disk_X.Disk CHANGE Volume LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{VirtIO: &QemuVirtIODisks{Disk_15: &QemuVirtIOStorage{Disk: &QemuVirtIODisk{
 							AsyncIO:         QemuDiskAsyncIO_IOuring,
 							Id:              23,
@@ -3227,7 +3227,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"virtio1": "test2:0/vm-0-disk-23.raw,backup=0,replicate=0"}},
 				{name: `Disks.VirtIO.Disk_X.Disk MIGRATE File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{VirtIO: &QemuVirtIODisks{Disk_1: &QemuVirtIOStorage{Disk: &QemuVirtIODisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -3251,7 +3251,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"virtio1": "test2:vm-0-disk-23,backup=0,replicate=0"}},
 				{name: `Disks.VirtIO.Disk_X.Disk MIGRATE Volume LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{VirtIO: &QemuVirtIODisks{Disk_1: &QemuVirtIOStorage{Disk: &QemuVirtIODisk{
 							Id:              23,
 							LinkedDiskId:    util.Pointer(GuestID(1)),
@@ -3283,7 +3283,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"virtio2": "test:9,backup=0,format=raw,replicate=0"}},
 				{name: `Disks.VirtIO.Disk_X.Disk RESIZE DOWN Gibibyte File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{VirtIO: &QemuVirtIODisks{Disk_2: &QemuVirtIOStorage{Disk: &QemuVirtIODisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -3308,7 +3308,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"virtio2": "test:9,backup=0,format=raw,replicate=0"}},
 				{name: `Disks.VirtIO.Disk_X.Disk RESIZE DOWN Gibibyte Volume LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{VirtIO: &QemuVirtIODisks{Disk_2: &QemuVirtIOStorage{Disk: &QemuVirtIODisk{
 							Id:              23,
 							LinkedDiskId:    util.Pointer(GuestID(1)),
@@ -3333,7 +3333,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"virtio2": "test:0.001,backup=0,format=raw,replicate=0"}},
 				{name: `Disks.VirtIO.Disk_X.Disk RESIZE DOWN Kibibyte File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{VirtIO: &QemuVirtIODisks{Disk_2: &QemuVirtIOStorage{Disk: &QemuVirtIODisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -3358,7 +3358,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"virtio2": "test:0.001,backup=0,format=raw,replicate=0"}},
 				{name: `Disks.VirtIO.Disk_X.Disk RESIZE DOWN Kibibyte Volume LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{VirtIO: &QemuVirtIODisks{Disk_2: &QemuVirtIOStorage{Disk: &QemuVirtIODisk{
 							Id:              23,
 							LinkedDiskId:    util.Pointer(GuestID(1)),
@@ -3383,7 +3383,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{}},
 				{name: `Disks.VirtIO.Disk_X.Disk RESIZE UP File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{VirtIO: &QemuVirtIODisks{Disk_3: &QemuVirtIOStorage{Disk: &QemuVirtIODisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -3407,7 +3407,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{}},
 				{name: `Disks.VirtIO.Disk_X.Disk RESIZE UP Volume LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{VirtIO: &QemuVirtIODisks{Disk_3: &QemuVirtIOStorage{Disk: &QemuVirtIODisk{
 							Id:              23,
 							LinkedDiskId:    util.Pointer(GuestID(1)),
@@ -3438,7 +3438,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"virtio5": "test:0/vm-0-disk-23.qcow2,backup=0,replicate=0"}},
 				{name: `Disks.VirtIO.Disk_X.Disk.Format CHANGE File LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{VirtIO: &QemuVirtIODisks{Disk_5: &QemuVirtIOStorage{Disk: &QemuVirtIODisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -3464,7 +3464,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{}},
 				{name: `Disks.VirtIO.Disk_X.Disk.Format CHANGE Volume LinkedClone`,
 					currentConfig: ConfigQemu{
-						LinkedVmId: 100,
+						LinkedID: util.Pointer(GuestID(100)),
 						Disks: &QemuStorages{VirtIO: &QemuVirtIODisks{Disk_5: &QemuVirtIOStorage{Disk: &QemuVirtIODisk{
 							Format:          QemuDiskFormat_Raw,
 							Id:              23,
@@ -4297,13 +4297,25 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 	}
 }
 
-func Test_ConfigQemu_mapToStruct(t *testing.T) {
+func Test_ConfigQemu_all(t *testing.T) {
 	baseConfig := func(config ConfigQemu) *ConfigQemu {
 		if config.CPU == nil {
 			config.CPU = &QemuCPU{}
 		}
+		if config.Description == nil {
+			config.Description = util.Pointer("")
+		}
 		if config.Memory == nil {
 			config.Memory = &QemuMemory{}
+		}
+		if config.Name == nil {
+			config.Name = util.Pointer(GuestName(""))
+		}
+		if config.Protection == nil {
+			config.Protection = util.Pointer(false)
+		}
+		if config.Tablet == nil {
+			config.Tablet = util.Pointer(true)
 		}
 		return &config
 	}
@@ -4329,7 +4341,7 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 	uint53 := uint(53)
 	type test struct {
 		name   string
-		input  map[string]interface{}
+		input  RawConfigQemu
 		vmr    *VmRef
 		output *ConfigQemu
 		err    error
@@ -4704,7 +4716,7 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 				{name: `ALL LinkedClone`,
 					input: map[string]interface{}{"ide1": "test2:110/base-110-disk-1.qcow2/100/vm-100-disk-53.qcow2,aio=io_uring,backup=0,cache=writethrough,discard=on,iops_rd=12,iops_rd_max=13,iops_rd_max_length=4,iops_wr=15,iops_wr_max=14,iops_wr_max_length=5,mbps_rd=1.46,mbps_rd_max=3.57,mbps_wr=2.68,mbps_wr_max=4.55,replicate=0,serial=disk-9763,size=1032G,ssd=1,wwn=0x500679CE00B1DAF4"},
 					output: baseConfig(ConfigQemu{
-						LinkedVmId: 110,
+						LinkedID: util.Pointer(GuestID(110)),
 						Disks: &QemuStorages{Ide: &QemuIdeDisks{Disk_1: &QemuIdeStorage{Disk: &QemuIdeDisk{
 							AsyncIO: QemuDiskAsyncIO_IOuring,
 							Backup:  false,
@@ -4925,7 +4937,7 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 				{name: `syntax fileSyntaxVolume LinkedClone`,
 					input: map[string]interface{}{"ide3": "test:base-110-disk-1/vm-100-disk-2"},
 					output: baseConfig(ConfigQemu{
-						LinkedVmId: 110,
+						LinkedID: util.Pointer(GuestID(110)),
 						Disks: &QemuStorages{Ide: &QemuIdeDisks{Disk_3: &QemuIdeStorage{Disk: &QemuIdeDisk{
 							Backup:       true,
 							Format:       QemuDiskFormat_Raw,
@@ -5184,7 +5196,7 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 				{name: `ALL LinkedClone`,
 					input: map[string]interface{}{"sata1": "test2:110/base-110-disk-1.qcow2/100/vm-100-disk-47.qcow2,aio=native,backup=0,cache=none,discard=on,iops_rd=10,iops_rd_max=12,iops_rd_max_length=4,iops_wr=11,iops_wr_max=13,iops_wr_max_length=5,mbps_rd=1.51,mbps_rd_max=3.51,mbps_wr=2.51,mbps_wr_max=4.51,replicate=0,serial=disk-9763,size=32G,ssd=1,wwn=0x5003B97600A8F2D4"},
 					output: baseConfig(ConfigQemu{
-						LinkedVmId: 110,
+						LinkedID: util.Pointer(GuestID(110)),
 						Disks: &QemuStorages{Sata: &QemuSataDisks{Disk_1: &QemuSataStorage{Disk: &QemuSataDisk{
 							AsyncIO: QemuDiskAsyncIO_Native,
 							Backup:  false,
@@ -5407,7 +5419,7 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 				{name: `syntax fileSyntaxVolume LinkedClone`,
 					input: map[string]interface{}{"sata1": "test:base-110-disk-1/vm-100-disk-2"},
 					output: baseConfig(ConfigQemu{
-						LinkedVmId: 110,
+						LinkedID: util.Pointer(GuestID(110)),
 						Disks: &QemuStorages{Sata: &QemuSataDisks{Disk_1: &QemuSataStorage{Disk: &QemuSataDisk{
 							Backup:       true,
 							Format:       QemuDiskFormat_Raw,
@@ -5668,7 +5680,7 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 				{name: `ALL LinkedClone`,
 					input: map[string]interface{}{"scsi1": "test:110/base-110-disk-1.qcow2/100/vm-100-disk-2.qcow2,aio=threads,backup=0,cache=writeback,discard=on,iops_rd=10,iops_rd_max=12,iops_rd_max_length=4,iops_wr=11,iops_wr_max=13,iops_wr_max_length=5,iothread=1,mbps_rd=1.51,mbps_rd_max=3.51,mbps_wr=2.51,mbps_wr_max=4.51,replicate=0,ro=1,serial=disk-9763,size=32G,ssd=1,wwn=0x500879DC00F3BE6A"},
 					output: baseConfig(ConfigQemu{
-						LinkedVmId: 110,
+						LinkedID: util.Pointer(GuestID(110)),
 						Disks: &QemuStorages{Scsi: &QemuScsiDisks{Disk_1: &QemuScsiStorage{Disk: &QemuScsiDisk{
 							AsyncIO: QemuDiskAsyncIO_Threads,
 							Backup:  false,
@@ -5909,7 +5921,7 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 				{name: `syntax fileSyntaxVolume LinkedClone`,
 					input: map[string]interface{}{"scsi7": "test:base-110-disk-1/vm-100-disk-2"},
 					output: baseConfig(ConfigQemu{
-						LinkedVmId: 110,
+						LinkedID: util.Pointer(GuestID(110)),
 						Disks: &QemuStorages{Scsi: &QemuScsiDisks{Disk_7: &QemuScsiStorage{Disk: &QemuScsiDisk{
 							Backup:       true,
 							Format:       QemuDiskFormat_Raw,
@@ -6185,7 +6197,7 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 				{name: `ALL LinkedClone`,
 					input: map[string]interface{}{"virtio1": "test2:110/base-110-disk-1.qcow2/100/vm-100-disk-31.qcow2,aio=io_uring,backup=0,cache=directsync,discard=on,iops_rd=10,iops_rd_max=12,iops_rd_max_length=2,iops_wr=11,iops_wr_max=13,iops_wr_max_length=3,iothread=1,mbps_rd=1.51,mbps_rd_max=3.51,mbps_wr=2.51,mbps_wr_max=4.51,replicate=0,ro=1,serial=disk-9763,size=32G,wwn=0x500FA2D000C69587"},
 					output: baseConfig(ConfigQemu{
-						LinkedVmId: 110,
+						LinkedID: util.Pointer(GuestID(110)),
 						Disks: &QemuStorages{VirtIO: &QemuVirtIODisks{Disk_1: &QemuVirtIOStorage{Disk: &QemuVirtIODisk{
 							AsyncIO: QemuDiskAsyncIO_IOuring,
 							Backup:  false,
@@ -6418,7 +6430,7 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 				{name: `syntax fileSyntaxVolume LinkedClone`,
 					input: map[string]interface{}{"virtio8": "test:base-110-disk-1/vm-100-disk-2"},
 					output: baseConfig(ConfigQemu{
-						LinkedVmId: 110,
+						LinkedID: util.Pointer(GuestID(110)),
 						Disks: &QemuStorages{VirtIO: &QemuVirtIODisks{Disk_8: &QemuVirtIOStorage{Disk: &QemuVirtIODisk{
 							Backup:       true,
 							Format:       QemuDiskFormat_Raw,
@@ -7231,7 +7243,7 @@ func Test_ConfigQemu_mapToStruct(t *testing.T) {
 				name += "/" + subTest.name
 			}
 			t.Run(name, func(*testing.T) {
-				output, err := ConfigQemu{}.mapToStruct(subTest.vmr, subTest.input)
+				output, err := subTest.input.all(subTest.vmr)
 				if err != nil {
 					require.Equal(t, subTest.err, err, name)
 				} else {

--- a/proxmox/config_qemu_usb.go
+++ b/proxmox/config_qemu_usb.go
@@ -45,10 +45,10 @@ type QemuUSBs map[QemuUsbID]QemuUSB
 
 const QemuUSBsAmount = uint8(QemuUsbIDMaximum) + 1
 
-func (QemuUSBs) mapToSDK(params map[string]interface{}) QemuUSBs {
+func (raw RawConfigQemu) USBs() QemuUSBs {
 	usbList := make(QemuUSBs)
 	for i := QemuUsbID(0); i < QemuUsbID(QemuUSBsAmount); i++ {
-		if v, isSet := params["usb"+i.String()]; isSet {
+		if v, isSet := raw[qemuPrefixApiKeyUSB+i.String()]; isSet {
 			usbList[i] = QemuUSB{}.mapToSDK(v.(string))
 		}
 	}
@@ -63,15 +63,15 @@ func (config QemuUSBs) mapToAPI(current QemuUSBs, params map[string]interface{})
 	for i, e := range config {
 		if v, isSet := current[i]; isSet {
 			if e.Delete {
-				builder.WriteString(",usb" + i.String())
+				builder.WriteString("," + qemuPrefixApiKeyUSB + i.String())
 				continue
 			}
-			params["usb"+i.String()] = e.mapToAPI(&v)
+			params[qemuPrefixApiKeyUSB+i.String()] = e.mapToAPI(&v)
 		} else {
 			if e.Delete {
 				continue
 			}
-			params["usb"+i.String()] = e.mapToAPI(nil)
+			params[qemuPrefixApiKeyUSB+i.String()] = e.mapToAPI(nil)
 		}
 	}
 	return builder.String()


### PR DESCRIPTION
Introduces the `RawConfigQemu` type and uses the get/set pattern to return properties from the `RawConfigQemu` just like the new  `RawConfigLxc` implementation.

Also changed the order of some structs to reduce padding bytes.