### PR TITLE
Feat: get pending current config

### DIFF
--- a/proxmox/config__lxc__new.go
+++ b/proxmox/config__lxc__new.go
@@ -796,7 +796,7 @@ func NewActiveRawConfigLXCFromApi(ctx context.Context, vmr *VmRef, c *Client) (r
 
 func guestGetActiveRawLxcConfig_Unsafe(ctx context.Context, vmr *VmRef, c clientApiInterface) (raw RawConfigLXC, pending bool, err error) {
 	var tmpConfig map[string]any
-	tmpConfig, pending, err = vmr.pendingConfig(ctx, c)
+	tmpConfig, pending, err = vmr.pendingActiveConfig(ctx, c)
 	if err != nil {
 		return nil, false, err
 	}

--- a/proxmox/config__qemu.go
+++ b/proxmox/config__qemu.go
@@ -1253,7 +1253,7 @@ func NewActiveRawConfigQemuFromApi(ctx context.Context, vmr *VmRef, c *Client) (
 
 func guestGetActiveRawQemuConfig_Unsafe(ctx context.Context, vmr *VmRef, c clientApiInterface) (raw RawConfigQemu, pending bool, err error) {
 	var tmpConfig map[string]any
-	tmpConfig, pending, err = vmr.pendingConfig(ctx, c)
+	tmpConfig, pending, err = vmr.pendingActiveConfig(ctx, c)
 	if err != nil {
 		return nil, false, err
 	}

--- a/proxmox/config__qemu.go
+++ b/proxmox/config__qemu.go
@@ -542,7 +542,7 @@ func (config ConfigQemu) Update(ctx context.Context, rebootIfNeeded bool, vmr *V
 	// Moving disks changes the disk id. we need to get the config again if any disk was moved.
 	if itemsToDeleteBeforeUpdate != "" || len(markedDisks.Move) != 0 {
 		var rawConfig map[string]any
-		rawConfig, rebootRequired, err = vmr.pendingConfig(ctx, ca)
+		rawConfig, rebootRequired, err = vmr.pendingCurrentConfig(ctx, ca)
 		if err != nil {
 			return
 		}

--- a/proxmox/config__qemu_test.go
+++ b/proxmox/config__qemu_test.go
@@ -4380,27 +4380,7 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 }
 
 func Test_ConfigQemu_get(t *testing.T) {
-	baseConfig := func(config ConfigQemu) *ConfigQemu {
-		if config.CPU == nil {
-			config.CPU = &QemuCPU{}
-		}
-		if config.Description == nil {
-			config.Description = util.Pointer("")
-		}
-		if config.Memory == nil {
-			config.Memory = &QemuMemory{}
-		}
-		if config.Name == nil {
-			config.Name = util.Pointer(GuestName(""))
-		}
-		if config.Protection == nil {
-			config.Protection = util.Pointer(false)
-		}
-		if config.Tablet == nil {
-			config.Tablet = util.Pointer(true)
-		}
-		return &config
-	}
+	baseConfig := func(config ConfigQemu) *ConfigQemu { return config.baseTest() }
 	parseIP := func(rawIP string) (ip netip.Addr) {
 		ip, _ = netip.ParseAddr(rawIP)
 		return
@@ -7374,29 +7354,14 @@ func Test_ActiveRawConfigQemu_Get(t *testing.T) {
 		if config.Boot == "" {
 			config.Boot = "cdn"
 		}
-		if config.CPU == nil {
-			config.CPU = &QemuCPU{}
-		}
-		if config.Description == nil {
-			config.Description = util.Pointer("")
-		}
 		if config.EFIDisk == nil {
 			config.EFIDisk = QemuDevice{}
 		}
 		if config.Hotplug == "" {
 			config.Hotplug = "network,disk,usb"
 		}
-		if config.Memory == nil {
-			config.Memory = &QemuMemory{}
-		}
-		if config.Name == nil {
-			config.Name = util.Pointer(GuestName(""))
-		}
 		if config.Onboot == nil {
 			config.Onboot = util.Pointer(true)
-		}
-		if config.Protection == nil {
-			config.Protection = util.Pointer(false)
 		}
 		if config.QemuDisks == nil {
 			config.QemuDisks = QemuDevices{}
@@ -7416,10 +7381,7 @@ func Test_ActiveRawConfigQemu_Get(t *testing.T) {
 		if config.Scsihw == "" {
 			config.Scsihw = "lsi"
 		}
-		if config.Tablet == nil {
-			config.Tablet = util.Pointer(true)
-		}
-		return &config
+		return config.baseTest()
 	}
 	tests := []struct {
 		name    string
@@ -9627,4 +9589,26 @@ func Test_ConfigQemu_Validate(t *testing.T) {
 			})
 		}
 	}
+}
+
+func (config ConfigQemu) baseTest() *ConfigQemu {
+	if config.CPU == nil {
+		config.CPU = &QemuCPU{}
+	}
+	if config.Description == nil {
+		config.Description = util.Pointer("")
+	}
+	if config.Memory == nil {
+		config.Memory = &QemuMemory{}
+	}
+	if config.Name == nil {
+		config.Name = util.Pointer(GuestName(""))
+	}
+	if config.Protection == nil {
+		config.Protection = util.Pointer(false)
+	}
+	if config.Tablet == nil {
+		config.Tablet = util.Pointer(true)
+	}
+	return &config
 }

--- a/proxmox/vmref.go
+++ b/proxmox/vmref.go
@@ -248,7 +248,13 @@ func (c *clientNew) guestCheckPendingChanges(ctx context.Context, vmr *VmRef) (b
 	return vmr.pendingChanges(ctx, c.apiGet())
 }
 
-func (vmr *VmRef) pendingConfig(ctx context.Context, c clientApiInterface) (map[string]any, bool, error) {
+const (
+	pendingCurrent  = "value"
+	pendingProperty = "key"
+)
+
+// pendingActiveConfig returns the active config without pending changes applied.
+func (vmr *VmRef) pendingActiveConfig(ctx context.Context, c clientApiInterface) (map[string]any, bool, error) {
 	changes, err := c.getGuestPendingChanges(ctx, vmr)
 	if err != nil {
 		return nil, false, err
@@ -257,7 +263,7 @@ func (vmr *VmRef) pendingConfig(ctx context.Context, c clientApiInterface) (map[
 	config := make(map[string]any, len(changes))
 	for _, item := range changes {
 		m := item.(map[string]any)
-		config[m["key"].(string)] = m["value"]
+		config[m[pendingProperty].(string)] = m[pendingCurrent]
 		if len(m) > 2 {
 			pending = true
 		}

--- a/proxmox/vmref.go
+++ b/proxmox/vmref.go
@@ -249,7 +249,9 @@ func (c *clientNew) guestCheckPendingChanges(ctx context.Context, vmr *VmRef) (b
 }
 
 const (
+	pendingNew      = "pending"
 	pendingCurrent  = "value"
+	pendingDelete   = "delete"
 	pendingProperty = "key"
 )
 
@@ -267,6 +269,30 @@ func (vmr *VmRef) pendingActiveConfig(ctx context.Context, c clientApiInterface)
 		if len(m) > 2 {
 			pending = true
 		}
+	}
+	return config, pending, nil
+}
+
+// pendingCurrentConfig returns the current config with any pending changes applied.
+func (vmr *VmRef) pendingCurrentConfig(ctx context.Context, c clientApiInterface) (map[string]any, bool, error) {
+	changes, err := c.getGuestPendingChanges(ctx, vmr)
+	if err != nil {
+		return nil, false, err
+	}
+	var pending bool
+	config := make(map[string]any, len(changes))
+	for _, item := range changes {
+		m := item.(map[string]any)
+		if _, ok := m[pendingDelete]; ok {
+			pending = true
+			continue
+		}
+		if v, ok := m[pendingNew]; ok {
+			config[m[pendingProperty].(string)] = v
+			pending = true
+			continue
+		}
+		config[m[pendingProperty].(string)] = m[pendingCurrent]
 	}
 	return config, pending, nil
 }


### PR DESCRIPTION
Add support for getting the pending config, which is an optimization for getting the pending flag and the normal config in 1 API call.

Reduced duplicate code between tests.