### PR TITLE
Feat: HaResource delete

### DIFF
--- a/proxmox/client__api.go
+++ b/proxmox/client__api.go
@@ -9,6 +9,7 @@ import (
 // in the future we might put the interface even lower, but for now this is sufficient
 type clientApiInterface interface {
 	createHaRule(ctx context.Context, params map[string]any) error
+	deleteHaResource(ctx context.Context, id GuestID) error
 	deleteHaRule(ctx context.Context, id HaRuleID) error
 	getGuestConfig(ctx context.Context, vmr *VmRef) (map[string]any, error)
 	getGuestPendingChanges(ctx context.Context, vmr *VmRef) ([]any, error)
@@ -31,6 +32,10 @@ type clientAPI struct {
 
 func (c *clientAPI) createHaRule(ctx context.Context, params map[string]any) error {
 	return c.post(ctx, "/cluster/ha/rules", params)
+}
+
+func (c *clientAPI) deleteHaResource(ctx context.Context, id GuestID) error {
+	return c.delete(ctx, "/cluster/ha/resources/"+id.String())
 }
 
 func (c *clientAPI) deleteHaRule(ctx context.Context, id HaRuleID) error {

--- a/proxmox/client__api__mock.go
+++ b/proxmox/client__api__mock.go
@@ -6,6 +6,7 @@ import (
 
 type mockClientAPI struct {
 	createHaRuleFunc           func(ctx context.Context, params map[string]any) error
+	deleteHaResourceFunc       func(ctx context.Context, id GuestID) error
 	deleteHaRuleFunc           func(ctx context.Context, id HaRuleID) error
 	getGuestConfigFunc         func(ctx context.Context, vmr *VmRef) (map[string]any, error)
 	getGuestPendingChangesFunc func(ctx context.Context, vmr *VmRef) ([]any, error)
@@ -28,6 +29,13 @@ func (m *mockClientAPI) createHaRule(ctx context.Context, params map[string]any)
 		m.panic("createHaRuleFunc")
 	}
 	return m.createHaRuleFunc(ctx, params)
+}
+
+func (m *mockClientAPI) deleteHaResource(ctx context.Context, id GuestID) error {
+	if m.deleteHaResourceFunc == nil {
+		m.panic("deleteHaResourceFunc")
+	}
+	return m.deleteHaResourceFunc(ctx, id)
 }
 
 func (m *mockClientAPI) deleteHaRule(ctx context.Context, id HaRuleID) error {

--- a/proxmox/client__new.go
+++ b/proxmox/client__new.go
@@ -27,6 +27,7 @@ type ClientNew interface {
 	haCreateNodeAffinityRuleNoCheck(ctx context.Context, ha HaNodeAffinityRule) error
 	haCreateResourceAffinityRule(ctx context.Context, ha HaResourceAffinityRule) error
 	haCreateResourceAffinityRuleNoCheck(ctx context.Context, ha HaResourceAffinityRule) error
+	haDeleteResource(ctx context.Context, id GuestID) error
 	haDeleteRule(ctx context.Context, id HaRuleID) error
 	haDeleteRuleNoCheck(ctx context.Context, id HaRuleID) error
 	haGetRule(ctx context.Context, id HaRuleID) (HaRule, error)

--- a/proxmox/client__new__mock.go
+++ b/proxmox/client__new__mock.go
@@ -16,6 +16,7 @@ type MockClient struct {
 	HaCreateNodeAffinityRuleNoCheckFunc     func(ctx context.Context, ha HaNodeAffinityRule) error
 	HaCreateResourceAffinityRuleFunc        func(ctx context.Context, ha HaResourceAffinityRule) error
 	HaCreateResourceAffinityRuleNoCheckFunc func(ctx context.Context, ha HaResourceAffinityRule) error
+	HaDeleteResourceFunc                    func(ctx context.Context, id GuestID) error
 	HaDeleteRuleFunc                        func(ctx context.Context, id HaRuleID) error
 	HaDeleteRuleNoCheckFunc                 func(ctx context.Context, id HaRuleID) error
 	HaGetRuleFunc                           func(ctx context.Context, id HaRuleID) (HaRule, error)
@@ -115,6 +116,13 @@ func (m *MockClient) haCreateResourceAffinityRuleNoCheck(ctx context.Context, ha
 		m.panic("HaCreateResourceAffinityRuleNoCheckFunc")
 	}
 	return m.HaCreateResourceAffinityRuleNoCheckFunc(ctx, ha)
+}
+
+func (m *MockClient) haDeleteResource(ctx context.Context, id GuestID) error {
+	if m.HaDeleteResourceFunc == nil {
+		m.panic("HaDeleteResourceFunc")
+	}
+	return m.HaDeleteResourceFunc(ctx, id)
 }
 
 func (m *MockClient) haDeleteRule(ctx context.Context, id HaRuleID) error {

--- a/proxmox/config__guest.go
+++ b/proxmox/config__guest.go
@@ -233,6 +233,29 @@ const (
 	GuestIdMinimum        = 100
 )
 
+func (id GuestID) DeleteHaResource(ctx context.Context, c *Client) error {
+	err := id.Validate()
+	if err != nil {
+		return err
+	}
+	return c.new().haDeleteResource(ctx, id)
+}
+
+func (c *clientNew) haDeleteResource(ctx context.Context, id GuestID) error {
+	return id.deleteHaResource(ctx, c.apiGet())
+}
+
+func (id GuestID) deleteHaResource(ctx context.Context, c clientApiInterface) error {
+	err := c.deleteHaResource(ctx, id)
+	if err != nil {
+		if strings.HasPrefix(err.Error(), "500 cannot delete service") {
+			return Error.haResourceDoesNotExist(id)
+		}
+		return err
+	}
+	return nil
+}
+
 func (id GuestID) errorContext() string {
 	return "ID " + id.String()
 }

--- a/proxmox/config__ha__rules.go
+++ b/proxmox/config__ha__rules.go
@@ -211,26 +211,24 @@ func (r *rawHaNodeAffinityRule) GetStrict() bool {
 
 func (r *rawHaNodeAffinityRule) get() *HaNodeAffinityRule {
 	return &HaNodeAffinityRule{
-		Comment:   util.Pointer(r.GetComment()),
-		Enabled:   util.Pointer(r.GetEnabled()),
-		Guests:    util.Pointer(r.GetGuests()),
-		ID:        r.GetID(),
-		Nodes:     util.Pointer(r.GetNodes()),
-		Strict:    util.Pointer(r.GetStrict()),
-		rawDigest: r.getDigest()}
+		Comment: util.Pointer(r.GetComment()),
+		Enabled: util.Pointer(r.GetEnabled()),
+		Guests:  util.Pointer(r.GetGuests()),
+		ID:      r.GetID(),
+		Nodes:   util.Pointer(r.GetNodes()),
+		Strict:  util.Pointer(r.GetStrict())}
 }
 
 func (r *rawHaNodeAffinityRule) getDigest() digest { return haGetDigest(r.a) }
 
 type HaNodeAffinityRule struct {
-	Comment   *string         `json:"comment,omitempty"` // Never nil when returned
-	Digest    [sha1.Size]byte `json:"digest,omitempty"`  // only returned.
-	Enabled   *bool           `json:"enabled,omitempty"` // Never nil when returned
-	Guests    *[]VmRef        `json:"guests,omitempty"`  // Never nil when returned
-	ID        HaRuleID        `json:"id"`
-	Nodes     *[]HaNode       `json:"nodes,omitempty"`  // Never nil when returned
-	Strict    *bool           `json:"strict,omitempty"` // Never nil when returned
-	rawDigest digest          `json:"-"`
+	Comment *string         `json:"comment,omitempty"` // Never nil when returned
+	Digest  [sha1.Size]byte `json:"digest,omitempty"`  // only returned.
+	Enabled *bool           `json:"enabled,omitempty"` // Never nil when returned
+	Guests  *[]VmRef        `json:"guests,omitempty"`  // Never nil when returned
+	ID      HaRuleID        `json:"id"`
+	Nodes   *[]HaNode       `json:"nodes,omitempty"`  // Never nil when returned
+	Strict  *bool           `json:"strict,omitempty"` // Never nil when returned
 }
 
 const (
@@ -477,12 +475,11 @@ func (r *rawHaResourceAffinityRule) GetID() HaRuleID { return haGetID(r.a) }
 
 func (r *rawHaResourceAffinityRule) get() *HaResourceAffinityRule {
 	return &HaResourceAffinityRule{
-		Affinity:  util.Pointer(r.GetAffinity()),
-		Comment:   util.Pointer(r.GetComment()),
-		Enabled:   util.Pointer(r.GetEnabled()),
-		Guests:    util.Pointer(r.GetGuests()),
-		ID:        r.GetID(),
-		rawDigest: r.getDigest()}
+		Affinity: util.Pointer(r.GetAffinity()),
+		Comment:  util.Pointer(r.GetComment()),
+		Enabled:  util.Pointer(r.GetEnabled()),
+		Guests:   util.Pointer(r.GetGuests()),
+		ID:       r.GetID()}
 }
 
 func (r *rawHaResourceAffinityRule) getDigest() digest { return haGetDigest(r.a) }
@@ -492,13 +489,12 @@ const (
 )
 
 type HaResourceAffinityRule struct {
-	Affinity  *HaAffinity     `json:"affinity,omitempty"` // Never nil when returned
-	Comment   *string         `json:"comment,omitempty"`  // Never nil when returned
-	Digest    [sha1.Size]byte `json:"digest,omitempty"`   // only returned.
-	Enabled   *bool           `json:"enabled,omitempty"`  // Never nil when returned
-	Guests    *[]VmRef        `json:"guests,omitempty"`   // Never nil when returned
-	ID        HaRuleID        `json:"id"`
-	rawDigest digest          `json:"-"`
+	Affinity *HaAffinity     `json:"affinity,omitempty"` // Never nil when returned
+	Comment  *string         `json:"comment,omitempty"`  // Never nil when returned
+	Digest   [sha1.Size]byte `json:"digest,omitempty"`   // only returned.
+	Enabled  *bool           `json:"enabled,omitempty"`  // Never nil when returned
+	Guests   *[]VmRef        `json:"guests,omitempty"`   // Never nil when returned
+	ID       HaRuleID        `json:"id"`
 }
 
 const (

--- a/proxmox/config__ha__rules_test.go
+++ b/proxmox/config__ha__rules_test.go
@@ -574,8 +574,7 @@ func Test_HaNodeAffinityRule_Get(t *testing.T) {
 						"digest": string("ebefeede3059417444308d2e58d2a5e504fe6151")},
 					outputPublic: baseRule(HaNodeAffinityRule{
 						Digest: [20]byte{0xeb, 0xef, 0xee, 0xde, 0x30, 0x59, 0x41, 0x74, 0x44, 0x30, 0x8d, 0x2e, 0x58, 0xd2, 0xa5, 0xe5, 0x04, 0xfe, 0x61, 0x51}}),
-					outputPrivate: util.Pointer(baseRule(HaNodeAffinityRule{
-						rawDigest: "ebefeede3059417444308d2e58d2a5e504fe6151"}))}}},
+					outputPrivate: util.Pointer(baseRule(HaNodeAffinityRule{}))}}},
 		{category: `Enabled`,
 			tests: []test{
 				{name: "false float",
@@ -1246,8 +1245,7 @@ func Test_HaResourceAffinityRule_Get(t *testing.T) {
 						"digest": string("ebefeede3059417444308d2e58d2a5e504fe6151")},
 					outputPublic: baseRule(HaResourceAffinityRule{
 						Digest: [20]byte{0xeb, 0xef, 0xee, 0xde, 0x30, 0x59, 0x41, 0x74, 0x44, 0x30, 0x8d, 0x2e, 0x58, 0xd2, 0xa5, 0xe5, 0x04, 0xfe, 0x61, 0x51}}),
-					outputPrivate: util.Pointer(baseRule(HaResourceAffinityRule{
-						rawDigest: "ebefeede3059417444308d2e58d2a5e504fe6151"}))}}},
+					outputPrivate: util.Pointer(baseRule(HaResourceAffinityRule{}))}}},
 		{category: `Enabled`,
 			tests: []test{
 				{name: "false float",

--- a/proxmox/error.go
+++ b/proxmox/error.go
@@ -40,3 +40,13 @@ func (errorMsg) guestIsProtectedCantDelete(id GuestID) error {
 		err: Error.GuestIsProtectedCantDelete(),
 		id:  id}
 }
+
+var errGuestNotHaManaged = errors.New("guest is not ha managed")
+
+func (msg errorMsg) HaResourceDoesNotExist() error { return errGuestNotHaManaged }
+
+func (errorMsg) haResourceDoesNotExist(id GuestID) error {
+	return &errorWrapper[GuestID]{
+		err: Error.HaResourceDoesNotExist(),
+		id:  id}
+}


### PR DESCRIPTION
Adds functionality to delete a HA Resource.

Removes unused `rawDigest` from the HA rules.

Related to https://github.com/Telmate/terraform-provider-proxmox/issues/1394