### PR TITLE
Feat: get pending config

### DIFF
--- a/proxmox/client__api.go
+++ b/proxmox/client__api.go
@@ -8,6 +8,7 @@ import (
 // in the future we might put the interface even lower, but for now this is sufficient
 type clientApiInterface interface {
 	getGuestConfig(ctx context.Context, vmr *VmRef) (map[string]any, error)
+	getGuestPendingChanges(ctx context.Context, vmr *VmRef) ([]any, error)
 	getPoolConfig(ctx context.Context, pool PoolName) (map[string]any, error)
 	getUserConfig(ctx context.Context, userId UserID) (map[string]any, error)
 	listGuestResources(ctx context.Context) ([]any, error)
@@ -24,6 +25,10 @@ type clientAPI struct {
 
 func (c *clientAPI) getGuestConfig(ctx context.Context, vmr *VmRef) (vmConfig map[string]any, err error) {
 	return c.getMap(ctx, "/nodes/"+vmr.node.String()+"/"+vmr.vmType.String()+"/"+vmr.vmId.String()+"/config", "vm", "CONFIG", nil)
+}
+
+func (c *clientAPI) getGuestPendingChanges(ctx context.Context, vmr *VmRef) ([]any, error) {
+	return c.getList(ctx, "/nodes/"+vmr.node.String()+"/"+vmr.vmType.String()+"/"+vmr.vmId.String()+"/pending", "Guest", "PENDING CONFIG", nil)
 }
 
 func (c *clientAPI) getPoolConfig(ctx context.Context, pool PoolName) (poolConfig map[string]any, err error) {

--- a/proxmox/client__api__mock.go
+++ b/proxmox/client__api__mock.go
@@ -5,10 +5,11 @@ import (
 )
 
 type mockClientAPI struct {
-	getGuestConfigFunc     func(ctx context.Context, vmr *VmRef) (map[string]any, error)
-	getPoolConfigFunc      func(ctx context.Context, pool PoolName) (map[string]any, error)
-	getUserConfigFunc      func(ctx context.Context, userId UserID) (map[string]any, error)
-	listGuestResourcesFunc func(ctx context.Context) ([]interface{}, error)
+	getGuestConfigFunc         func(ctx context.Context, vmr *VmRef) (map[string]any, error)
+	getGuestPendingChangesFunc func(ctx context.Context, vmr *VmRef) ([]any, error)
+	getPoolConfigFunc          func(ctx context.Context, pool PoolName) (map[string]any, error)
+	getUserConfigFunc          func(ctx context.Context, userId UserID) (map[string]any, error)
+	listGuestResourcesFunc     func(ctx context.Context) ([]interface{}, error)
 }
 
 func (m mockClientAPI) new() clientApiInterface { return &m }
@@ -22,6 +23,13 @@ func (m *mockClientAPI) getGuestConfig(ctx context.Context, vmr *VmRef) (vmConfi
 		m.panic("getGuestConfigFunc")
 	}
 	return m.getGuestConfigFunc(ctx, vmr)
+}
+
+func (m *mockClientAPI) getGuestPendingChanges(ctx context.Context, vmr *VmRef) ([]any, error) {
+	if m.getGuestPendingChangesFunc == nil {
+		m.panic("getGuestPendingChangesFunc")
+	}
+	return m.getGuestPendingChangesFunc(ctx, vmr)
 }
 
 func (m *mockClientAPI) getPoolConfig(ctx context.Context, pool PoolName) (poolConfig map[string]any, err error) {

--- a/proxmox/client__api__reusable.go
+++ b/proxmox/client__api__reusable.go
@@ -17,7 +17,7 @@ func (c *clientAPI) getResourceList(ctx context.Context, resourceType string) ([
 	if resourceType != "" {
 		url = url + "?type=" + resourceType
 	}
-	return c.getList(ctx, url, nil)
+	return c.getList(ctx, url, "", "", nil)
 }
 
 // Primitive methods
@@ -30,8 +30,8 @@ func (c *clientAPI) getMap(ctx context.Context, url, text, message string, ignor
 	return data["data"].(map[string]any), err
 }
 
-func (c *clientAPI) getList(ctx context.Context, url string, ignore errorIgnore) ([]any, error) {
-	list, err := c.getRootList(ctx, url, ignore)
+func (c *clientAPI) getList(ctx context.Context, url, text, message string, ignore errorIgnore) ([]any, error) {
+	list, err := c.getRootList(ctx, url, text, message, ignore)
 	if err != nil {
 		return nil, err
 	}
@@ -53,10 +53,13 @@ func (c *clientAPI) getRootMap(ctx context.Context, url, text, message string, i
 	return config, nil
 }
 
-func (c *clientAPI) getRootList(ctx context.Context, url string, ignore errorIgnore) (map[string]any, error) {
+func (c *clientAPI) getRootList(ctx context.Context, url, text, message string, ignore errorIgnore) (map[string]any, error) {
 	var data map[string]any
 	if err := c.getJsonRetry(ctx, url, &data, 3, ignore); err != nil {
 		return nil, err
+	}
+	if data["data"] == nil {
+		return nil, errors.New(text + " " + message + " not readable")
 	}
 	return data, nil
 }

--- a/proxmox/client__new.go
+++ b/proxmox/client__new.go
@@ -17,7 +17,9 @@ type ClientNew interface {
 	// Guest
 	guestCheckPendingChanges(ctx context.Context, vmr *VmRef) (bool, error)
 	guestCheckVmRef(ctx context.Context, vmr *VmRef) error
+	guestGetLxcActiveRawConfig(ctx context.Context, vmr *VmRef) (raw RawConfigLXC, pending bool, err error)
 	guestGetLxcRawConfig(ctx context.Context, vmr *VmRef) (RawConfigLXC, error)
+	guestGetQemuActiveRawConfig(ctx context.Context, vmr *VmRef) (raw RawConfigQemu, pending bool, err error)
 	guestGetQemuRawConfig(ctx context.Context, vmr *VmRef) (RawConfigQemu, error)
 	guestListResources(ctx context.Context) (RawGuestResources, error)
 	// Pool

--- a/proxmox/client__new.go
+++ b/proxmox/client__new.go
@@ -1,6 +1,9 @@
 package proxmox
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
 // The new implementation of the client
 
@@ -12,6 +15,8 @@ type ClientNew interface {
 	apiGet() clientApiInterface // TODO once we use `ClientNew` everywhere this function can be removed
 
 	// Guest
+	guestCheckPendingChanges(ctx context.Context, vmr *VmRef) (bool, error)
+	guestCheckVmRef(ctx context.Context, vmr *VmRef) error
 	guestGetLxcRawConfig(ctx context.Context, vmr *VmRef) (RawConfigLXC, error)
 	guestGetQemuRawConfig(ctx context.Context, vmr *VmRef) (RawConfigQemu, error)
 	guestListResources(ctx context.Context) (RawGuestResources, error)
@@ -30,3 +35,22 @@ type clientNew struct {
 func (c *clientNew) old() *Client { return c.oldClient }
 
 func (c *clientNew) apiGet() clientApiInterface { return c.api }
+
+func (c *clientNew) guestCheckVmRef(ctx context.Context, vmr *VmRef) error {
+	if vmr == nil {
+		return errors.New(VmRef_Error_Nil)
+	}
+	if vmr.node == "" || vmr.vmType == guestUnknown {
+		raw, err := c.guestListResources(ctx)
+		if err != nil {
+			return err
+		}
+		rawGuest, err := raw.SelectID(vmr.vmId)
+		if err != nil {
+			return err
+		}
+		vmr.node = rawGuest.GetNode()
+		vmr.vmType = rawGuest.GetType()
+	}
+	return nil
+}

--- a/proxmox/client__new__mock.go
+++ b/proxmox/client__new__mock.go
@@ -4,9 +4,11 @@ import "context"
 
 type MockClient struct {
 	// Guest
-	GuestGetLxcRawConfigFunc  func(ctx context.Context, vmr *VmRef) (RawConfigLXC, error)
-	GuestGetQemuRawConfigFunc func(ctx context.Context, vmr *VmRef) (RawConfigQemu, error)
-	GuestListResourcesFunc    func(ctx context.Context) (RawGuestResources, error)
+	GuestCheckPendingChangesFunc func(ctx context.Context, vmr *VmRef) (bool, error)
+	GuestCheckVmRefFunc          func(ctx context.Context, vmr *VmRef) error
+	GuestGetLxcRawConfigFunc     func(ctx context.Context, vmr *VmRef) (RawConfigLXC, error)
+	GuestGetQemuRawConfigFunc    func(ctx context.Context, vmr *VmRef) (RawConfigQemu, error)
+	GuestListResourcesFunc       func(ctx context.Context) (RawGuestResources, error)
 	// Pool
 	PoolGetRawConfigFunc        func(ctx context.Context, pool PoolName) (RawConfigPool, error)
 	PoolGetRawConfigNoCheckFunc func(ctx context.Context, pool PoolName) (RawConfigPool, error)
@@ -21,6 +23,20 @@ func (m *MockClient) panic(field string) { panic(field + " not set in MockClient
 func (m *MockClient) old() *Client { panic("old not implemented in MockClient") }
 
 func (m *MockClient) apiGet() clientApiInterface { panic("apiGet not implemented in MockClient") }
+
+func (m *MockClient) guestCheckPendingChanges(ctx context.Context, vmr *VmRef) (bool, error) {
+	if m.GuestCheckPendingChangesFunc == nil {
+		m.panic("GuestCheckPendingChangesFunc")
+	}
+	return m.GuestCheckPendingChangesFunc(ctx, vmr)
+}
+
+func (m *MockClient) guestCheckVmRef(ctx context.Context, vmr *VmRef) error {
+	if m.GuestCheckVmRefFunc == nil {
+		m.panic("GuestCheckVmRefFunc")
+	}
+	return m.GuestCheckVmRefFunc(ctx, vmr)
+}
 
 func (m *MockClient) guestGetLxcRawConfig(ctx context.Context, vmr *VmRef) (RawConfigLXC, error) {
 	if m.GuestGetLxcRawConfigFunc == nil {

--- a/proxmox/client__new__mock.go
+++ b/proxmox/client__new__mock.go
@@ -4,11 +4,13 @@ import "context"
 
 type MockClient struct {
 	// Guest
-	GuestCheckPendingChangesFunc func(ctx context.Context, vmr *VmRef) (bool, error)
-	GuestCheckVmRefFunc          func(ctx context.Context, vmr *VmRef) error
-	GuestGetLxcRawConfigFunc     func(ctx context.Context, vmr *VmRef) (RawConfigLXC, error)
-	GuestGetQemuRawConfigFunc    func(ctx context.Context, vmr *VmRef) (RawConfigQemu, error)
-	GuestListResourcesFunc       func(ctx context.Context) (RawGuestResources, error)
+	GuestCheckPendingChangesFunc    func(ctx context.Context, vmr *VmRef) (bool, error)
+	GuestCheckVmRefFunc             func(ctx context.Context, vmr *VmRef) error
+	GuestGetLxcActiveRawConfigFunc  func(ctx context.Context, vmr *VmRef) (raw RawConfigLXC, pending bool, err error)
+	GuestGetLxcRawConfigFunc        func(ctx context.Context, vmr *VmRef) (RawConfigLXC, error)
+	GuestGetQemuActiveRawConfigFunc func(ctx context.Context, vmr *VmRef) (raw RawConfigQemu, pending bool, err error)
+	GuestGetQemuRawConfigFunc       func(ctx context.Context, vmr *VmRef) (RawConfigQemu, error)
+	GuestListResourcesFunc          func(ctx context.Context) (RawGuestResources, error)
 	// Pool
 	PoolGetRawConfigFunc        func(ctx context.Context, pool PoolName) (RawConfigPool, error)
 	PoolGetRawConfigNoCheckFunc func(ctx context.Context, pool PoolName) (RawConfigPool, error)
@@ -38,11 +40,25 @@ func (m *MockClient) guestCheckVmRef(ctx context.Context, vmr *VmRef) error {
 	return m.GuestCheckVmRefFunc(ctx, vmr)
 }
 
+func (m *MockClient) guestGetLxcActiveRawConfig(ctx context.Context, vmr *VmRef) (raw RawConfigLXC, pending bool, err error) {
+	if m.GuestGetLxcActiveRawConfigFunc == nil {
+		m.panic("GuestGetLxcActiveRawConfigFunc")
+	}
+	return m.GuestGetLxcActiveRawConfigFunc(ctx, vmr)
+}
+
 func (m *MockClient) guestGetLxcRawConfig(ctx context.Context, vmr *VmRef) (RawConfigLXC, error) {
 	if m.GuestGetLxcRawConfigFunc == nil {
 		m.panic("GuestGetLxcRawConfigFunc")
 	}
 	return m.GuestGetLxcRawConfigFunc(ctx, vmr)
+}
+
+func (m *MockClient) guestGetQemuActiveRawConfig(ctx context.Context, vmr *VmRef) (raw RawConfigQemu, pending bool, err error) {
+	if m.GuestGetQemuActiveRawConfigFunc == nil {
+		m.panic("GuestGetQemuActiveRawConfigFunc")
+	}
+	return m.GuestGetQemuActiveRawConfigFunc(ctx, vmr)
 }
 
 func (m *MockClient) guestGetQemuRawConfig(ctx context.Context, vmr *VmRef) (RawConfigQemu, error) {

--- a/proxmox/config__guest.go
+++ b/proxmox/config__guest.go
@@ -344,12 +344,9 @@ func guestHasFeature(ctx context.Context, vmr *VmRef, client *Client, feature Gu
 }
 
 // Check if there are any pending changes that require a reboot to be applied.
+// Same as VmRef.PendingChanges.
 func GuestHasPendingChanges(ctx context.Context, vmr *VmRef, client *Client) (bool, error) {
-	params, err := pendingGuestConfigFromApi(ctx, vmr, client)
-	if err != nil {
-		return false, err
-	}
-	return keyExists(params, "pending") || keyExists(params, "delete"), nil
+	return vmr.PendingChanges(ctx, client)
 }
 
 // Reboot the specified guest
@@ -425,13 +422,6 @@ func ListGuestFeatures(ctx context.Context, vmr *VmRef, client *Client) (feature
 	}
 	features.Snapshot, err = guestHasFeature(ctx, vmr, client, GuestFeature_Snapshot)
 	return
-}
-
-func pendingGuestConfigFromApi(ctx context.Context, vmr *VmRef, client *Client) ([]interface{}, error) {
-	if err := client.CheckVmRef(ctx, vmr); err != nil {
-		return nil, err
-	}
-	return client.GetItemConfigInterfaceArray(ctx, "/nodes/"+vmr.node.String()+"/"+vmr.vmType.String()+"/"+vmr.vmId.String()+"/pending", "Guest", "PENDING CONFIG")
 }
 
 const guest_ApiError_AlreadyExists string = "config file already exists"

--- a/proxmox/config__lxc__new.go
+++ b/proxmox/config__lxc__new.go
@@ -749,6 +749,8 @@ type LxcSwap uint
 
 func (swap LxcSwap) String() string { return strconv.Itoa(int(swap)) } // String is for fmt.Stringer.
 
+// NewRawConfigLXCFromAPI returns the configuration of the LXC container.
+// Including pending changes.
 func NewRawConfigLXCFromAPI(ctx context.Context, vmr *VmRef, c *Client) (RawConfigLXC, error) {
 	if vmr == nil {
 		return nil, errors.New(VmRef_Error_Nil)
@@ -769,4 +771,23 @@ func guestGetLxcRawConfig_Unsafe(ctx context.Context, vmr *VmRef, c clientApiInt
 
 func (c *clientNew) guestGetLxcRawConfig(ctx context.Context, vmr *VmRef) (RawConfigLXC, error) {
 	return guestGetLxcRawConfig_Unsafe(ctx, vmr, c.api)
+}
+
+// NewActiveRawConfigLXCFromApi returns the active configuration of the LXC container.
+// Without pending changes.
+func NewActiveRawConfigLXCFromApi(ctx context.Context, vmr *VmRef, c *Client) (raw RawConfigLXC, pending bool, err error) {
+	return c.new().guestGetLxcActiveRawConfig(ctx, vmr)
+}
+
+func guestGetActiveRawLxcConfig_Unsafe(ctx context.Context, vmr *VmRef, c clientApiInterface) (raw RawConfigLXC, pending bool, err error) {
+	var tmpConfig map[string]any
+	tmpConfig, pending, err = vmr.pendingConfig(ctx, c)
+	if err != nil {
+		return nil, false, err
+	}
+	return &rawConfigLXC{a: tmpConfig}, pending, nil
+}
+
+func (c *clientNew) guestGetLxcActiveRawConfig(ctx context.Context, vmr *VmRef) (raw RawConfigLXC, pending bool, err error) {
+	return guestGetActiveRawLxcConfig_Unsafe(ctx, vmr, c.api)
 }

--- a/proxmox/config__lxc__new.go
+++ b/proxmox/config__lxc__new.go
@@ -288,6 +288,8 @@ func (config ConfigLXC) update_Unsafe(
 	currentState PowerState,
 	c *Client) error {
 
+	ca := c.new().apiGet()
+
 	var move []lxcMountMove
 	var resize []lxcMountResize
 	var getRootMount, getMounts, requiresOffStateForMountActions bool
@@ -368,7 +370,7 @@ func (config ConfigLXC) update_Unsafe(
 			return err
 		}
 		if currentState == PowerStateRunning || currentState == PowerStateUnknown { // If the guest is running, we have to check if it has pending changes
-			pendingChanges, err := GuestHasPendingChanges(ctx, vmr, c)
+			pendingChanges, err := vmr.pendingChanges(ctx, ca)
 			if err != nil {
 				return fmt.Errorf("error checking for pending changes: %w", err)
 			}

--- a/proxmox/config__qemu.go
+++ b/proxmox/config__qemu.go
@@ -476,6 +476,9 @@ func (config *ConfigQemu) mapToStruct(vmr *VmRef, params map[string]interface{})
 
 func (config ConfigQemu) Update(ctx context.Context, rebootIfNeeded bool, vmr *VmRef, client *Client) (rebootRequired bool, err error) {
 	// TODO add digest during update to check if the config has changed
+
+	ca := client.new().apiGet()
+
 	// currentConfig will be mutated
 	currentConfig, err := NewConfigQemuFromApi(ctx, vmr, client)
 	if err != nil {
@@ -532,8 +535,18 @@ func (config ConfigQemu) Update(ctx context.Context, rebootIfNeeded bool, vmr *V
 		if err != nil {
 			return false, fmt.Errorf("error updating VM: %v", err)
 		}
-		// Deleting these items can create pending changes
-		rebootRequired, err = GuestHasPendingChanges(ctx, vmr, client)
+
+	}
+
+	// Deleting items can create pending changes.
+	// Moving disks changes the disk id. we need to get the config again if any disk was moved.
+	if itemsToDeleteBeforeUpdate != "" || len(markedDisks.Move) != 0 {
+		var rawConfig map[string]any
+		rawConfig, rebootRequired, err = vmr.pendingConfig(ctx, ca)
+		if err != nil {
+			return
+		}
+		currentConfig, err = (&rawConfigQemu{a: rawConfig}).get(vmr)
 		if err != nil {
 			return
 		}
@@ -547,14 +560,6 @@ func (config ConfigQemu) Update(ctx context.Context, rebootIfNeeded bool, vmr *V
 			} else {
 				return rebootRequired, errors.New(ConfigQemu_Error_UnableToUpdateWithoutReboot)
 			}
-		}
-	}
-
-	// TODO GuestHasPendingChanges() has the current vm config technically. We can use this to avoid an extra API call.
-	if len(markedDisks.Move) != 0 { // Moving disks changes the disk id. we need to get the config again if any disk was moved.
-		currentConfig, err = NewConfigQemuFromApi(ctx, vmr, client)
-		if err != nil {
-			return
 		}
 	}
 
@@ -578,7 +583,7 @@ func (config ConfigQemu) Update(ctx context.Context, rebootIfNeeded bool, vmr *V
 	}
 
 	if !rebootRequired && !stopped { // only check if reboot is required if the vm is not already stopped
-		rebootRequired, err = GuestHasPendingChanges(ctx, vmr, client)
+		rebootRequired, err = vmr.pendingChanges(ctx, ca)
 		if err != nil {
 			return
 		}

--- a/proxmox/config__qemu.go
+++ b/proxmox/config__qemu.go
@@ -1219,6 +1219,8 @@ const (
 	qemuPrefixApiKeyUSB         string = "usb"
 )
 
+// NewRawConfigQemuFromApi returns the configuration of the LXC container.
+// Including pending changes.
 func NewRawConfigQemuFromApi(ctx context.Context, vmr *VmRef, client *Client) (RawConfigQemu, error) {
 	if vmr == nil {
 		return nil, errors.New(VmRef_Error_Nil)
@@ -1239,6 +1241,25 @@ func guestGetRawQemuConfig_Unsafe(ctx context.Context, vmr *VmRef, c clientApiIn
 
 func (c *clientNew) guestGetQemuRawConfig(ctx context.Context, vmr *VmRef) (RawConfigQemu, error) {
 	return guestGetRawQemuConfig_Unsafe(ctx, vmr, c.api)
+}
+
+// NewActiveRawConfigQemuFromApi returns the active configuration of the LXC container.
+// Without pending changes.
+func NewActiveRawConfigQemuFromApi(ctx context.Context, vmr *VmRef, c *Client) (raw RawConfigQemu, pending bool, err error) {
+	return c.new().guestGetQemuActiveRawConfig(ctx, vmr)
+}
+
+func guestGetActiveRawQemuConfig_Unsafe(ctx context.Context, vmr *VmRef, c clientApiInterface) (raw RawConfigQemu, pending bool, err error) {
+	var tmpConfig map[string]any
+	tmpConfig, pending, err = vmr.pendingConfig(ctx, c)
+	if err != nil {
+		return nil, false, err
+	}
+	return &rawConfigQemu{a: tmpConfig}, pending, nil
+}
+
+func (c *clientNew) guestGetQemuActiveRawConfig(ctx context.Context, vmr *VmRef) (raw RawConfigQemu, pending bool, err error) {
+	return guestGetActiveRawQemuConfig_Unsafe(ctx, vmr, c.api)
 }
 
 func NewConfigQemuFromApi(ctx context.Context, vmr *VmRef, client *Client) (config *ConfigQemu, err error) {


### PR DESCRIPTION
Add ways to check if there are pending config changes.
Add a way to get the active config, as the normal config has the pending changes included.
Improved some tests due to the new mocks.

Closes #458