### PR TITLE
Fix HA VM Migration Race Condition

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"mime/multipart"
 	"net/http"
 	"os"
@@ -304,6 +305,35 @@ func (c *Client) GetVmInfo(ctx context.Context, vmr *VmRef) (vmInfo map[string]i
 		}
 	}
 	return nil, fmt.Errorf("vm '%d' not found", vmr.vmId)
+}
+
+func (c *Client) WaitForVmLock(ctx context.Context, vmr *VmRef) error {
+	// a bit of initial sleep, as the lock won't be gone instantly
+	time.Sleep(5 * time.Second)
+
+	timeout := time.After(300 * time.Second) // 5 minutes timeout
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeout:
+			return fmt.Errorf("timed out waiting for VM %d to unlock after migration", vmr.VmId())
+		case <-ticker.C:
+			vmInfo, err := c.GetVmInfo(ctx, vmr)
+			if err != nil {
+				log.Printf("[DEBUG] error getting vm info while waiting for lock release: %v", err)
+				continue
+			}
+
+			if lock, ok := vmInfo["lock"]; !ok {
+				log.Printf("[DEBUG] VM %d unlocked", vmr.VmId())
+				return nil
+			} else {
+				log.Printf("[DEBUG] VM %d is still locked: %v", vmr.VmId(), lock)
+			}
+		}
+	}
 }
 
 func (c *Client) GetVmRefByName(ctx context.Context, name GuestName) (vmr *VmRef, err error) {

--- a/proxmox/config__qemu.go
+++ b/proxmox/config__qemu.go
@@ -567,8 +567,15 @@ func (config ConfigQemu) Update(ctx context.Context, rebootIfNeeded bool, vmr *V
 		if err = vmr.migrate_Unsafe(ctx, client, *config.Node, true); err != nil {
 			return
 		}
+
 		// Set node to the node the VM was migrated to
 		vmr.node = *config.Node
+
+		// After migration, we must wait for the lock to be released.
+		err = waitForMigrationLockRelease(ctx, client, vmr)
+		if err != nil {
+			return
+		}
 	}
 
 	versionEncoded := version.Encode()
@@ -1310,4 +1317,44 @@ func NewConfigQemuFromApi(ctx context.Context, vmr *VmRef, client *Client) (conf
 		return config, nil
 	}
 	return
+}
+
+func waitForMigrationLockRelease(ctx context.Context, client *Client, vmr *VmRef) error {
+	// Give a little time for the lock to potentially appear before we start polling.
+	time.Sleep(5 * time.Second)
+
+	timeout := time.After(10 * time.Minute) // 10 minutes, as large migrations can take a while.
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+
+	targetNode := vmr.Node()
+
+	for {
+		select {
+		case <-timeout:
+			return fmt.Errorf("timed out waiting for VM %d to unlock on node %s after migration", vmr.VmId(), targetNode)
+		case <-ticker.C:
+			// We need to create a new VmRef for GetVmInfo as it updates the node info in the ref.
+			currentStatusVmr := NewVmRef(vmr.VmId())
+			vmInfo, err := client.GetVmInfo(ctx, currentStatusVmr)
+			if err != nil {
+				log.Printf("[DEBUG] Waiting for VM %d to be available after migration, current error: %v", vmr.VmId(), err)
+				continue
+			}
+
+			// Check if the VM is on the target node yet.
+			if currentStatusVmr.Node() != targetNode {
+				log.Printf("[DEBUG] Waiting for VM %d to appear on node %s, currently on %s", vmr.VmId(), targetNode, currentStatusVmr.Node())
+				continue
+			}
+
+			// Once on the target node, check for a lock.
+			if lock, ok := vmInfo["lock"]; !ok {
+				log.Printf("[DEBUG] VM %d is on node %s and has no lock.", vmr.VmId(), targetNode)
+				return nil // Success!
+			} else {
+				log.Printf("[DEBUG] Waiting for VM %d on node %s to unlock. Current lock: %v", vmr.VmId(), targetNode, lock)
+			}
+		}
+	}
 }


### PR DESCRIPTION
### Fix HA VM Migration Race Condition

This pull request resolves a race condition that occurs when migrating High Availability (HA) virtual machines.

#### The Problem

When a Terraform plan modifies the `target_node` of a `proxmox_vm_qemu` resource with HA enabled, the provider initiates a migration. However, it would then immediately attempt to apply further configuration updates to the VM on the new node.

Due to cluster synchronization delays, the VM's configuration file might not be immediately available on the destination node, or the VM might still be locked by the migration process. This resulted in intermittent errors, such as:
- `500 Configuration file 'nodes/...' does not exist`
- `500 VM is locked (migrate)`

This pull request addresses issue [#1343](https://github.com/Telmate/terraform-provider-proxmox/issues/1343).

#### The Solution

To ensure the provider waits until the migration is fully complete, this change introduces a robust polling mechanism. After initiating a migration, the provider will now:

1.  Poll the cluster status until the VM is reported as being on the correct destination node.
2.  Once the VM is on the target node, continue polling until the migration lock (`lock: migrate`) is released from the VM's status.

This ensures that the provider only proceeds with subsequent configuration updates after the Proxmox cluster has fully finalized the migration and the VM is ready for new commands. A generous 10-minute timeout has been implemented to accommodate large or slow migrations.