### PR TITLE
Create aarch64 qemu VMs/Templates

### DIFF
--- a/proxmox/config__qemu.go
+++ b/proxmox/config__qemu.go
@@ -150,12 +150,14 @@ type ConfigQemu struct {
 	ID               *GuestID              `json:"id,omitempty"`   // Required for creation, cannot be changed
 	Node             *NodeName             `json:"node,omitempty"` // Required for creation
 	Agent            *QemuGuestAgent       `json:"agent,omitempty"`
+	Architecture     CpuArchitecture       `json:"architecture,omitempty"` // only returned
 	Args             string                `json:"args,omitempty"`
 	Bios             string                `json:"bios,omitempty"`
 	Boot             string                `json:"boot,omitempty"`     // TODO should be an array of custom enums
 	BootDisk         string                `json:"bootdisk,omitempty"` // TODO discuss deprecation? Only returned as it's deprecated in the proxmox api
 	CPU              *QemuCPU              `json:"cpu,omitempty"`      // never nil when returned
 	CloudInit        *CloudInit            `json:"cloudinit,omitempty"`
+	CreateOptions    *QemuCreateOptions    `json:"create,omitempty"`      // only used during creation, never returned
 	Description      *string               `json:"description,omitempty"` // never nil when returned
 	Disks            *QemuStorages         `json:"disks,omitempty"`
 	EfiDisk          *EfiDisk              `json:"efidisk,omitempty"`
@@ -199,6 +201,17 @@ const (
 	ConfigQemu_Error_MemoryRequired              string = "memory is required during creation"
 	ConfigQemu_Error_NodeRequired                string = "node is required during creation"
 )
+
+// QemuCreateOptions groups settings PVE only honors in the initial create POST; mapToApiUpdate must not touch them.
+type QemuCreateOptions struct {
+	Architecture *CpuArchitecture `json:"architecture,omitempty"`
+}
+
+func (config QemuCreateOptions) mapToAPI(params map[string]any) {
+	if config.Architecture != nil {
+		params["arch"] = config.Architecture.String()
+	}
+}
 
 // Deprecated: use QemuGuestInterface.Create() instead.
 // Create - Tell Proxmox API to make the VM
@@ -419,6 +432,9 @@ func (config *ConfigQemu) mapToAPI(currentConfig ConfigQemu, version Version) (p
 func (config ConfigQemu) mapToApiCreate(version Version) (map[string]any, *[]byte) {
 	params := config.mapToAPI(ConfigQemu{}, version)
 	builder := strings.Builder{}
+	if config.CreateOptions != nil {
+		config.CreateOptions.mapToAPI(params)
+	}
 	if config.Description != nil && *config.Description != "" {
 		builder.WriteString("&" + qemuApiKeyDescription + "=")
 		builder.WriteString(body.Escape(*config.Description))
@@ -536,6 +552,9 @@ func (config *ConfigQemu) mapToStruct(vmr *VmRef, params map[string]interface{})
 	}
 	if _, isSet := params["bootdisk"]; isSet {
 		config.BootDisk = params["bootdisk"].(string)
+	}
+	if v, isSet := params["arch"]; isSet {
+		config.Architecture = CpuArchitecture(v.(string))
 	}
 	if _, isSet := params["bios"]; isSet {
 		config.Bios = params["bios"].(string)

--- a/proxmox/config__qemu__cpu.go
+++ b/proxmox/config__qemu__cpu.go
@@ -264,6 +264,8 @@ var cpuTypeTableV7 = map[string]string{
 	string(cpuType_IntelSkylakeServerNoTSXIBRS_Lower): string(CpuType_IntelSkylakeServerNoTSXIBRS),
 	string(cpuType_IntelWestmere_Lower):               string(CpuType_IntelWestmere),
 	string(cpuType_IntelWestmereIBRS_Lower):           string(CpuType_IntelWestmereIBRS),
+	string(cpuType_ArmCortexA57_Lower):                string(CpuType_ArmCortexA57),
+	string(cpuType_ArmCortexA72_Lower):                string(CpuType_ArmCortexA72),
 }
 
 var cpuTypeTableV8 = map[string]string{
@@ -436,6 +438,10 @@ const (
 	cpuType_X86_64_v3_Lower                   CpuType = "x8664v3"
 	CpuType_X86_64_v4                         CpuType = "x86-64-v4"
 	cpuType_X86_64_v4_Lower                   CpuType = "x8664v4"
+	CpuType_ArmCortexA57                      CpuType = "cortex-a57"
+	cpuType_ArmCortexA57_Lower                CpuType = "cortexa57"
+	CpuType_ArmCortexA72                      CpuType = "cortex-a72"
+	cpuType_ArmCortexA72_Lower                CpuType = "cortexa72"
 )
 
 func (CpuType) Error(version Version) error {

--- a/proxmox/config__qemu__cpu_test.go
+++ b/proxmox/config__qemu__cpu_test.go
@@ -176,6 +176,18 @@ func test_CpuTypeValidate_data() []struct {
 		{name: `Valid EPYC-Turin`,
 			config:  CpuType_AmdEPYCTurin,
 			version: Version{Major: 9}.max()},
+		{name: `Valid cortex-a57`,
+			config:  CpuType_ArmCortexA57,
+			version: Version{}.max()},
+		{name: `Valid cortex-a57 hyphen-stripped lookup`,
+			config:  CpuType("cortexa57"),
+			version: Version{}.max()},
+		{name: `Valid cortex-a72`,
+			config:  CpuType_ArmCortexA72,
+			version: Version{}.max()},
+		{name: `Valid cortex-a72 hyphen-stripped lookup`,
+			config:  CpuType("cortexa72"),
+			version: Version{}.max()},
 	}
 }
 

--- a/proxmox/config__qemu_test.go
+++ b/proxmox/config__qemu_test.go
@@ -3549,6 +3549,24 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"usb1": "spice"}},
 			},
 		},
+		{category: `CreateOptions.Architecture`,
+			create: []qemuTestCaseAPI{
+				{name: `nil CreateOptions`,
+					config: &ConfigQemu{}},
+				{name: `nil Architecture`,
+					config: &ConfigQemu{CreateOptions: &QemuCreateOptions{}}},
+				{name: `aarch64`,
+					config: &ConfigQemu{CreateOptions: &QemuCreateOptions{
+						Architecture: util.Pointer(CpuArchitecture("aarch64"))}},
+					output: map[string]interface{}{"arch": "aarch64"}},
+				{name: `x86_64`,
+					config: &ConfigQemu{CreateOptions: &QemuCreateOptions{
+						Architecture: util.Pointer(CpuArchitecture("x86_64"))}},
+					output: map[string]interface{}{"arch": "x86_64"}}},
+			update: []qemuTestCaseAPI{
+				{name: `ignored on update`,
+					config: &ConfigQemu{CreateOptions: &QemuCreateOptions{
+						Architecture: util.Pointer(CpuArchitecture("aarch64"))}}}}},
 	}
 	for _, test := range tests {
 		for _, subTest := range append(test.create, test.createUpdate...) {
@@ -3567,6 +3585,26 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 				testParamsEqualRaw(t, subTest.body, tmpBody, name+" Body")
 			})
 		}
+	}
+}
+
+func Test_ConfigQemu_mapToStruct_Architecture(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		input  map[string]interface{}
+		output CpuArchitecture
+	}{
+		{name: `absent`, input: map[string]interface{}{}, output: ""},
+		{name: `aarch64`, input: map[string]interface{}{"arch": "aarch64"}, output: "aarch64"},
+		{name: `x86_64`, input: map[string]interface{}{"arch": "x86_64"}, output: "x86_64"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := &ConfigQemu{}
+			require.NoError(t, config.mapToStruct(nil, tt.input))
+			require.Equal(t, tt.output, config.Architecture)
+		})
 	}
 }
 


### PR DESCRIPTION
This PR adds the parameter *arch* to qemu. The intention was to enable Hashicorp Packer to create arm VMs (their packer-proxmox-iso did not catch up with proxmox-api-go, though. But in the lab i have a PR for packer-proxmox-iso as well and i can easily create aarch64 Debian VMs)

<img width="881" height="337" alt="image" src="https://github.com/user-attachments/assets/7340daf7-6fb1-47df-a823-8a74a5cf7954" />
