### PR TITLE
Feat: Bump Go to 1.26.2

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -7,7 +7,7 @@ on:
     branches: [master]
 
 env:
-  GO_VERSION: '1.24'
+  GO_VERSION: '1.26.2'
 
 jobs:
   verify-dependencies:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/Telmate/proxmox-api-go
 
-go 1.23.0
-
-toolchain go1.24.1
+go 1.26.2
 
 require (
 	github.com/joho/godotenv v1.5.1

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -1044,8 +1044,7 @@ func (c *Client) getNextIDstart_Unsafe(ctx context.Context, guestID GuestID) (Gu
 		if err == nil {
 			break
 		}
-		var apiErr *ApiError
-		if !errors.As(err, &apiErr) {
+		if _, ok := err.(*ApiError); !ok {
 			return 0, err
 		}
 		guestID++

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -568,7 +568,7 @@ func (c *Client) WaitForCompletion(ctx context.Context, taskResponse map[string]
 		time.Sleep(TaskStatusCheckInterval * time.Second)
 		waited = waited + TaskStatusCheckInterval
 	}
-	return "", fmt.Errorf("Wait timeout for:" + taskUpid)
+	return "", errors.New("Wait timeout for:" + taskUpid)
 }
 
 var (
@@ -585,7 +585,7 @@ func (c *Client) GetTaskExitstatus(ctx context.Context, taskUpid string) (exitSt
 		exitStatus = data["data"].(map[string]interface{})["exitstatus"]
 	}
 	if exitStatus != nil && rxExitStatusSuccess.FindString(exitStatus.(string)) == "" {
-		err = fmt.Errorf(exitStatus.(string))
+		err = errors.New(exitStatus.(string))
 	}
 	return
 }
@@ -2230,7 +2230,7 @@ func (c *Client) GetItemConfig(ctx context.Context, url, text, message string) (
 		return nil, err
 	}
 	if config["data"] == nil {
-		return nil, fmt.Errorf(text + " " + message + " not readable")
+		return nil, errors.New(text + " " + message + " not readable")
 	}
 	return
 }

--- a/proxmox/client__api.go
+++ b/proxmox/client__api.go
@@ -2,7 +2,6 @@ package proxmox
 
 import (
 	"context"
-	"errors"
 	"strings"
 	"time"
 )
@@ -60,8 +59,7 @@ func (c *clientAPI) getGuestPendingChanges(ctx context.Context, vmr *VmRef) ([]a
 func (c *clientAPI) getGuestQemuAgent(ctx context.Context, vmr *VmRef) (map[string]any, GuestAgentState, error) {
 	guestID := vmr.vmId.String()
 	out, err := c.getMap(ctx, "/nodes/"+vmr.node.String()+"/qemu/"+guestID+"/agent/network-get-interfaces", "guest agent", "data")
-	var apiErr *ApiError
-	if errors.As(err, &apiErr) {
+	if apiErr, ok := err.(*ApiError); ok {
 		if strings.HasPrefix(apiErr.Message, "QEMU guest agent is not running") {
 			return out, GuestAgentStateNotRunning, nil
 		}
@@ -74,8 +72,7 @@ func (c *clientAPI) getGuestQemuAgent(ctx context.Context, vmr *VmRef) (map[stri
 
 func (c *clientAPI) getHaRule(ctx context.Context, id HaRuleID) (haRule map[string]any, err error) {
 	out, err := c.getMap(ctx, "/cluster/ha/rules/"+id.String(), "ha rule", "CONFIG")
-	var apiErr *ApiError
-	if errors.As(err, &apiErr) {
+	if apiErr, ok := err.(*ApiError); ok {
 		if strings.HasPrefix(apiErr.Message, "no such ha rule ") {
 			return out, nil
 		}
@@ -92,8 +89,7 @@ func (c *clientAPI) getUserConfig(ctx context.Context, userID UserID) (map[strin
 	if err == nil {
 		return config, true, nil
 	}
-	var apiErr *ApiError
-	if ok := errors.As(err, &apiErr); ok {
+	if apiErr, ok := err.(*ApiError); ok {
 		if strings.HasPrefix(apiErr.Message, "no such user ") {
 			return config, false, nil
 		}

--- a/proxmox/client__api__reusable.go
+++ b/proxmox/client__api__reusable.go
@@ -244,7 +244,7 @@ func (c *clientAPI) waitForCompletion(ctx context.Context, taskResponse map[stri
 		time.Sleep(TaskStatusCheckInterval * time.Second)
 		waited = waited + TaskStatusCheckInterval
 	}
-	return fmt.Errorf("Wait timeout for:" + taskUpid)
+	return errors.New("Wait timeout for:" + taskUpid)
 }
 
 func (c *clientAPI) getTaskExitStatus(ctx context.Context, taskUpID string) (bool, error) {

--- a/proxmox/config__apiToken.go
+++ b/proxmox/config__apiToken.go
@@ -273,8 +273,7 @@ type ApiTokenID struct {
 
 func (id ApiTokenID) delete(ctx context.Context, c *clientAPI) (bool, error) {
 	err := c.deleteRetry(ctx, "/access/users/"+id.User.String()+"/token/"+id.TokenName.String(), 3)
-	var apiErr *ApiError
-	if errors.As(err, &apiErr) {
+	if apiErr, ok := err.(*ApiError); ok {
 		if strings.HasPrefix(apiErr.Message, "no such token ") {
 			return false, nil
 		}
@@ -310,8 +309,7 @@ func (id *ApiTokenID) Parse(s string) error {
 func (id ApiTokenID) read(ctx context.Context, c *clientAPI) (*rawApiTokenConfig, bool, error) {
 	data, err := c.getMap(ctx, "/access/users/"+id.User.String()+"/token/"+id.TokenName.String(), "api token", "CONFIG")
 	if err != nil {
-		var apiErr *ApiError
-		if errors.As(err, &apiErr) {
+		if apiErr, ok := err.(*ApiError); ok {
 			if strings.HasPrefix(apiErr.Message, "no such token ") {
 				return nil, false, nil
 			}

--- a/proxmox/config__group.go
+++ b/proxmox/config__group.go
@@ -447,8 +447,7 @@ func (group GroupName) Delete(ctx context.Context, client *Client) error {
 
 func (group GroupName) delete(ctx context.Context, c *clientAPI) (bool, error) {
 	if err := c.deleteRetry(ctx, "/access/groups/"+group.String(), 3); err != nil {
-		var apiErr *ApiError
-		if errors.As(err, &apiErr) {
+		if apiErr, ok := err.(*ApiError); ok {
 			if strings.HasPrefix(apiErr.Message, "delete group failed: group '"+group.String()+"' does not exist") {
 				return false, nil
 			}
@@ -490,8 +489,7 @@ func (GroupName) mapToArray(params any) *[]GroupName {
 func (group GroupName) read(ctx context.Context, c *clientAPI) (*rawGroupConfig, bool, error) {
 	raw, err := c.getMap(ctx, "/access/groups/"+group.String(), "group", "CONFIG")
 	if err != nil {
-		var apiErr *ApiError
-		if errors.As(err, &apiErr) {
+		if apiErr, ok := err.(*ApiError); ok {
 			if strings.HasPrefix(apiErr.Message, "group '"+group.String()+"' does not exist") {
 				return nil, false, nil
 			}

--- a/proxmox/config__guest.go
+++ b/proxmox/config__guest.go
@@ -595,8 +595,6 @@ func guestCreateLoop_Unsafe(ctx context.Context, idKey, url string, params map[s
 		}
 		params[idKey] = int(guestID)
 		if err = ca.postRawTask(ctx, url, combineParamsAndBody(params, body)); err != nil {
-			var apiErr *ApiError
-			var taskErr *TaskError
 			// TODO test what happens during a LXC clone
 			//
 			// Create LXC
@@ -609,11 +607,11 @@ func guestCreateLoop_Unsafe(ctx context.Context, idKey, url string, params map[s
 			// Create QEMU
 			// "unable to create VM 106 - VM 106 already exists on node 'pve-9l'"
 			// the task returns the same message
-			if errors.As(err, &apiErr) {
+			if apiErr, ok := err.(*ApiError); ok {
 				if !strings.Contains(apiErr.Message, "already exists") {
 					return 0, err
 				}
-			} else if errors.As(err, &taskErr) {
+			} else if taskErr, ok := err.(*TaskError); ok {
 				if !strings.Contains(taskErr.Error(), "already exists") {
 					return 0, err
 				}

--- a/proxmox/config__pool.go
+++ b/proxmox/config__pool.go
@@ -828,8 +828,7 @@ func (pool PoolName) AddGuestsNoCheck(ctx context.Context, c *Client, guestIDs [
 
 func (pool PoolName) delete(ctx context.Context, c *clientAPI) (bool, error) {
 	if err := c.deleteRetry(ctx, "/pools/"+pool.String(), 3); err != nil {
-		var apiErr *ApiError
-		if errors.As(err, &apiErr) {
+		if apiErr, ok := err.(*ApiError); ok {
 			const prefix = "delete pool failed: pool '"
 			const prefixLen = len(prefix)
 			if strings.HasPrefix(apiErr.Message, prefix) {
@@ -913,8 +912,7 @@ func (pool PoolName) read(ctx context.Context, c *clientAPI) (r *rawPoolInfo, er
 	var raw map[string]any
 	raw, err = c.getMap(ctx, "/pools/"+pool.String(), "pool", "CONFIG")
 	if err != nil {
-		var apiErr *ApiError
-		if errors.As(err, &apiErr) { // check for not found
+		if apiErr, ok := err.(*ApiError); ok { // check for not found
 			if strings.HasPrefix(apiErr.Message, "pool '"+pool.String()+"' does not exist") {
 				return nil, err, nil
 			}

--- a/proxmox/config__qemu.go
+++ b/proxmox/config__qemu.go
@@ -1516,8 +1516,7 @@ func guestGetQemuConfig(ctx context.Context, vmr *VmRef, client *Client) (raw *r
 
 	// HAstate is return by the api for a vm resource type but not the HAgroup
 	err = client.ReadVMHA(ctx, vmr) // TODO: can be optimized, uses same API call as GetVmConfig and GetVmInfo
-	var apiErr *ApiError
-	if errors.As(err, &apiErr) {
+	if apiErr, ok := err.(*ApiError); ok {
 		if strings.HasPrefix(apiErr.Message, "no such resource") {
 			err = nil
 		}

--- a/proxmox/snapshot.go
+++ b/proxmox/snapshot.go
@@ -570,8 +570,7 @@ func (snap SnapshotName) create(ctx context.Context, c *clientAPI, vmr VmRef, de
 
 func (snap SnapshotName) delete(ctx context.Context, c *clientAPI, vmr VmRef) (bool, error) {
 	if err := c.deleteTask(ctx, "/nodes/"+vmr.node.String()+"/"+vmr.vmType.String()+"/"+vmr.vmId.String()+"/snapshot/"+snap.String()); err != nil {
-		var taskErr *TaskError
-		if errors.As(err, &taskErr) {
+		if taskErr, ok := err.(*TaskError); ok {
 			if strings.HasPrefix(taskErr.Message, `snapshot '`+snap.String()+`' does not exist`) {
 				return false, nil
 			}


### PR DESCRIPTION

- Bump go to 1.26.2
- Replaced incorrect usage of `fmt.Errorf()` with `errors.New()`.
- While refactoring `errors.As()` to `errors.AsType()` I realized we only want the topmost error, so we can just try to cast it. 