### PR TITLE
feat: Extend the ConfigContent_Template with new methods

### DIFF
--- a/proxmox/content__template.go
+++ b/proxmox/content__template.go
@@ -30,6 +30,12 @@ func (content ConfigContent_Template) toContentFile() Content_File {
 	}
 }
 
+// Returns the volume id of the Template, it is in the form of <storage>:vztmpl/<file>
+// Ex: local:vztmpl/alpine-3.22-default_20250617_amd64.tar.xz
+func (content ConfigContent_Template) VolId() string {
+	return content.toContentFile().format()
+}
+
 func (content ConfigContent_Template) Download(ctx context.Context, client *Client) error {
 	return DownloadLxcTemplate(ctx, client, content)
 }


### PR DESCRIPTION
In this patch, I add the following methods to `ConfigContent_Template` :

* `Delete` to delete a template on a node
* `Exists` to return either a template exists on the target node or not
* `Download` to download a template on a node
* `VolId` to return the template volume identifier that is used in LXC config

I tried to reuse as much as possible the code from other parts, mainly from `content.go`. In the end, this patch doesn't implement any new feature but offers a simpler way to use the `ConfigContent_Template` object in other projects.

closes #494