### PR TITLE
fix: append disk format to settings for non-raw volumes

### DIFF
--- a/proxmox/config__qemu__disk.go
+++ b/proxmox/config__qemu__disk.go
@@ -244,11 +244,17 @@ func (disk qemuDisk) formatDisk(vmID, LinkedVmId GuestID, currentStorage string,
 			tmpId = strconv.Itoa(int(LinkedVmId))
 			settings = "base-" + tmpId + "-disk-" + strconv.Itoa(int(*disk.LinkedDiskId)) + "/" + settings
 		}
+		// For volume syntax, append format if not raw (e.g., qcow2 on LVM with snapshot-as-volume-chain enabled)
+		if disk.Format != QemuDiskFormat_Raw {
+			settings += "." + string(disk.Format)
+		}
 	}
 	// storage:100/vm-100-disk-0.raw
 	// storage:110/base-110-disk-1.raw/100/vm-100-disk-0.raw
 	// storage:vm-100-disk-0
 	// storage:base-110-disk-1/vm-100-disk-0
+	// storage:vm-100-disk-0.qcow2 (for volume syntax with non-raw format)
+	// storage:base-110-disk-1/vm-100-disk-0.qcow2 (for linked clone volume syntax with non-raw format)
 	settings = disk.Storage + ":" + settings
 	return
 }

--- a/proxmox/config__qemu__disk.go
+++ b/proxmox/config__qemu__disk.go
@@ -243,10 +243,12 @@ func (disk qemuDisk) formatDisk(vmID, LinkedVmId GuestID, currentStorage string,
 			// base-110-disk-1/vm-100-disk-0
 			tmpId = strconv.Itoa(int(LinkedVmId))
 			settings = "base-" + tmpId + "-disk-" + strconv.Itoa(int(*disk.LinkedDiskId)) + "/" + settings
-		}
-		// For volume syntax, append format if not raw (e.g., qcow2 on LVM with snapshot-as-volume-chain enabled)
-		if disk.Format != QemuDiskFormat_Raw {
-			settings += "." + string(disk.Format)
+		} else {
+			// For volume syntax, append format if not raw (e.g., qcow2 on LVM with snapshot-as-volume-chain enabled)
+			// Linked clone feature is not supported for LVM
+			if disk.Format != QemuDiskFormat_Raw {
+				settings += "." + string(disk.Format)
+			}
 		}
 	}
 	// storage:100/vm-100-disk-0.raw


### PR DESCRIPTION
This PR fixes issue https://github.com/Telmate/terraform-provider-proxmox/issues/1403.

Since Proxmox introduced snapshot-as-volume-chain support for LVM storage, volumes can now be in either `raw` or `qcow2` format. The previous implementation did not account for this distinction.

This change adds an additional validation step to correctly handle both formats, ensuring compatibility with the updated Proxmox behavior.
