### PR TITLE
migrate: move testUserPermissions to list userpermissions in the new cli

### DIFF
--- a/cli/command/list/list-userpermissions.go
+++ b/cli/command/list/list-userpermissions.go
@@ -1,0 +1,32 @@
+package list
+
+import (
+	"sort"
+
+	"github.com/Telmate/proxmox-api-go/cli"
+	"github.com/Telmate/proxmox-api-go/proxmox"
+	"github.com/spf13/cobra"
+)
+
+var list_userPermissionsCmd = &cobra.Command{
+	Use:   "userpermissions USER PATH",
+	Short: "Prints the list of permissions for the specified USER and PATH",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) (err error) {
+		path := args[1]
+		userId, err := proxmox.NewUserID(args[0])
+		if err != nil {
+			return
+		}
+
+		client := cli.NewClient()
+		permissions, err := client.GetUserPermissions(cli.Context(), userId, path)
+		sort.Strings(permissions)
+		cli.PrintRawJson(listCmd.OutOrStdout(), permissions)
+		return
+	},
+}
+
+func init() {
+	listCmd.AddCommand(list_userPermissionsCmd)
+}


### PR DESCRIPTION
This patch moves the command `testUserPermissions` from the legacy CLI to `list userpermissions`. I feel like the name could be better, but I also feel like it doesn't really matter so much right now.

Unlike in the legacy CLI, `list userpermissions` will output the array of string in json instead of using go output format for a list, I feel like it's more useful. Both arguments USER and PATH are required, I don't feel like making them optional is really useful.

fixes #517 

### Testing

The command can be tested by running : 

```sh
NEW_CLI=true ./proxmox-api-go -i list userpermissions root@pam /
# ["Datastore.Allocate","Datastore.AllocateSpace","Datastore.AllocateTemplate","Datastore.Audit","Group.Allocate","Mapping.Audit","Mapping.Modify","Mapping.Use","Permissions.Modify","Pool.Allocate","Pool.Audit","Realm.Allocate","Realm.AllocateUser","SDN.Allocate","SDN.Audit","SDN.Use","Sys.AccessNetwork","Sys.Audit","Sys.Console","Sys.Incoming","Sys.Modify","Sys.PowerMgmt","Sys.Syslog","User.Modify","VM.Allocate","VM.Audit","VM.Backup","VM.Clone","VM.Config.CDROM","VM.Config.CPU","VM.Config.Cloudinit","VM.Config.Disk","VM.Config.HWType","VM.Config.Memory","VM.Config.Network","VM.Config.Options","VM.Console","VM.GuestAgent.Audit","VM.GuestAgent.FileRead","VM.GuestAgent.FileSystemMgmt","VM.GuestAgent.FileWrite","VM.GuestAgent.Unrestricted","VM.Migrate","VM.PowerMgmt","VM.Replicate","VM.Snapshot","VM.Snapshot.Rollback"]
```