### PR TITLE
fix: guest qemu create wont load config correctly

### DIFF
--- a/cli/command/create/guest/create-guest.go
+++ b/cli/command/create/guest/create-guest.go
@@ -57,7 +57,7 @@ func createGuest(ctx context.Context, args []string, IDtype string) (err error) 
 		// 		VirtualCores: util.Pointer(proxmox.CpuVirtualCores(2)),
 		// 	},
 		// }.Update(ctx, true, vmr, c)
-		vmr, err = config.Create(cli.Context(), c)
+		_, err = config.Create(cli.Context(), c)
 	}
 	if err != nil {
 		return


### PR DESCRIPTION
I don't really know what was going on in this file, and feel like things are done weirdly, however the command will work at least with this config.

I feel like the code was commented out and a workaround was added to make it work, however there were several reasons why it could not work, first because the node was not set and second because the vmid was not set.

I think this patch is not better than a workaround, I set the node but it was already set before for the vmref. However I think it may be better to let it like that for now.

### Test

Tested by running :

```sh
NEW_CLI=true proxmox-api-go -i create guest qemu --file ./qemu.json 123 pve
# QemuGuest (123) has been created
```

Tested with this config :

```json
{
    "name": "test-qemu01",
    "bios": "seabios",
    "tablet": true,
    "memory": {
        "capacity": 2048
    },
    "ostype": "l26",
    "sockets": 1,
    "cpu": {
        "type": "host",
        "cores": 1
    },
    "numa": false,
    "kvm": true,
    "hotplug": "network,disk,usb",
    "boot": "order=ide2;net0",
    "scsihw": "virtio-scsi-pci",
    "network": {
        "0": {
            "bridge": "vmbr0",
            "firewall": true,
            "id": 0,
            "macaddr": "B6:8F:9D:7C:8F:BC",
            "model": "virtio"
        }
    }
}
```

