### PR TITLE
refactor: reimplement delete guest api call

### DIFF
--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -617,6 +617,7 @@ func (c *Client) DeleteVm(ctx context.Context, vmr *VmRef) (exitStatus string, e
 	return c.DeleteVmParams(ctx, vmr, nil)
 }
 
+// Deprecated: use VmRef.Delete() instead.
 func (c *Client) DeleteVmParams(ctx context.Context, vmr *VmRef, params map[string]interface{}) (exitStatus string, err error) {
 	err = c.CheckVmRef(ctx, vmr)
 	if err != nil {

--- a/proxmox/client__api.go
+++ b/proxmox/client__api.go
@@ -9,6 +9,7 @@ import (
 // in the future we might put the interface even lower, but for now this is sufficient
 type clientApiInterface interface {
 	createHaRule(ctx context.Context, params map[string]any) error
+	deleteGuest(ctx context.Context, vmr *VmRef, purge bool) error
 	deleteHaResource(ctx context.Context, id GuestID) error
 	deleteHaRule(ctx context.Context, id HaRuleID) error
 	getGuestConfig(ctx context.Context, vmr *VmRef) (map[string]any, error)

--- a/proxmox/client__api__mock.go
+++ b/proxmox/client__api__mock.go
@@ -6,6 +6,7 @@ import (
 
 type mockClientAPI struct {
 	createHaRuleFunc           func(ctx context.Context, params map[string]any) error
+	deleteGuestFunc            func(ctx context.Context, vmr *VmRef, purge bool) error
 	deleteHaResourceFunc       func(ctx context.Context, id GuestID) error
 	deleteHaRuleFunc           func(ctx context.Context, id HaRuleID) error
 	getGuestConfigFunc         func(ctx context.Context, vmr *VmRef) (map[string]any, error)
@@ -31,6 +32,13 @@ func (m *mockClientAPI) createHaRule(ctx context.Context, params map[string]any)
 		m.panic("createHaRuleFunc")
 	}
 	return m.createHaRuleFunc(ctx, params)
+}
+
+func (m *mockClientAPI) deleteGuest(ctx context.Context, vmr *VmRef, purge bool) error {
+	if m.deleteGuestFunc == nil {
+		m.panic("deleteGuestFunc")
+	}
+	return m.deleteGuestFunc(ctx, vmr, purge)
 }
 
 func (m *mockClientAPI) deleteHaResource(ctx context.Context, id GuestID) error {

--- a/proxmox/client__api__reusable.go
+++ b/proxmox/client__api__reusable.go
@@ -29,6 +29,19 @@ func (c *clientAPI) delete(ctx context.Context, url string) (err error) {
 	return
 }
 
+// Makes a DELETE request and waits on proxmox for the task to complete.
+// It returns the HTTP error as 'err'.
+func (c *clientAPI) deleteTask(ctx context.Context, url string) error {
+	var resp *http.Response
+	resp, err := c.session.delete(ctx, url, nil, nil)
+	if err != nil {
+		_ = c.handleTaskError(resp)
+		return err
+	}
+	_, err = c.checkTask(ctx, resp)
+	return err
+}
+
 func (c *clientAPI) getMap(ctx context.Context, url, text, message string, ignore errorIgnore) (map[string]any, error) {
 	data, err := c.getRootMap(ctx, url, text, message, ignore)
 	if err != nil {


### PR DESCRIPTION
Optimizes the logic to reduce the amount of API calls made when deleting a guest with HA enabled.
implements the delete guest API call