### PR TITLE
Feat: CPU arch validate

### DIFF
--- a/proxmox/config__lxc__new.go
+++ b/proxmox/config__lxc__new.go
@@ -12,14 +12,14 @@ import (
 	"github.com/Telmate/proxmox-api-go/internal/util"
 )
 
-type CpuArchitecture string
+type LxcCpuArchitecture string
 
-func (arch CpuArchitecture) String() string { return string(arch) } // String is for fmt.Stringer.
+func (arch LxcCpuArchitecture) String() string { return string(arch) } // String is for fmt.Stringer.
 
 type OperatingSystem string
 
 type ConfigLXC struct {
-	Architecture    CpuArchitecture     `json:"architecture"` // only returned
+	Architecture    LxcCpuArchitecture  `json:"architecture"` // only returned
 	BootMount       *LxcBootMount       `json:"boot_mount,omitempty"`
 	CPU             *LxcCPU             `json:"cpu,omitempty"`
 	CreateOptions   *LxcCreateOptions   `json:"create,omitempty"` // only used during creation, never returned
@@ -575,7 +575,7 @@ func (config ConfigLXC) validateUpdate(current ConfigLXC) (err error) {
 
 type RawConfigLXC interface {
 	Get(vmr VmRef, state PowerState) *ConfigLXC
-	GetArchitecture() CpuArchitecture
+	GetArchitecture() LxcCpuArchitecture
 	GetBootMount() *LxcBootMount
 	GetDNS() *GuestDNS
 	GetDescription() *string
@@ -640,9 +640,9 @@ func (raw *rawConfigLXC) get(vmr VmRef) *ConfigLXC {
 	return &config
 }
 
-func (raw *rawConfigLXC) GetArchitecture() CpuArchitecture {
+func (raw *rawConfigLXC) GetArchitecture() LxcCpuArchitecture {
 	if v, isSet := raw.a[lxcApiKeyArchitecture]; isSet {
-		return CpuArchitecture(v.(string))
+		return LxcCpuArchitecture(v.(string))
 	}
 	return ""
 }

--- a/proxmox/config__lxc__new__mock.go
+++ b/proxmox/config__lxc__new__mock.go
@@ -5,7 +5,7 @@ import "crypto/sha1"
 // RawConfigLXCMock is a mock implementation of the RawConfigLXC interface
 type RawConfigLXCMock struct {
 	GetFunc                func(vmr VmRef, state PowerState) *ConfigLXC
-	GetArchitectureFunc    func() CpuArchitecture
+	GetArchitectureFunc    func() LxcCpuArchitecture
 	GetBootMountFunc       func() *LxcBootMount
 	GetDNSFunc             func() *GuestDNS
 	GetDescriptionFunc     func() *string
@@ -31,7 +31,7 @@ func (m *RawConfigLXCMock) Get(vmr VmRef, state PowerState) *ConfigLXC {
 	return m.GetFunc(vmr, state)
 }
 
-func (m *RawConfigLXCMock) GetArchitecture() CpuArchitecture {
+func (m *RawConfigLXCMock) GetArchitecture() LxcCpuArchitecture {
 	if m.GetArchitectureFunc == nil {
 		m.panic("GetArchitectureFunc")
 	}

--- a/proxmox/config__lxc__new_test.go
+++ b/proxmox/config__lxc__new_test.go
@@ -16,7 +16,7 @@ import (
 
 func Test_CpuArchitecture_String(t *testing.T) {
 	t.Parallel()
-	require.Equal(t, "amd64", CpuArchitecture("amd64").String())
+	require.Equal(t, "amd64", LxcCpuArchitecture("amd64").String())
 }
 
 func Test_ConfigLXC_mapToAPI(t *testing.T) {

--- a/proxmox/config__qemu.go
+++ b/proxmox/config__qemu.go
@@ -150,14 +150,13 @@ type ConfigQemu struct {
 	ID               *GuestID              `json:"id,omitempty"`   // Required for creation, cannot be changed
 	Node             *NodeName             `json:"node,omitempty"` // Required for creation
 	Agent            *QemuGuestAgent       `json:"agent,omitempty"`
-	Architecture     CpuArchitecture       `json:"architecture,omitempty"` // only returned
+	Architecture     *QemuCpuArchitecture  `json:"architecture,omitempty"` // only used during creation
 	Args             string                `json:"args,omitempty"`
 	Bios             string                `json:"bios,omitempty"`
 	Boot             string                `json:"boot,omitempty"`     // TODO should be an array of custom enums
 	BootDisk         string                `json:"bootdisk,omitempty"` // TODO discuss deprecation? Only returned as it's deprecated in the proxmox api
 	CPU              *QemuCPU              `json:"cpu,omitempty"`      // never nil when returned
 	CloudInit        *CloudInit            `json:"cloudinit,omitempty"`
-	CreateOptions    *QemuCreateOptions    `json:"create,omitempty"`      // only used during creation, never returned
 	Description      *string               `json:"description,omitempty"` // never nil when returned
 	Disks            *QemuStorages         `json:"disks,omitempty"`
 	EfiDisk          *EfiDisk              `json:"efidisk,omitempty"`
@@ -201,17 +200,6 @@ const (
 	ConfigQemu_Error_MemoryRequired              string = "memory is required during creation"
 	ConfigQemu_Error_NodeRequired                string = "node is required during creation"
 )
-
-// QemuCreateOptions groups settings PVE only honors in the initial create POST; mapToApiUpdate must not touch them.
-type QemuCreateOptions struct {
-	Architecture *CpuArchitecture `json:"architecture,omitempty"`
-}
-
-func (config QemuCreateOptions) mapToAPI(params map[string]any) {
-	if config.Architecture != nil {
-		params["arch"] = config.Architecture.String()
-	}
-}
 
 // Deprecated: use QemuGuestInterface.Create() instead.
 // Create - Tell Proxmox API to make the VM
@@ -432,8 +420,9 @@ func (config *ConfigQemu) mapToAPI(currentConfig ConfigQemu, version Version) (p
 func (config ConfigQemu) mapToApiCreate(version Version) (map[string]any, *[]byte) {
 	params := config.mapToAPI(ConfigQemu{}, version)
 	builder := strings.Builder{}
-	if config.CreateOptions != nil {
-		config.CreateOptions.mapToAPI(params)
+	if config.Architecture != nil {
+		builder.WriteString("&" + qemuApiKeyArchitecture + "=")
+		builder.WriteString(config.Architecture.String())
 	}
 	if config.Description != nil && *config.Description != "" {
 		builder.WriteString("&" + qemuApiKeyDescription + "=")
@@ -552,9 +541,6 @@ func (config *ConfigQemu) mapToStruct(vmr *VmRef, params map[string]interface{})
 	}
 	if _, isSet := params["bootdisk"]; isSet {
 		config.BootDisk = params["bootdisk"].(string)
-	}
-	if v, isSet := params["arch"]; isSet {
-		config.Architecture = CpuArchitecture(v.(string))
 	}
 	if _, isSet := params["bios"]; isSet {
 		config.Bios = params["bios"].(string)
@@ -878,6 +864,11 @@ func (config ConfigQemu) Validate(current *ConfigQemu, version Version) (err err
 		}
 		if err = config.Node.Validate(); err != nil {
 			return
+		}
+		if config.Architecture != nil {
+			if err = config.Architecture.Validate(); err != nil {
+				return
+			}
 		}
 		if config.CPU == nil {
 			return errors.New(ConfigQemu_Error_CpuRequired)
@@ -1341,6 +1332,7 @@ type configQemuUpdate struct {
 type RawConfigQemu interface {
 	Get(vmr VmRef) (*ConfigQemu, error)
 	GetAgent() *QemuGuestAgent
+	GetArchitecture() *QemuCpuArchitecture
 	GetCPU() *QemuCPU
 	GetCloudInit() *CloudInit
 	GetDescription() string
@@ -1373,6 +1365,7 @@ func (raw *rawConfigQemu) Get(vmr VmRef) (*ConfigQemu, error) {
 func (raw *rawConfigQemu) get(vmr VmRef) (*ConfigQemu, error) {
 	config := ConfigQemu{
 		Agent:            raw.GetAgent(),
+		Architecture:     raw.GetArchitecture(),
 		CPU:              raw.GetCPU(),
 		CloudInit:        raw.GetCloudInit(),
 		Description:      util.Pointer(raw.GetDescription()),
@@ -1456,6 +1449,7 @@ const (
 	qemuApiKeyCpuUnits          = "cpuunits"
 	qemuApiKeyCpuVirtual        = "vcpus"
 	qemuApiKeyDescription       = "description"
+	qemuApiKeyArchitecture      = "arch"
 	qemuApiKeyEfiDisk           = "efidisk0"
 	qemuApiKeyGuestAgent        = "agent"
 	qemuApiKeyMemoryBallooning  = "balloon"

--- a/proxmox/config__qemu__architecture.go
+++ b/proxmox/config__qemu__architecture.go
@@ -1,0 +1,36 @@
+package proxmox
+
+import "errors"
+
+// Enum
+//
+//	const (
+//		QemuCpuArchitectureAmd64
+//		QemuCpuArchitectureArm64
+//	)
+type QemuCpuArchitecture string
+
+const QemuCpuArchitecture_Error = "invalid cpu architecture"
+
+const (
+	QemuCpuArchitectureAmd64 QemuCpuArchitecture = "x86_64"
+	QemuCpuArchitectureArm64 QemuCpuArchitecture = "aarch64"
+)
+
+func (arch QemuCpuArchitecture) String() string { return string(arch) } // String is for fmt.Stringer.
+
+func (arch QemuCpuArchitecture) Validate() error {
+	switch arch {
+	case QemuCpuArchitectureAmd64, QemuCpuArchitectureArm64:
+		return nil
+	}
+	return errors.New(QemuCpuArchitecture_Error)
+}
+
+func (raw *rawConfigQemu) GetArchitecture() *QemuCpuArchitecture {
+	if v, isSet := raw.a[qemuApiKeyArchitecture]; isSet {
+		return new(QemuCpuArchitecture(v.(string)))
+	}
+	return nil
+
+}

--- a/proxmox/config__qemu_test.go
+++ b/proxmox/config__qemu_test.go
@@ -282,6 +282,17 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					config:        &ConfigQemu{Agent: &QemuGuestAgent{}},
 					currentLegacy: ConfigQemu{Agent: &QemuGuestAgent{}},
 					output:        map[string]interface{}{"agent": "0"}}}},
+		{category: `Architecture`,
+			create: []qemuTestCaseAPI{
+				{name: `aarch64`,
+					config: &ConfigQemu{Architecture: new(QemuCpuArchitecture("aarch64"))},
+					body:   map[string]string{"arch": "aarch64"}},
+				{name: `x86_64`,
+					config: &ConfigQemu{Architecture: new(QemuCpuArchitecture("x86_64"))},
+					body:   map[string]string{"arch": "x86_64"}}},
+			update: []qemuTestCaseAPI{
+				{name: `ignored on update`,
+					config: &ConfigQemu{Architecture: new(QemuCpuArchitecture("x86_64"))}}}},
 		{category: `CPU`,
 			create: []qemuTestCaseAPI{
 				{name: `Affinity empty`,
@@ -3549,24 +3560,6 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 					output: map[string]interface{}{"usb1": "spice"}},
 			},
 		},
-		{category: `CreateOptions.Architecture`,
-			create: []qemuTestCaseAPI{
-				{name: `nil CreateOptions`,
-					config: &ConfigQemu{}},
-				{name: `nil Architecture`,
-					config: &ConfigQemu{CreateOptions: &QemuCreateOptions{}}},
-				{name: `aarch64`,
-					config: &ConfigQemu{CreateOptions: &QemuCreateOptions{
-						Architecture: util.Pointer(CpuArchitecture("aarch64"))}},
-					output: map[string]interface{}{"arch": "aarch64"}},
-				{name: `x86_64`,
-					config: &ConfigQemu{CreateOptions: &QemuCreateOptions{
-						Architecture: util.Pointer(CpuArchitecture("x86_64"))}},
-					output: map[string]interface{}{"arch": "x86_64"}}},
-			update: []qemuTestCaseAPI{
-				{name: `ignored on update`,
-					config: &ConfigQemu{CreateOptions: &QemuCreateOptions{
-						Architecture: util.Pointer(CpuArchitecture("aarch64"))}}}}},
 	}
 	for _, test := range tests {
 		for _, subTest := range append(test.create, test.createUpdate...) {
@@ -3585,26 +3578,6 @@ func Test_ConfigQemu_mapToAPI(t *testing.T) {
 				testParamsEqualRaw(t, subTest.body, tmpBody, name+" Body")
 			})
 		}
-	}
-}
-
-func Test_ConfigQemu_mapToStruct_Architecture(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name   string
-		input  map[string]interface{}
-		output CpuArchitecture
-	}{
-		{name: `absent`, input: map[string]interface{}{}, output: ""},
-		{name: `aarch64`, input: map[string]interface{}{"arch": "aarch64"}, output: "aarch64"},
-		{name: `x86_64`, input: map[string]interface{}{"arch": "x86_64"}, output: "x86_64"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			config := &ConfigQemu{}
-			require.NoError(t, config.mapToStruct(nil, tt.input))
-			require.Equal(t, tt.output, config.Architecture)
-		})
 	}
 }
 
@@ -3655,6 +3628,14 @@ func Test_ConfigQemu_get(t *testing.T) {
 				{name: `Type`,
 					input:  map[string]interface{}{"agent": string("1,type=virtio")},
 					output: baseConfig(ConfigQemu{Agent: &QemuGuestAgent{Enable: util.Pointer(true), Type: util.Pointer(QemuGuestAgentType_VirtIO)}})}}},
+		{category: `Architecture`,
+			tests: []qemuTestCaseGet{
+				{name: `aarch64`,
+					input:  map[string]any{"arch": string("aarch64")},
+					output: baseConfig(ConfigQemu{Architecture: new(QemuCpuArchitectureArm64)})},
+				{name: `x86_64`,
+					input:  map[string]any{"arch": string("x86_64")},
+					output: baseConfig(ConfigQemu{Architecture: new(QemuCpuArchitectureAmd64)})}}},
 		{category: `CPU`,
 			tests: []qemuTestCaseGet{
 				{name: `all`,
@@ -6828,6 +6809,17 @@ func Test_ConfigQemu_Validate(t *testing.T) {
 		valid    qemuTestTypeValidate
 		invalid  qemuTestTypeValidate
 	}{
+		{category: `Architecture`,
+			valid: qemuTestTypeValidate{
+				create: []qemuTestCaseValidate{
+					{input: baseConfig(ConfigQemu{
+						Architecture: new(QemuCpuArchitecture("aarch64"))})}}},
+			invalid: qemuTestTypeValidate{
+				create: []qemuTestCaseValidate{
+					{name: `errors.New(QemuCpuArchitecture_Error)`,
+						input: baseConfig(ConfigQemu{
+							Architecture: new(QemuCpuArchitecture("invalid"))}),
+						err: errors.New(QemuCpuArchitecture_Error)}}}},
 		{category: `Agent`,
 			valid: qemuTestTypeValidate{
 				createUpdate: []qemuTestCaseValidate{

--- a/test/api/Qemu/config.go
+++ b/test/api/Qemu/config.go
@@ -97,8 +97,9 @@ func MinimumConfig(id pveSDK.GuestID, node pveSDK.NodeName, name pveSDK.GuestNam
 
 func MaximumConfig(id pveSDK.GuestID, node pveSDK.NodeName, name pveSDK.GuestName) (set pveSDK.ConfigQemu, expected *pveSDK.ConfigQemu) {
 	set = pveSDK.ConfigQemu{
-		CPU:         &pveSDK.QemuCPU{Cores: new(pveSDK.QemuCpuCores(1))},
-		Description: new(body.Alphanumeric + body.Symbols),
+		Architecture: new(pveSDK.QemuCpuArchitectureAmd64),
+		CPU:          &pveSDK.QemuCPU{Cores: new(pveSDK.QemuCpuCores(1))},
+		Description:  new(body.Alphanumeric + body.Symbols),
 		Disks: &pveSDK.QemuStorages{
 			Ide: &pveSDK.QemuIdeDisks{
 				Disk_0: &pveSDK.QemuIdeStorage{CdRom: &pveSDK.QemuCdRom{}},

--- a/test/api/Qemu/update_qemu_test.go
+++ b/test/api/Qemu/update_qemu_test.go
@@ -203,8 +203,10 @@ func Test_Qemu_Upate_Max_To_Reduced(t *testing.T) {
 	c := cl.New()
 	var vmr *pveSDK.VmRef
 	setMax, expectedMax := MaximumConfig(guestID, node, guestName)
-	setReduced, expectedReduced := ReducedConfig(guestID, node, guestName)
 	expectedMax.Boot = "order=ide1;ide0"
+	expectedMax.Architecture = new(pveSDK.QemuCpuArchitectureAmd64)
+	setReduced, expectedReduced := ReducedConfig(guestID, node, guestName)
+	expectedReduced.Architecture = new(pveSDK.QemuCpuArchitectureAmd64)
 	tests := []struct {
 		name string
 		test func(t *testing.T)


### PR DESCRIPTION
Turns out Lxc and Qemu cpu architecture is slightly different, they now each have their own type.
Added validate logic for the Qemu architecture.
Added Qemu architecture to integration tests.