### PR TITLE
docs: update readme

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,34 @@
 TEST?=$(shell go list ./...)
+SRC?=$(shell find cli proxmox internal main.go -name '*.go') go.mod go.sum
+ 
+PHONY += all
+all: build bash_completion
 
+PHONY += build
+build: proxmox-api-go
+
+proxmox-api-go: $(SRC)
+	go build -o proxmox-api-go
+
+PHONY += bash_completion
+bash_completion: proxmox-api-go-completion.bash
+
+proxmox-api-go-completion.bash: proxmox-api-go
+	NEW_CLI=true ./proxmox-api-go completion bash > $@
+
+PHONY += install_bash_completion
+install_bash_completion: $(HOME)/.local/share/bash-completion/completions/proxmox-api-go
+
+$(HOME)/.local/share/bash-completion/completions/proxmox-api-go: proxmox-api-go-completion.bash
+	@mkdir -p $(dir $@)
+	cp $^ $@
+
+PHONY += test
 test:
 	@go test $(TEST)
+
+PHONY += clean
+clean:
+	rm -f proxmox-api-go proxmox-api-go-completion.bash
+
+.PHONY: $(PHONY)

--- a/README.md
+++ b/README.md
@@ -10,13 +10,22 @@ Want to help with the project please refer to our [style-guide](docs/style-guide
 
 ## Build
 
+An example of usage of the SDK is the CLI in this project, it can be compiled using the following command :
+
 ```sh
-go build -o proxmox-api-go
+make build
 ```
 
-## Run
+> [!NOTE]
+> It is possible to generate autocompletion for the CLI by executing
+> ```sh
+> make bash_completion  # or install_bash_completion to install completion locally
+> ```
+> However, the autocompletion will only be usable if `proxmox-api-go` is in `$PATH` and `NEW_CLI` is set to `true` (see below the new CLI usage)
 
-Create a local `.env` file in the root directory of the project and add the following environment variables:
+## Using the CLI
+
+Start with configuring the CLI, you can do so by creating a local `.env` file in the root directory of the project and add the following environment variables:
 
 ```sh
 PM_API_URL="https://xxxx.com:8006/api2/json"
@@ -26,9 +35,10 @@ PM_OTP=otpcode (only if required)
 PM_HTTP_HEADERS=Key,Value,Key1,Value1 (only if required)
 ```
 
-**Note**: Do not commit your local `.env` file to version control to keep your credentials secure.
+> [!WARNING]
+> Do not commit your local `.env` file to version control to keep your credentials secure.
 
-Or export the environment variables:
+It is also possible to export the environment variables:
 
 ```sh
 export PM_API_URL="https://xxxx.com:8006/api2/json"
@@ -38,376 +48,86 @@ export PM_OTP=otpcode (only if required)
 export PM_HTTP_HEADERS=Key,Value,Key1,Value1 (only if required)
 ```
 
-Run commands (examples, not a complete list):
+#### The new CLI
+
+In order to use the new CLI, the environment variable `NEW_CLI` must be equal to `true` like that :
+
+```sh
+export NEW_CLI=true
+# unset NEW_CLI  # To revert this operation
+```
+
+Then, it is possible to use `./proxmox-api-go help` to browse available commands.
+
+### The legacy CLI
+
+This is the default mode, and it is **deprecated**, however here is a list of commands (examples, not a complete list):
 
 ```sh
 ./proxmox-api-go installQemu proxmox-node-name < qemu1.json
-
 ./proxmox-api-go createQemu 123 proxmox-node-name < qemu1.json
-
 ./proxmox-api-go -debug start 123
-
 ./proxmox-api-go -debug stop 123
-
 ./proxmox-api-go cloneQemu template-name proxmox-node-name < clone1.json
-
 ./proxmox-api-go migrate 123 migrate-to-proxmox-node-name
-
 ./proxmox-api-go createQemuSnapshot vm-name snapshot_name
-
 ./proxmox-api-go deleteQemuSnapshot vm-name snapshot_name
-
 ./proxmox-api-go listQemuSnapshot vm-name
-
 ./proxmox-api-go rollbackQemu vm-name
-
 ./proxmox-api-go getResourceList
-
 ./proxmox-api-go getVmList
-
 ./proxmox-api-go getUserList
-
 ./proxmox-api-go getUser userid
-
 ./proxmox-api-go updateUserPassword userid password
-
 ./proxmox-api-go setUser userid password < user.json
-
 ./proxmox-api-go deleteUser userid
-
 ./proxmox-api-go getAcmeAccountList
-
 ./proxmox-api-go getAcmeAccount accountid
-
 ./proxmox-api-go createAcmeAccount accountid < acmeAccount.json
-
 ./proxmox-api-go updateAcmeAccountEmail accountid email0,email1,email2
-
 ./proxmox-api-go deleteAcmeAccount accountid
-
 ./proxmox-api-go getAcmePluginList
-
 ./proxmox-api-go getAcmePlugin pluginid
-
 ./proxmox-api-go setAcmePlugin pluginid < acmePlugin.json
-
 ./proxmox-api-go deleteAcmePlugin pluginid
-
 ./proxmox-api-go getMetricsServerList
-
 ./proxmox-api-go getMetricsServer metricsid
-
 ./proxmox-api-go setMetricsServer metricsid < metricsServer.json
-
 ./proxmox-api-go deleteMetricsServer metricsid
-
 ./proxmox-api-go getStorageList
-
 ./proxmox-api-go getStorage storageid
-
 ./proxmox-api-go createStorage storageid < storage.json
-
 ./proxmox-api-go updateStorage storageid < storage.json
-
 ./proxmox-api-go deleteStorage
-
 ./proxmox-api-go getNetworkList node
-
 ./proxmox-api-go getNetworkInterface node interfaceName
-
 ./proxmox-api-go createNetwork < network.json
-
 ./proxmox-api-go updateNetwork < network.json
-
 ./proxmox-api-go deleteNetwork node iface
-
 ./proxmox-api-go applyNetwork node
-
 ./proxmox-api-go revertNetwork node
-
 ./proxmox-api-go node reboot proxmox-node-name
-
 ./proxmox-api-go node shutdown proxmox-node-name
-
 ./proxmox-api-go unlink 123 proxmox-node-name "virtio1,virtio2,virtioN" [false|true]
-
 ```
 
 ## Proxy server support
 
-Just use the flag -proxy and specify your proxy url and port
+With the new CLI :
+
+```sh
+./proxmox-api-go --proxy https://localhost:8080 <cmd>
+```
+
+With the legacy CLI :
 
 ```sh
 ./proxmox-api-go -proxy https://localhost:8080 start 123
 ```
 
-### Format
+## JSON Config format
 
-createQemu JSON Sample:
-
-```json
-{
-  "name": "golang1.test.com",
-  "description": "Test proxmox-api-go",
-  "memory": {
-    "capacity": 2048
-  },
-  "ostype": "l26",
-  "cores": 2,
-  "sockets": 1,
-  "iso": {
-    "storage": "local",
-    "file": "ubuntu-14.04.5-server-amd64.iso"
-  },
-  "disk": {
-    "0": {
-      "type": "virtio",
-      "storage": "local",
-      "storage_type": "dir",
-      "size": "30G",
-      "backup": true
-    }
-  },
-  "efidisk": {
-    "storage": "local",
-    "pre-enrolled-keys": "1",
-    "efitype": "4m"
-  },
-  "network": {
-    "0": {
-      "model": "virtio",
-      "bridge": "nat"
-    },
-    "1": {
-      "model": "virtio",
-      "bridge": "vmbr0",
-      "firewall": true,
-      "tag": -1
-    }
-  },
-  "rng0": {
-    "source": "/dev/urandom",
-    "max_bytes": "1024",
-    "period": "1000"
-  },
-  "usb": {
-    "0": {
-      "host": "0658:0200",
-      "usb3": true
-    }
-  }
-}
-```
-
-cloneQemu JSON Sample:
-
-```json
-{
-  "full": {
-    "node": "pve-latest",
-    "name": "golang2.test.com",
-    "pool": "my-pool",
-    "storage": "local-zfs",
-    "format": "raw"
-  }
-}
-```
-
-setUser JSON Sample:
-
-```json
-{
-  "comment": "",
-  "email": "b.wayne@proxmox.com",
-  "enable": true,
-  "expire": 0,
-  "firstname": "Bruce",
-  "lastname": "Wayne",
-  "groups": [
-    "admins",
-    "usergroup"
-  ],
-  "keys": "2fa key"
-}
-```
-
-createAcmeAccount JSON Sample:
-
-```json
-{
-  "contact": [
-    "b.wayne@proxmox.com",
-    "c.kent@proxmox.com"
-  ],
-  "directory": "https://acme-staging-v02.api.letsencrypt.org/directory",
-  "tos": true
-}
-```
-
-setAcmePlugin JSON Sample:
-
-```json
-{
-  "api": "aws",
-  "data": "AWS_ACCESS_KEY_ID=DEMOACCESSKEYID\nAWS_SECRET_ACCESS_KEY=DEMOSECRETACCESSKEY\n",
-  "enable": true,
-  "validation-delay": 30
-}
-```
-
-setMetricsServer JSON Sample:
-
-```json
-{
-  "port": 8086,
-  "server": "192.168.67.3",
-  "type": "influxdb",
-  "enable": true,
-  "mtu": 1500,
-  "timeout": 1,
-  "influxdb": {
-    "protocol": "https",
-    "max-body-size": 25000000,
-    "verify-certificate": false,
-    "token": "Rm8mqheWSVrrKKBW"
-  }
-}
-```
-
-createStorage JSON Sample:
-
-```json
-{
-  "enable": true,
-  "type": "smb",
-  "smb": {
-    "username": "b.wayne",
-    "share": "NetworkShare",
-    "preallocation": "metadata",
-    "domain": "organization.com",
-    "server": "10.20.1.1",
-    "version": "3.11",
-    "password": "Enter123!"
-  },
-  "content": {
-    "backup": true,
-    "iso": false,
-    "template": true,
-    "diskimage": true,
-    "container": true,
-    "snippets": false
-  },
-  "backupretention": {
-    "last": 10,
-    "hourly": 4,
-    "daily": 7,
-    "monthly": 3,
-    "weekly": 2,
-    "yearly": 1
-  }
-}
-```
-
-### Cloud-init options
-
-Cloud-init VMs must be cloned from a cloud-init ready template.
-See: https://pve.proxmox.com/wiki/Cloud-Init_Support
-
-- `username` - User name to change ssh keys and password for instead of the image’s configured default user.
-- `userpassword` - Password to assign the user.
-- `cicustom` - Specify custom files to replace the automatically generated ones at start, as JSON object of:
-  - `meta` - JSON object of:
-    - `path` - as string
-    - `storage` - as string
-  - `network` - JSON object of:
-    - `path` - as string
-    - `storage` - as string
-  - `user` - JSON object of:
-    - `path` - as string
-    - `storage` - as string
-  - `vendor` - JSON object of:
-    - `path` - as string
-    - `storage` - as string
-- `dns` - Sets DNS settings, as JSON object of:
-  - `nameservers` - Sets DNS server IP address for a VM, as list of stings.
-  - `searchdomain` - Sets DNS search domains for a VM, as string.
-- `sshkeys` - public ssh keys, as list of strings.
-- `ipconfig` - Sets IP configuration for network interfaces, as dictionary of interface index number to JSON object:
-  - `ip4` - for IPv4, as JSON object of:
-    - `address` - IPv4Format/CIDR
-    - `dhcp` - true/false
-    - `gateway` - GatewayIPv4
-  - `ip6` - for IPv6, as JSON object of:
-    - `address` - IPv6Format/CIDR
-    - `dhcp` - true/false
-    - `gateway` - GatewayIPv6
-    - `slaac` - true/false
-- `ciupgrade` - If true does a package update after startup
-
-Example:
-
-```json
-{
-  "cloudinit": {
-    "username": "test",
-    "userpassword": "passw0rd",
-    "cicustom": {
-      "meta": {
-        "path": "path/to/meta",
-        "storage": "local"
-      },
-      "network": {
-        "path": "path/to/network",
-        "storage": "local"
-      },
-      "user": {
-        "path": "path/to/user",
-        "storage": "local"
-      },
-      "vendor": {
-        "path": "path/to/vendor",
-        "storage": "local"
-      }
-    },
-    "dns": {
-      "nameservers": [
-        "8.8.8.8"
-      ],
-      "searchdomain": "test.com"
-    },
-    "sshkeys": [
-      "...",
-      "..."
-    ],
-    "ipconfig": {
-      "0": {
-        "ip4": {
-          "address": "10.0.2.17/24",
-          "gateway": "10.0.2.2"
-        },
-        "ip6": {
-          "address": "2001:0db8:0:2::17/64",
-          "gateway": "2001:0db8:0:2::2"
-        }
-      },
-      "1": {
-        "ip4": {
-          "dhcp": true
-        },
-        "ip6": {
-          "dhcp": true
-        }
-      },
-      "2": {
-        "ip6": {
-          "slaac": true
-        }
-      }
-    },
-    "ciupgrade": true
-  }
-}
-```
+Many configs are passed through `stdin` or by specifying a file (with the parameter `--file` with the new CLI), examples of these configs can be found in [this directory](./docs/config-examples).
 
 ### ISO requirements (non cloud-init)
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ export PM_OTP=otpcode (only if required)
 export PM_HTTP_HEADERS=Key,Value,Key1,Value1 (only if required)
 ```
 
-#### The new CLI
+### The new CLI
 
 In order to use the new CLI, the environment variable `NEW_CLI` must be equal to `true` like that :
 
@@ -127,9 +127,9 @@ With the legacy CLI :
 
 ## JSON Config format
 
-Many configs are passed through `stdin` or by specifying a file (with the parameter `--file` with the new CLI), examples of these configs can be found in [this directory](./docs/config-examples).
+Many commands use configs from files or `stdin`, examples of these configs can be found in [this directory](./docs/config-examples).
 
-### ISO requirements (non cloud-init)
+## ISO requirements (non cloud-init)
 
 Kickstart auto install
 

--- a/docs/config-examples/README.md
+++ b/docs/config-examples/README.md
@@ -1,0 +1,44 @@
+# JSON Config examples for commands
+
+Many configs are passed through `stdin` or by specifying a file (with the parameter `--file` with the new CLI), here are examples about them :
+
+* [createQemu](./create-qemu.example.json)
+* [cloneQemu](./clone-qemu.example.json)
+* [setUser](./set-user.example.json)
+* [createAcmeAccount](./create-acme-account.example.json)
+* [setAcmePlugin](./set-acme-plugin.example.json)
+* [setMetricsServer](./set-metrics-server.example.json)
+* [createStorage](./create-storage.example.json)
+
+## Cloud init
+
+- `username` - User name to change ssh keys and password for instead of the image’s configured default user.
+- `userpassword` - Password to assign the user.
+- `cicustom` - Specify custom files to replace the automatically generated ones at start, as JSON object of:
+  - `meta` - JSON object of:
+    - `path` - as string
+    - `storage` - as string
+  - `network` - JSON object of:
+    - `path` - as string
+    - `storage` - as string
+  - `user` - JSON object of:
+    - `path` - as string
+    - `storage` - as string
+  - `vendor` - JSON object of:
+    - `path` - as string
+    - `storage` - as string
+- `dns` - Sets DNS settings, as JSON object of:
+  - `nameservers` - Sets DNS server IP address for a VM, as list of stings.
+  - `searchdomain` - Sets DNS search domains for a VM, as string.
+- `sshkeys` - public ssh keys, as list of strings.
+- `ipconfig` - Sets IP configuration for network interfaces, as dictionary of interface index number to JSON object:
+  - `ip4` - for IPv4, as JSON object of:
+    - `address` - IPv4Format/CIDR
+    - `dhcp` - true/false
+    - `gateway` - GatewayIPv4
+  - `ip6` - for IPv6, as JSON object of:
+    - `address` - IPv6Format/CIDR
+    - `dhcp` - true/false
+    - `gateway` - GatewayIPv6
+    - `slaac` - true/false
+- `ciupgrade` - If true does a package update after startup

--- a/docs/config-examples/README.md
+++ b/docs/config-examples/README.md
@@ -12,6 +12,8 @@ Many configs are passed through `stdin` or by specifying a file (with the parame
 
 ## Cloud init
 
+The cloud init format should follow the following schema :
+
 - `username` - User name to change ssh keys and password for instead of the image’s configured default user.
 - `userpassword` - Password to assign the user.
 - `cicustom` - Specify custom files to replace the automatically generated ones at start, as JSON object of:

--- a/docs/config-examples/clone-qemu.example.json
+++ b/docs/config-examples/clone-qemu.example.json
@@ -1,0 +1,9 @@
+{
+  "full": {
+    "node": "pve-latest",
+    "name": "golang2.test.com",
+    "pool": "my-pool",
+    "storage": "local-zfs",
+    "format": "raw"
+  }
+}

--- a/docs/config-examples/cloud-init.example.json
+++ b/docs/config-examples/cloud-init.example.json
@@ -1,0 +1,60 @@
+{
+  "cloudinit": {
+    "username": "test",
+    "userpassword": "passw0rd",
+    "cicustom": {
+      "meta": {
+        "path": "path/to/meta",
+        "storage": "local"
+      },
+      "network": {
+        "path": "path/to/network",
+        "storage": "local"
+      },
+      "user": {
+        "path": "path/to/user",
+        "storage": "local"
+      },
+      "vendor": {
+        "path": "path/to/vendor",
+        "storage": "local"
+      }
+    },
+    "dns": {
+      "nameservers": [
+        "8.8.8.8"
+      ],
+      "searchdomain": "test.com"
+    },
+    "sshkeys": [
+      "...",
+      "..."
+    ],
+    "ipconfig": {
+      "0": {
+        "ip4": {
+          "address": "10.0.2.17/24",
+          "gateway": "10.0.2.2"
+        },
+        "ip6": {
+          "address": "2001:0db8:0:2::17/64",
+          "gateway": "2001:0db8:0:2::2"
+        }
+      },
+      "1": {
+        "ip4": {
+          "dhcp": true
+        },
+        "ip6": {
+          "dhcp": true
+        }
+      },
+      "2": {
+        "ip6": {
+          "slaac": true
+        }
+      }
+    },
+    "ciupgrade": true
+  }
+}

--- a/docs/config-examples/create-acme-account.json
+++ b/docs/config-examples/create-acme-account.json
@@ -1,0 +1,8 @@
+{
+  "contact": [
+    "b.wayne@proxmox.com",
+    "c.kent@proxmox.com"
+  ],
+  "directory": "https://acme-staging-v02.api.letsencrypt.org/directory",
+  "tos": true
+}

--- a/docs/config-examples/create-qemu.example.json
+++ b/docs/config-examples/create-qemu.example.json
@@ -1,0 +1,51 @@
+{
+  "name": "golang1.test.com",
+  "description": "Test proxmox-api-go",
+  "memory": {
+    "capacity": 2048
+  },
+  "ostype": "l26",
+  "cores": 2,
+  "sockets": 1,
+  "iso": {
+    "storage": "local",
+    "file": "ubuntu-14.04.5-server-amd64.iso"
+  },
+  "disk": {
+    "0": {
+      "type": "virtio",
+      "storage": "local",
+      "storage_type": "dir",
+      "size": "30G",
+      "backup": true
+    }
+  },
+  "efidisk": {
+    "storage": "local",
+    "pre-enrolled-keys": "1",
+    "efitype": "4m"
+  },
+  "network": {
+    "0": {
+      "model": "virtio",
+      "bridge": "nat"
+    },
+    "1": {
+      "model": "virtio",
+      "bridge": "vmbr0",
+      "firewall": true,
+      "tag": -1
+    }
+  },
+  "rng0": {
+    "source": "/dev/urandom",
+    "max_bytes": "1024",
+    "period": "1000"
+  },
+  "usb": {
+    "0": {
+      "host": "0658:0200",
+      "usb3": true
+    }
+  }
+}

--- a/docs/config-examples/create-storage.example.json
+++ b/docs/config-examples/create-storage.example.json
@@ -1,0 +1,29 @@
+{
+  "enable": true,
+  "type": "smb",
+  "smb": {
+    "username": "b.wayne",
+    "share": "NetworkShare",
+    "preallocation": "metadata",
+    "domain": "organization.com",
+    "server": "10.20.1.1",
+    "version": "3.11",
+    "password": "Enter123!"
+  },
+  "content": {
+    "backup": true,
+    "iso": false,
+    "template": true,
+    "diskimage": true,
+    "container": true,
+    "snippets": false
+  },
+  "backupretention": {
+    "last": 10,
+    "hourly": 4,
+    "daily": 7,
+    "monthly": 3,
+    "weekly": 2,
+    "yearly": 1
+  }
+}

--- a/docs/config-examples/set-acme-plugin.example.json
+++ b/docs/config-examples/set-acme-plugin.example.json
@@ -1,0 +1,6 @@
+{
+  "api": "aws",
+  "data": "AWS_ACCESS_KEY_ID=DEMOACCESSKEYID\nAWS_SECRET_ACCESS_KEY=DEMOSECRETACCESSKEY\n",
+  "enable": true,
+  "validation-delay": 30
+}

--- a/docs/config-examples/set-metrics-server.example.json
+++ b/docs/config-examples/set-metrics-server.example.json
@@ -1,0 +1,14 @@
+{
+  "port": 8086,
+  "server": "192.168.67.3",
+  "type": "influxdb",
+  "enable": true,
+  "mtu": 1500,
+  "timeout": 1,
+  "influxdb": {
+    "protocol": "https",
+    "max-body-size": 25000000,
+    "verify-certificate": false,
+    "token": "Rm8mqheWSVrrKKBW"
+  }
+}

--- a/docs/config-examples/set-user.example.json
+++ b/docs/config-examples/set-user.example.json
@@ -1,0 +1,13 @@
+{
+  "comment": "",
+  "email": "b.wayne@proxmox.com",
+  "enable": true,
+  "expire": 0,
+  "firstname": "Bruce",
+  "lastname": "Wayne",
+  "groups": [
+    "admins",
+    "usergroup"
+  ],
+  "keys": "2fa key"
+}


### PR DESCRIPTION
I updated the README and the Makefile to add things, here is a list of them :

* Add rules in the Makefile to build the CLI and generate bash completion and install it locally
* Explain how to use the new CLI
* Precise that the legacy CLI is deprecated
* Move all JSON config examples in a separate directory to make the main README smaller
* Remove newlines between commands in the legacy CLI examples
* Add the new CLI first in proxy usage
