### PR TITLE
Add support for host-managed parameter in LXC networks

### DIFF
--- a/proxmox/config__lxc__networks.go
+++ b/proxmox/config__lxc__networks.go
@@ -15,9 +15,10 @@ import (
 // https://github.com/proxmox/proxmox-ve-rs/blob/1811e0560cb11186aa94fe24605ce8bf7d05cc62/proxmox-ve-config/src/guest/vm.rs#L154
 
 type LxcNetwork struct {
-	Bridge        *string           `json:"bridge,omitempty"`    // Required for creation. Never nil when returned
-	Connected     *bool             `json:"connected,omitempty"` // Never nil when returned
-	Firewall      *bool             `json:"firewall,omitempty"`  // Never nil when returned
+	Bridge        *string           `json:"bridge,omitempty"`      // Required for creation. Never nil when returned
+	Connected     *bool             `json:"connected,omitempty"`   // Never nil when returned
+	Firewall      *bool             `json:"firewall,omitempty"`    // Never nil when returned
+	HostManaged   *bool             `json:"host_managed,omitempty"` // Set by Proxmox for OCI containers. Never nil when returned
 	IPv4          *LxcIPv4          `json:"ipv4,omitempty"`
 	IPv6          *LxcIPv6          `json:"ipv6,omitempty"`
 	MAC           *net.HardwareAddr `json:"mac,omitempty"` // Never nil when returned
@@ -357,6 +358,7 @@ func (raw *rawConfigLXC) GetNetworks() LxcNetworks {
 			var bridge string
 			var connected bool = true
 			var firewall bool
+			var hostManaged bool
 			var name LxcNetworkName
 			var mac net.HardwareAddr
 			var macOriginal string
@@ -370,6 +372,9 @@ func (raw *rawConfigLXC) GetNetworks() LxcNetworks {
 			if v, isSet := settings["firewall"]; isSet && v == "1" {
 				firewall = true
 			}
+			if v, isSet := settings["host-managed"]; isSet && v == "1" {
+				hostManaged = true
+			}
 			if v, isSet := settings["name"]; isSet {
 				name = LxcNetworkName(v)
 			}
@@ -378,12 +383,13 @@ func (raw *rawConfigLXC) GetNetworks() LxcNetworks {
 				mac, _ = net.ParseMAC(v)
 			}
 			network := LxcNetwork{
-				Bridge:    &bridge,
-				Connected: &connected,
-				Firewall:  &firewall,
-				MAC:       &mac,
-				Name:      &name,
-				mac:       macOriginal}
+				Bridge:      &bridge,
+				Connected:   &connected,
+				Firewall:    &firewall,
+				HostManaged: &hostManaged,
+				MAC:         &mac,
+				Name:        &name,
+				mac:         macOriginal}
 			var ipSet bool
 			var ipv4 LxcIPv4
 			if v, isSet := settings["ip"]; isSet {


### PR DESCRIPTION
## Description

This PR adds support for the `host-managed` parameter in LXC network configurations, which was introduced in Proxmox VE 9.1 for OCI-based containers.

## Problem

When creating LXC containers from OCI images (Docker Hub images) on Proxmox VE 9.1+, the API automatically sets a `host-managed=1` parameter on network interfaces. The SDK was not parsing this parameter, which caused the provider to fail with validation errors.

## Changes

- Added `HostManaged` field to `LxcNetwork` struct
- Added parsing logic in `GetNetworks()` to read the `host-managed` parameter from API responses
- Updated struct initialization to include the new field

## Technical Details

The `host-managed` parameter is automatically set by Proxmox for OCI-based containers to indicate that the network interface is managed by the host system. This is distinct from traditional LXC containers where this parameter is not present.

API response example for OCI container:
```
net0: name=eth0,bridge=vmbr1,host-managed=1,hwaddr=XX:XX:XX:XX:XX:XX,ip=dhcp,type=veth
```

## Testing

Tested on Proxmox VE 9.1.1 with:
- OCI containers (nginx, redis images)
- Traditional LXC templates (Debian, Ubuntu)
- Both container types create and parse correctly

## Backward Compatibility

Fully backward compatible. Traditional LXC templates that do not have the `host-managed` parameter continue to work as before, with the field defaulting to `false`.

## Related

This change is required for the corresponding terraform-provider-proxmox PR to support OCI containers on Proxmox 9.1+.
