### PR TITLE
fix: can't update linked boot mount

### DIFF
--- a/proxmox/config__lxc__mount.go
+++ b/proxmox/config__lxc__mount.go
@@ -86,13 +86,7 @@ func (config LxcBootMount) mapToApiUpdate(current LxcBootMount, privileged bool,
 	if usedConfig.SizeInKibibytes != nil {
 		rootFs += ",size=" + usedConfig.SizeInKibibytes.String()
 	}
-	if usedConfig.Storage != nil {
-		rootFs = *usedConfig.Storage + ":" + current.rawDisk + rootFs
-		if current.Storage != nil && rootFs == *current.Storage+":"+current.rawDisk+current.string(privileged) {
-			return
-		}
-	}
-	params[lxcApiKeyRootFS] = rootFs
+	params[lxcApiKeyRootFS] = current.rawDisk + rootFs
 }
 
 func (config LxcBootMount) markMountChanges_Unsafe(current *LxcBootMount) lxcUpdateChanges {

--- a/proxmox/config__lxc__new_test.go
+++ b/proxmox/config__lxc__new_test.go
@@ -261,7 +261,22 @@ func Test_ConfigLXC_mapToAPI(t *testing.T) {
 						Replicate: util.Pointer(false)}},
 					output: map[string]any{"rootfs": ""}}},
 			update: []test{
-				{name: `all storage change, no api `,
+				{name: `all storage change, linked clone`,
+					config: ConfigLXC{BootMount: &LxcBootMount{
+						Storage:         util.Pointer("local-zfs"),
+						SizeInKibibytes: util.Pointer(LxcMountSize(4 * gibibyte)),
+						ACL:             util.Pointer(TriBoolTrue),
+						Options: &LxcBootMountOptions{
+							Discard: util.Pointer(true)},
+						Replicate: util.Pointer(false)}},
+					currentConfig: ConfigLXC{BootMount: &LxcBootMount{
+						Storage:         util.Pointer("local-zfs"),
+						SizeInKibibytes: util.Pointer(LxcMountSize(4 * gibibyte)),
+						ACL:             util.Pointer(TriBoolTrue),
+						Replicate:       util.Pointer(false),
+						rawDisk:         "local-zfs:basevol-9100-disk-0/subvol-105-disk-0"}},
+					output: map[string]any{"rootfs": "local-zfs:basevol-9100-disk-0/subvol-105-disk-0,acl=1,mountoptions=discard,replicate=0,size=4G"}},
+				{name: `all storage change, no api change`,
 					config: ConfigLXC{BootMount: &LxcBootMount{
 						Storage: util.Pointer("local-zfs")}},
 					currentConfig: ConfigLXC{BootMount: &LxcBootMount{


### PR DESCRIPTION
When implementing clone in the Terraform provider I noticed that updating the boot mount of linked clones fails.

Added a test case for the linked clone and removed code that was never executed by any test case.