### PR TITLE
Add missing 'EPYC-Genoa', 'EPYC-Genoa-v2' and 'EPYC-Turin" cpu-type

### DIFF
--- a/proxmox/config__qemu__cpu.go
+++ b/proxmox/config__qemu__cpu.go
@@ -252,6 +252,10 @@ const (
 	cpuType_AmdEPYCRomeV2_Lower               CpuType = "epycromev2"
 	CpuType_AmdEPYCV3                         CpuType = "EPYC-v3"
 	cpuType_AmdEPYCV3_Lower                   CpuType = "epycv3"
+	CpuType_AmdEPYCGenoa                      CpuType = "EPYC-Genoa"
+	cpuType_AmdEPYCGenoa_Lower                CpuType = "epycgenoa"
+	CpuType_AmdEPYCGenoaV2                    CpuType = "EPYC-Genoa-v2"
+	cpuType_AmdEPYCGenoaV2_Lower              CpuType = "epycgenoav2"
 	CpuType_Host                              CpuType = "host"
 	CpuType_IntelHaswell                      CpuType = "Haswell"
 	cpuType_IntelHaswell_Lower                CpuType = "haswell"
@@ -414,6 +418,8 @@ func (CpuType) cpuV8(cpus map[CpuType]CpuType) {
 	cpus[cpuType_AmdEPYCMilanV2_Lower] = CpuType_AmdEPYCMilanV2
 	cpus[cpuType_AmdEPYCRomeV2_Lower] = CpuType_AmdEPYCRomeV2
 	cpus[cpuType_AmdEPYCV3_Lower] = CpuType_AmdEPYCV3
+	cpus[cpuType_AmdEPYCGenoa_Lower] = CpuType_AmdEPYCGenoa
+	cpus[cpuType_AmdEPYCGenoaV2_Lower] = CpuType_AmdEPYCGenoaV2
 	cpus[cpuType_IntelIcelakeServerV3_Lower] = CpuType_IntelIcelakeServerV3
 	cpus[cpuType_IntelIcelakeServerV4_Lower] = CpuType_IntelIcelakeServerV4
 	cpus[cpuType_IntelIcelakeServerV5_Lower] = CpuType_IntelIcelakeServerV5

--- a/proxmox/config__qemu__cpu.go
+++ b/proxmox/config__qemu__cpu.go
@@ -256,6 +256,8 @@ const (
 	cpuType_AmdEPYCGenoa_Lower                CpuType = "epycgenoa"
 	CpuType_AmdEPYCGenoaV2                    CpuType = "EPYC-Genoa-v2"
 	cpuType_AmdEPYCGenoaV2_Lower              CpuType = "epycgenoav2"
+	CpuType_AmdEPYCTurin                      CpuType = "EPYC-Turin"
+	cpuType_AmdEPYCTurin_Lower                CpuType = "epycturin"
 	CpuType_Host                              CpuType = "host"
 	CpuType_IntelHaswell                      CpuType = "Haswell"
 	cpuType_IntelHaswell_Lower                CpuType = "haswell"
@@ -434,11 +436,18 @@ func (CpuType) cpuV8(cpus map[CpuType]CpuType) {
 	cpus[cpuType_X86_64_v4_Lower] = CpuType_X86_64_v4
 }
 
+func (CpuType) cpuV9(cpus map[CpuType]CpuType) {
+	cpus[cpuType_AmdEPYCTurin_Lower] = CpuType_AmdEPYCTurin
+}
+
 func (CpuType) Error(version Version) error {
 	// v7
 	cpus := CpuType("").cpuBase()
 	if version.Encode() >= version_8_0_0 { // v8
 		CpuType("").cpuV8(cpus)
+	}
+	if version.Encode() >= version_9_0_0 { // v9
+		CpuType("").cpuV9(cpus)
 	}
 	cpusConverted := make([]string, len(cpus))
 	var index int
@@ -454,6 +463,9 @@ func (cpu CpuType) mapToApi(version EncodedVersion) string {
 	cpus := CpuType("").cpuBase()
 	if version >= version_8_0_0 {
 		cpu.cpuV8(cpus)
+	}
+	if version >= version_9_0_0 {
+		cpu.cpuV9(cpus)
 	}
 	if v, ok := cpus[CpuType(strings.ToLower(strings.ReplaceAll(strings.ReplaceAll(string(cpu), "_", ""), "-", "")))]; ok {
 		return string(v)

--- a/proxmox/config__qemu__cpu_test.go
+++ b/proxmox/config__qemu__cpu_test.go
@@ -152,6 +152,11 @@ func Test_CpuType_Validate(t *testing.T) {
 				config:  CpuType_AmdEPYCGenoa,
 				version: Version{Major: 7}.max()},
 			output: CpuType("").Error(Version{Major: 7}.max())},
+		{name: `Invalid V8 EPYC-Turin`,
+			input: testInput{
+				config:  CpuType_AmdEPYCTurin,
+				version: Version{Major: 8}.max()},
+			output: CpuType("").Error(Version{Major: 8}.max())},
 		// Valid
 		{name: `Valid empty`,
 			input: testInput{
@@ -176,6 +181,10 @@ func Test_CpuType_Validate(t *testing.T) {
 			input: testInput{
 				config:  CpuType_AmdEPYCGenoaV2,
 				version: Version{Major: 8}.max()}},
+		{name: `Valid EPYC-Turin`,
+			input: testInput{
+				config:  CpuType_AmdEPYCTurin,
+				version: Version{Major: 9}.max()}},
 	}
 	for _, test := range testData {
 		t.Run(test.name, func(*testing.T) {

--- a/proxmox/config__qemu__cpu_test.go
+++ b/proxmox/config__qemu__cpu_test.go
@@ -147,6 +147,11 @@ func Test_CpuType_Validate(t *testing.T) {
 				config:  CpuType_AmdEPYCRomeV2,
 				version: Version{Major: 7}.max()},
 			output: CpuType("").Error(Version{Major: 7}.max())},
+		{name: `Invalid V7 EPYC-Genoa`,
+			input: testInput{
+				config:  CpuType_AmdEPYCGenoa,
+				version: Version{Major: 7}.max()},
+			output: CpuType("").Error(Version{Major: 7}.max())},
 		// Valid
 		{name: `Valid empty`,
 			input: testInput{
@@ -163,6 +168,14 @@ func Test_CpuType_Validate(t *testing.T) {
 		{name: `Valid weird`,
 			input: testInput{config: CpuType("S-k__-Yl_-A--k-e__-Se-R-v-__Er--n-OTs_X---I-_br-S"),
 				version: Version{}.max()}},
+		{name: `Valid EPYC-Genoa`,
+			input: testInput{
+				config:  CpuType_AmdEPYCGenoa,
+				version: Version{Major: 8}.max()}},
+		{name: `Valid EPYC-Genoa-v2`,
+			input: testInput{
+				config:  CpuType_AmdEPYCGenoaV2,
+				version: Version{Major: 8}.max()}},
 	}
 	for _, test := range testData {
 		t.Run(test.name, func(*testing.T) {


### PR DESCRIPTION
While playing with Packer I noticed the zen4 and zen5 cpu types were missing.