### PR TITLE
fix: make nextid get next id

### DIFF
--- a/cli/command/get/id/get-id-next.go
+++ b/cli/command/get/id/get-id-next.go
@@ -2,18 +2,29 @@ package id
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/Telmate/proxmox-api-go/cli"
+	"github.com/Telmate/proxmox-api-go/proxmox"
 	"github.com/spf13/cobra"
 )
 
 var id_nextCmd = &cobra.Command{
 	Use:   "next",
 	Short: "Returns the lowest available ID",
-	Args:  cobra.NoArgs,
+	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) (err error) {
 		c := cli.NewClient()
-		id, err := c.GetNextID(cli.Context(), nil)
+		var currentID *proxmox.GuestID
+		if len(args) > 0 {
+			currentIdInt, err := strconv.Atoi(args[0])
+			if err != nil {
+				return err
+			}
+			id := proxmox.GuestID(currentIdInt)
+			currentID = &id
+		}
+		id, err := c.GetNextID(cli.Context(), currentID)
 		if err != nil {
 			return
 		}

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -946,6 +946,10 @@ func (c *Client) GetNextIdNoCheck(ctx context.Context, startID *GuestID) (GuestI
 	}
 	tmpID, err := c.GetItemConfigString(ctx, url, "API", "cluster/nextid")
 	if err != nil {
+		if err.Error() == "400 Parameter verification failed." {
+			*startID++
+			return c.GetNextID(ctx, startID)
+		}
 		return 0, err
 	}
 	var id int


### PR DESCRIPTION
The proxmox API returns an error (rightly or wrongly?) when an in-use vmid is passed as a parameter to the API call.

e.g. from pvesh on my 8.3.5 cluster:
```
root@tc-01:~# pvesh get /cluster/nextid -vmid 2004
400 Parameter verification failed.
vmid: VM 2004 already exists
pvesh get <api_path> [OPTIONS] [FORMAT_OPTIONS]
```

from a proxmox-api-go debug log:
```
HTTP/1.1 400 Parameter verification failed. Connection: close Content-Length: 101 Cache-Control: max-age=0 Content-Type: application/json;charset=UTF-8 Date: Mon, 18 Aug 2025 11:59:14 GMT Expires: Mon, 18 Aug 2025 11:59:14 GMT Pragma: no-cache Server: pve-api-daemon/3.0 {"errors":{"vmid":"VM 2004 already exists"},"data":null,"message":"Parameter verification failed.\n"}
```

My expectation would be that the next available id would be returned instead of the error, this was the case in previous versions of proxmox-api-go until this commit https://github.com/Telmate/proxmox-api-go/commit/9b95514b3fb474c4c3b1e66d739c7e691c6adba7 removed the recursive call which increments the id each time until a valid one is found.

I can see a world in which it is expected that the user should implement the retry logic as that is how the proxmox API behaves but I think it's a better user experience if it just does what the name of the function implies.

I've also updated the new cli to accept a positional arg since I was using that to test this.

Please let me know your thoughts.