### PR TITLE
Fix: lxc snapshot description, trailing `\n`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,9 +47,9 @@ test_integration_api: # Integration, setting this higher can exhoust the depth o
 		./test/api/Authentication/... \
 		./test/api/Connection/... \
 		./test/api/Group/... \
-		./test/api/Lxc/... \
+		./test/api/lxc/... \
 		./test/api/Pool/... \
-		./test/api/Qemu/... \
+		./test/api/qemu/... \
 		./test/api/Snapshot/... \
 		./test/api/User/...
 

--- a/proxmox/config__lxc__new.go
+++ b/proxmox/config__lxc__new.go
@@ -653,7 +653,7 @@ func (raw *rawConfigLXC) GetArchitecture() LxcCpuArchitecture {
 
 func (raw *rawConfigLXC) GetDescription() *string {
 	if v, isSet := raw.a[lxcApiKeyDescription]; isSet {
-		return util.Pointer(v.(string))
+		return new(strings.TrimSpace(v.(string)))
 	}
 	return nil
 }

--- a/proxmox/config__qemu.go
+++ b/proxmox/config__qemu.go
@@ -759,7 +759,7 @@ func (config ConfigQemu) updateNoCheck(
 		if err != nil {
 			return
 		}
-		currentLegacy, err = (&rawConfigQemu{a: rawConfig}).get(*vmr)
+		currentLegacy, err = (&rawConfigQemu{a: rawConfig, id: vmr.vmId, node: vmr.node}).get(*vmr)
 		if err != nil {
 			return
 		}
@@ -1391,9 +1391,11 @@ type RawConfigQemu interface {
 	GetCloudInit() *CloudInit
 	GetDescription() string
 	GetEfiDisk() *EfiDisk
+	GetID() GuestID
 	GetMemory() *QemuMemory
 	GetName() GuestName
 	GetNetworks() QemuNetworkInterfaces
+	GetNode() NodeName
 	GetPciDevices() QemuPciDevices
 	GetProtection() bool
 	GetRandomnessDevice() *VirtIoRNG
@@ -1408,7 +1410,11 @@ type RawConfigQemu interface {
 
 var _ RawConfigQemu = (*rawConfigQemu)(nil)
 
-type rawConfigQemu struct{ a map[string]any }
+type rawConfigQemu struct {
+	a    map[string]any
+	id   GuestID
+	node NodeName
+}
 
 func (raw *rawConfigQemu) Get(vmr VmRef) (*ConfigQemu, error) {
 	config, err := raw.get(vmr)
@@ -1429,9 +1435,11 @@ func (raw *rawConfigQemu) get(vmr VmRef) (*ConfigQemu, error) {
 		EfiDisk:          raw.GetEfiDisk(),
 		HaGroup:          vmr.HaGroup(),
 		HaState:          vmr.HaState(),
+		ID:               new(raw.GetID()),
 		Memory:           raw.GetMemory(),
 		Name:             util.Pointer(raw.GetName()),
 		Networks:         raw.GetNetworks(),
+		Node:             new(raw.GetNode()),
 		PciDevices:       raw.GetPciDevices(),
 		Protection:       util.Pointer(raw.GetProtection()),
 		RandomnessDevice: raw.GetRandomnessDevice(),
@@ -1457,12 +1465,16 @@ func (raw *rawConfigQemu) GetDescription() string {
 	return ""
 }
 
+func (raw *rawConfigQemu) GetID() GuestID { return raw.id }
+
 func (raw *rawConfigQemu) GetName() GuestName {
 	if v, isSet := raw.a[qemuApiKeyName]; isSet {
 		return GuestName(v.(string))
 	}
 	return ""
 }
+
+func (raw *rawConfigQemu) GetNode() NodeName { return raw.node }
 
 func (raw *rawConfigQemu) GetProtection() bool {
 	if v, isSet := raw.a[qemuApiKeyProtection]; isSet {
@@ -1546,7 +1558,7 @@ func guestGetRawQemuConfig_Unsafe(ctx context.Context, vmr *VmRef, c clientApiIn
 	if err != nil {
 		return nil, err
 	}
-	return &rawConfigQemu{a: rawConfig}, nil
+	return &rawConfigQemu{a: rawConfig, id: vmr.vmId, node: vmr.node}, nil
 }
 
 func (c *clientNewTest) guestGetQemuRawConfig(ctx context.Context, vmr *VmRef) (*rawConfigQemu, error) {
@@ -1565,7 +1577,7 @@ func guestGetActiveRawQemuConfig_Unsafe(ctx context.Context, vmr *VmRef, c clien
 	if err != nil {
 		return nil, false, err
 	}
-	return &rawConfigQemu{a: tmpConfig}, pending, nil
+	return &rawConfigQemu{a: tmpConfig, id: vmr.vmId, node: vmr.node}, pending, nil
 }
 
 func (c *clientNewTest) guestGetQemuActiveRawConfig(ctx context.Context, vmr *VmRef) (raw *rawConfigQemu, pending bool, err error) {

--- a/proxmox/config__qemu_test.go
+++ b/proxmox/config__qemu_test.go
@@ -94,11 +94,17 @@ func testQemuBaseConfig_get(config ConfigQemu) *ConfigQemu {
 	if config.Description == nil {
 		config.Description = util.Pointer("")
 	}
+	if config.ID == nil {
+		config.ID = new(GuestID(0))
+	}
 	if config.Memory == nil {
 		config.Memory = &QemuMemory{}
 	}
 	if config.Name == nil {
 		config.Name = util.Pointer(GuestName(""))
+	}
+	if config.Node == nil {
+		config.Node = new(NodeName(""))
 	}
 	if config.Protection == nil {
 		config.Protection = util.Pointer(false)
@@ -6033,11 +6039,17 @@ func Test_ActiveRawConfigQemu_Get(t *testing.T) {
 		if config.Hotplug == "" {
 			config.Hotplug = "network,disk,usb"
 		}
+		if config.ID == nil {
+			config.ID = new(GuestID(0))
+		}
 		if config.Memory == nil {
 			config.Memory = &QemuMemory{}
 		}
 		if config.Name == nil {
 			config.Name = util.Pointer(GuestName(""))
+		}
+		if config.Node == nil {
+			config.Node = new(NodeName(""))
 		}
 		if config.Protection == nil {
 			config.Protection = util.Pointer(false)

--- a/proxmox/snapshot.go
+++ b/proxmox/snapshot.go
@@ -161,7 +161,7 @@ func (c *snapshotClient) ReadQemuNoCheck(ctx context.Context, guest VmRef, name 
 	if err != nil {
 		return nil, err
 	}
-	return &rawConfigQemu{a: params}, nil
+	return &rawConfigQemu{a: params, id: guest.vmId, node: guest.node}, nil
 }
 
 func (c *snapshotClient) Rollback(ctx context.Context, guest VmRef, name SnapshotName, start bool) error {

--- a/proxmox/snapshot.go
+++ b/proxmox/snapshot.go
@@ -427,7 +427,7 @@ func (r *rawSnapshotInfo) GetTime() *time.Time {
 
 func (r *rawSnapshotInfo) GetDescription() string {
 	if v, isSet := r.a[snapshotListApiKeyDescription]; isSet {
-		return v.(string)
+		return strings.TrimSpace(v.(string))
 	}
 	return ""
 }

--- a/proxmox/snapshot_test.go
+++ b/proxmox/snapshot_test.go
@@ -294,11 +294,11 @@ func Test_snapshotClient_List(t *testing.T) {
 						map[string]any{"name": "snap1",
 							"snaptime": float64(1700000000)},
 						map[string]any{"name": "snap2",
-							"description": "This is snap2",
+							"description": "This is snap2\n", // Lxc has descriptions suffixed with \n
 							"parent":      "snap1",
 							"snaptime":    float64(1700000100)},
 						map[string]any{"name": "current",
-							"description": "You are here!",
+							"description": "You are here!\n",
 							"parent":      "snap2"},
 					}}),
 			)},
@@ -407,9 +407,9 @@ func Test_snapshotClient_ReadLxc(t *testing.T) {
 			guest:    VmRef{vmId: 100, node: "testNode", vmType: GuestLxc},
 			snapName: SnapshotName("snap1"),
 			config: baseConfig(ConfigLXC{
-				ID:   util.Pointer(GuestID(100)),
-				Name: util.Pointer(GuestName("lxc-name")),
-				Node: util.Pointer(NodeName("testNode")),
+				ID:   new(GuestID(100)),
+				Name: new(GuestName("lxc-name")),
+				Node: new(NodeName("testNode")),
 			}),
 			requests: mockServer.RequestsGetJson("/nodes/testNode/lxc/100/snapshot/snap1/config", map[string]any{
 				"data": map[string]any{
@@ -419,9 +419,10 @@ func Test_snapshotClient_ReadLxc(t *testing.T) {
 			guest:    VmRef{vmId: 300},
 			snapName: SnapshotName("snap1"),
 			config: baseConfig(ConfigLXC{
-				ID:   util.Pointer(GuestID(300)),
-				Name: util.Pointer(GuestName("lxc-name")),
-				Node: util.Pointer(NodeName("myNode")),
+				Description: new(string("test")),
+				ID:          new(GuestID(300)),
+				Name:        new(GuestName("lxc-name")),
+				Node:        new(NodeName("myNode")),
 			}),
 			requests: mockServer.Append(
 				mockServer.RequestsGetJson("/cluster/resources?type=vm", map[string]any{"data": []any{
@@ -431,7 +432,8 @@ func Test_snapshotClient_ReadLxc(t *testing.T) {
 				}}),
 				mockServer.RequestsGetJson("/nodes/myNode/lxc/300/snapshot/snap1/config", map[string]any{
 					"data": map[string]any{
-						"hostname": "lxc-name",
+						"description": "test\n", // Lxc has descriptions suffixed with \n
+						"hostname":    "lxc-name",
 					},
 				}))},
 		{name: `Validate error`,
@@ -542,8 +544,9 @@ func Test_snapshotClient_ReadQemu(t *testing.T) {
 			guest:    VmRef{vmId: 200},
 			snapName: SnapshotName("snap1"),
 			config: baseConfig(ConfigQemu{
-				ID:   util.Pointer(GuestID(200)),
-				Name: util.Pointer(GuestName("test-qemu")),
+				ID:   new(GuestID(200)),
+				Name: new(GuestName("test-qemu")),
+				Node: new(NodeName("testNode")),
 			}),
 			requests: mockServer.Append(
 				mockServer.RequestsGetJson("/cluster/resources?type=vm", map[string]any{"data": []any{

--- a/test/api/Snapshot/create_snapshot_test.go
+++ b/test/api/Snapshot/create_snapshot_test.go
@@ -9,27 +9,31 @@ import (
 
 	"github.com/Telmate/proxmox-api-go/internal/body"
 	"github.com/Telmate/proxmox-api-go/internal/pad"
-	"github.com/Telmate/proxmox-api-go/internal/util"
 	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
 	"github.com/Telmate/proxmox-api-go/test"
+	"github.com/Telmate/proxmox-api-go/test/api/qemu"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_Snapshot_CreateQemu(t *testing.T) {
 	t.Parallel()
-	const snap1 = pveSDK.SnapshotName("snap1")
-	const guest = pveSDK.GuestID(800)
-	const node = pveSDK.NodeName(test.FirstNode)
+	const (
+		guest    = pveSDK.GuestID(800)
+		name     = pveSDK.GuestName("Test-Snapshot-CreateQemu")
+		node     = pveSDK.NodeName(test.FirstNode)
+		snapName = pveSDK.SnapshotName("snap1")
+	)
 	snapshot := pveSDK.SnapshotInfo{
-		Name:        snap1,
+		Name:        snapName,
 		Description: "Test snapshot" + body.Symbols,
-		VmState:     util.Pointer(false),
+		VmState:     new(false),
 	}
 	cl, err := pveSDK.NewClient(test.ApiURL, nil, "", &tls.Config{InsecureSkipVerify: true}, "", 1000, false)
 	require.NoError(t, err)
 	ctx := context.Background()
 	require.NoError(t, cl.Login(ctx, test.UserID, test.Password, ""))
 	c := cl.New()
+	set, _ := qemu.MinimumConfig(guest, node, name)
 	var currentTime time.Time
 	currentTimePtr := &currentTime
 	tests := []struct {
@@ -44,7 +48,7 @@ func Test_Snapshot_CreateQemu(t *testing.T) {
 			}},
 		{name: `Create guest`,
 			test: func(t *testing.T) {
-				guestCreate(t, ctx, c, guest, node, "Test-Snapshot-CreateQemu")
+				createQemu(t, ctx, c, set)
 			}},
 		{name: `Create snapshot`,
 			test: func(t *testing.T) {

--- a/test/api/Snapshot/delete_snapshot_test.go
+++ b/test/api/Snapshot/delete_snapshot_test.go
@@ -9,20 +9,25 @@ import (
 	"github.com/Telmate/proxmox-api-go/internal/pad"
 	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
 	"github.com/Telmate/proxmox-api-go/test"
+	"github.com/Telmate/proxmox-api-go/test/api/qemu"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_Snapshot_Delete(t *testing.T) {
 	t.Parallel()
-	const snap1 = pveSDK.SnapshotName("snap1")
-	const guest = pveSDK.GuestID(801)
-	const node = pveSDK.NodeName(test.FirstNode)
-	snapshots := []pveSDK.SnapshotName{snap1}
+	const (
+		guest    = pveSDK.GuestID(801)
+		name     = pveSDK.GuestName("Test-Snapshot-Delete")
+		node     = pveSDK.NodeName(test.FirstNode)
+		snapName = pveSDK.SnapshotName("snap1")
+	)
+	snapshots := []pveSDK.SnapshotName{snapName}
 	cl, err := pveSDK.NewClient(test.ApiURL, nil, "", &tls.Config{InsecureSkipVerify: true}, "", 1000, false)
 	require.NoError(t, err)
 	ctx := context.Background()
 	require.NoError(t, cl.Login(ctx, test.UserID, test.Password, ""))
 	c := cl.New()
+	set, _ := qemu.MinimumConfig(guest, node, name)
 	tests := []struct {
 		name string
 		test func(t *testing.T)
@@ -35,11 +40,11 @@ func Test_Snapshot_Delete(t *testing.T) {
 			}},
 		{name: `Create guest`,
 			test: func(t *testing.T) {
-				guestCreate(t, ctx, c, guest, node, "Test-Snapshot-Delete")
+				createQemu(t, ctx, c, set)
 			}},
 		{name: `Create snapshot`,
 			test: func(t *testing.T) {
-				require.NoError(t, c.Snapshot.CreateQemu(ctx, *pveSDK.NewVmRef(guest), snap1, "Test snapshot", false))
+				require.NoError(t, c.Snapshot.CreateQemu(ctx, *pveSDK.NewVmRef(guest), snapName, "Test snapshot", false))
 			}},
 		{name: `List snapshots`,
 			test: func(t *testing.T) {
@@ -54,7 +59,7 @@ func Test_Snapshot_Delete(t *testing.T) {
 			}},
 		{name: `Delete snapshot`,
 			test: func(t *testing.T) {
-				existed, err := c.Snapshot.Delete(ctx, *pveSDK.NewVmRef(guest), snap1)
+				existed, err := c.Snapshot.Delete(ctx, *pveSDK.NewVmRef(guest), snapName)
 				require.NoError(t, err)
 				require.True(t, existed)
 			}},
@@ -71,7 +76,7 @@ func Test_Snapshot_Delete(t *testing.T) {
 			}},
 		{name: `Delete non-existing snapshot`,
 			test: func(t *testing.T) {
-				existed, err := c.Snapshot.Delete(ctx, *pveSDK.NewVmRef(guest), snap1)
+				existed, err := c.Snapshot.Delete(ctx, *pveSDK.NewVmRef(guest), snapName)
 				require.NoError(t, err)
 				require.False(t, existed)
 			}},

--- a/test/api/Snapshot/helper_test.go
+++ b/test/api/Snapshot/helper_test.go
@@ -4,20 +4,18 @@ import (
 	"context"
 	"testing"
 
-	"github.com/Telmate/proxmox-api-go/internal/util"
 	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
 	"github.com/stretchr/testify/require"
 )
 
-func guestCreate(t *testing.T, ctx context.Context, c pveSDK.ClientNew, guest pveSDK.GuestID, node pveSDK.NodeName, name pveSDK.GuestName) {
-	config := pveSDK.ConfigQemu{
-		CPU:    &pveSDK.QemuCPU{Cores: util.Pointer(pveSDK.QemuCpuCores(1))},
-		ID:     &guest,
-		Memory: &pveSDK.QemuMemory{CapacityMiB: util.Pointer(pveSDK.QemuMemoryCapacity(16))},
-		Name:   util.Pointer(name),
-		Node:   util.Pointer(node),
-	}
+func createQemu(t *testing.T, ctx context.Context, c pveSDK.ClientNew, config pveSDK.ConfigQemu) {
 	vmRef, err := c.QemuGuest.Create(ctx, config)
+	require.NoError(t, err)
+	require.NotNil(t, vmRef)
+}
+
+func createLxc(t *testing.T, ctx context.Context, c *pveSDK.Client, config pveSDK.ConfigLXC) {
+	vmRef, err := config.Create(ctx, c)
 	require.NoError(t, err)
 	require.NotNil(t, vmRef)
 }

--- a/test/api/Snapshot/list_snapshot_test.go
+++ b/test/api/Snapshot/list_snapshot_test.go
@@ -9,32 +9,37 @@ import (
 
 	"github.com/Telmate/proxmox-api-go/internal/body"
 	"github.com/Telmate/proxmox-api-go/internal/pad"
-	"github.com/Telmate/proxmox-api-go/internal/util"
 	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
 	"github.com/Telmate/proxmox-api-go/test"
+	"github.com/Telmate/proxmox-api-go/test/api/lxc"
+	"github.com/Telmate/proxmox-api-go/test/api/qemu"
 	"github.com/stretchr/testify/require"
 )
 
-func Test_Snapshot_List(t *testing.T) {
+func Test_Snapshot_List_Qemu(t *testing.T) {
 	t.Parallel()
 	snapshots := []pveSDK.SnapshotInfo{
 		{Name: "snap1",
 			Description: "First snapshot" + body.Symbols,
-			VmState:     util.Pointer(false)},
+			VmState:     new(false)},
 		{Name: "mySnap",
-			VmState: util.Pointer(false),
-			Parent:  util.Pointer(pveSDK.SnapshotName("snap1"))},
+			VmState: new(false),
+			Parent:  new(pveSDK.SnapshotName("snap1"))},
 		{Name: "test-snapshot",
 			Description: "a",
-			VmState:     util.Pointer(false),
-			Parent:      util.Pointer(pveSDK.SnapshotName("mySnap"))}}
-	const guest = pveSDK.GuestID(802)
-	const node = pveSDK.NodeName(test.FirstNode)
+			VmState:     new(false),
+			Parent:      new(pveSDK.SnapshotName("mySnap"))}}
+	const (
+		guest = pveSDK.GuestID(802)
+		name  = pveSDK.GuestName("Test-Snapshot-List-Qemu")
+		node  = pveSDK.NodeName(test.FirstNode)
+	)
 	cl, err := pveSDK.NewClient(test.ApiURL, nil, "", &tls.Config{InsecureSkipVerify: true}, "", 1000, false)
 	require.NoError(t, err)
 	ctx := context.Background()
 	require.NoError(t, cl.Login(ctx, test.UserID, test.Password, ""))
 	c := cl.New()
+	set, _ := qemu.MinimumConfig(guest, node, name)
 	var currentTime time.Time
 	currentTimePtr := &currentTime
 	tests := []struct {
@@ -49,13 +54,88 @@ func Test_Snapshot_List(t *testing.T) {
 			}},
 		{name: `Create guest`,
 			test: func(t *testing.T) {
-				guestCreate(t, ctx, c, guest, node, "Test-Snapshot-List")
+				createQemu(t, ctx, c, set)
 			}},
 		{name: `Create snapshot`,
 			test: func(t *testing.T) {
 				*currentTimePtr = time.Now()
 				for _, snap := range snapshots {
 					require.NoError(t, c.Snapshot.CreateQemu(ctx, *pveSDK.NewVmRef(guest), snap.Name, snap.Description, *snap.VmState))
+				}
+			}},
+		{name: `List snapshots`,
+			test: func(t *testing.T) {
+				raw, err := c.Snapshot.List(ctx, *pveSDK.NewVmRef(guest))
+				require.NoError(t, err)
+				require.NotNil(t, raw)
+				snapshotMap := raw.AsMap()
+				for _, snapshot := range snapshots {
+					raw, exists := snapshotMap[snapshot.Name]
+					require.True(t, exists, "snapshot %q not found in list", snapshot.Name)
+					require.NotNil(t, raw)
+					snapshotInfo := raw.Get()
+					require.Equal(t, snapshot.Name, snapshotInfo.Name)
+					require.Equal(t, snapshot.Description, snapshotInfo.Description)
+					require.Equal(t, snapshot.VmState, snapshotInfo.VmState)
+					require.Equal(t, snapshot.Parent, snapshotInfo.Parent)
+					require.WithinDuration(t, *currentTimePtr, *snapshotInfo.Time, time.Minute)
+				}
+			}},
+		{name: `Delete guest`,
+			test: func(t *testing.T) {
+				existed, err := c.Guest.Delete(ctx, *pveSDK.NewVmRef(guest))
+				require.NoError(t, err)
+				require.True(t, existed)
+			}},
+	}
+	for i, test := range tests {
+		t.Run(pad.Left(strconv.Itoa(i), 2, '0')+" "+test.name, test.test)
+	}
+}
+
+func Test_Snapshot_List_Lxc(t *testing.T) {
+	t.Parallel()
+	snapshots := []pveSDK.SnapshotInfo{
+		{Name: "snap1",
+			Description: "First snapshot" + body.Symbols},
+		{Name: "mySnap",
+			Parent: new(pveSDK.SnapshotName("snap1"))},
+		{Name: "test-snapshot",
+			Description: "a",
+			Parent:      new(pveSDK.SnapshotName("mySnap"))}}
+	const (
+		guest   = pveSDK.GuestID(806)
+		name    = pveSDK.GuestName("Test-Snapshot-List-Lxc")
+		node    = pveSDK.NodeName(test.FirstNode)
+		storage = pveSDK.StorageName(test.GuestStorage)
+	)
+	cl, err := pveSDK.NewClient(test.ApiURL, nil, "", &tls.Config{InsecureSkipVerify: true}, "", 1000, false)
+	require.NoError(t, err)
+	ctx := context.Background()
+	require.NoError(t, cl.Login(ctx, test.UserID, test.Password, ""))
+	c := cl.New()
+	set, _ := lxc.MinimumConfig(guest, node, storage, new(false), name)
+	var currentTime time.Time
+	currentTimePtr := &currentTime
+	tests := []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{name: `Ensure guest does not exist`,
+			test: func(t *testing.T) {
+				existed, err := c.Guest.Delete(ctx, *pveSDK.NewVmRef(guest))
+				require.NoError(t, err)
+				require.False(t, existed)
+			}},
+		{name: `Create guest`,
+			test: func(t *testing.T) {
+				createLxc(t, ctx, cl, set)
+			}},
+		{name: `Create snapshot`,
+			test: func(t *testing.T) {
+				*currentTimePtr = time.Now()
+				for _, snap := range snapshots {
+					require.NoError(t, c.Snapshot.CreateLxc(ctx, *pveSDK.NewVmRef(guest), snap.Name, snap.Description))
 				}
 			}},
 		{name: `List snapshots`,

--- a/test/api/Snapshot/read_snapshot_test.go
+++ b/test/api/Snapshot/read_snapshot_test.go
@@ -9,26 +9,31 @@ import (
 
 	"github.com/Telmate/proxmox-api-go/internal/body"
 	"github.com/Telmate/proxmox-api-go/internal/pad"
-	"github.com/Telmate/proxmox-api-go/internal/util"
 	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
 	"github.com/Telmate/proxmox-api-go/test"
+	"github.com/Telmate/proxmox-api-go/test/api/lxc"
+	"github.com/Telmate/proxmox-api-go/test/api/qemu"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_Snapshot_ReadQemu(t *testing.T) {
 	t.Parallel()
-	const snap1 = pveSDK.SnapshotName("snap1")
-	const guest = pveSDK.GuestID(804)
-	const node = pveSDK.NodeName(test.FirstNode)
+	const (
+		guest    = pveSDK.GuestID(804)
+		name     = pveSDK.GuestName("Test-Snapshot-ReadQemu")
+		node     = pveSDK.NodeName(test.FirstNode)
+		snapName = pveSDK.SnapshotName("snap1")
+	)
 	snapshot := pveSDK.SnapshotInfo{
-		Name:        snap1,
+		Name:        snapName,
 		Description: "Test snapshot" + body.Symbols,
-		VmState:     util.Pointer(false)}
+		VmState:     new(false)}
 	cl, err := pveSDK.NewClient(test.ApiURL, nil, "", &tls.Config{InsecureSkipVerify: true}, "", 1000, false)
 	require.NoError(t, err)
 	ctx := context.Background()
 	require.NoError(t, cl.Login(ctx, test.UserID, test.Password, ""))
 	c := cl.New()
+	set, expected := qemu.MinimumConfig(guest, node, name)
 	var currentTime time.Time
 	currentTimePtr := &currentTime
 	tests := []struct {
@@ -43,7 +48,7 @@ func Test_Snapshot_ReadQemu(t *testing.T) {
 			}},
 		{name: `Create guest`,
 			test: func(t *testing.T) {
-				guestCreate(t, ctx, c, guest, node, "Test-Snapshot-ReadQemu")
+				createQemu(t, ctx, c, set)
 			}},
 		{name: `Create snapshot`,
 			test: func(t *testing.T) {
@@ -56,32 +61,70 @@ func Test_Snapshot_ReadQemu(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, raw)
 				config, _ := raw.Get(pveSDK.VmRef{})
-				expected := util.Pointer(pveSDK.ConfigQemu{
-					Name: util.Pointer(pveSDK.GuestName("Test-Snapshot-ReadQemu")),
-					Bios: "seabios",
-					Boot: " ",
-					CPU: &pveSDK.QemuCPU{
-						Cores:   new(pveSDK.QemuCpuCores(1)),
-						Numa:    new(false),
-						Sockets: new(pveSDK.QemuCpuSockets(1))},
-					Description: util.Pointer("Test snapshot" + body.Symbols),
-					Hotplug:     "network,disk,usb",
-					Memory: &pveSDK.QemuMemory{
-						CapacityMiB: util.Pointer(pveSDK.QemuMemoryCapacity(16)),
-					},
-					Protection:      util.Pointer(false),
-					QemuDisks:       pveSDK.QemuDevices{},
-					QemuKVM:         util.Pointer(true),
-					QemuOs:          "other",
-					QemuUnusedDisks: pveSDK.QemuDevices{},
-					QemuVga:         pveSDK.QemuDevice{},
-					Tablet:          util.Pointer(true),
-					StartAtNodeBoot: util.Pointer(false),
-					Scsihw:          "lsi",
-					Tags:            new(pveSDK.Tags),
-				})
-				config.Smbios1 = "" // ignore smbios differences
+				config.Smbios1 = ""
+				expected.Description = &snapshot.Description
 				require.Equal(t, expected, config)
+			}},
+		{name: `Delete guest`,
+			test: func(t *testing.T) {
+				existed, err := c.Guest.Delete(ctx, *pveSDK.NewVmRef(guest))
+				require.NoError(t, err)
+				require.True(t, existed)
+			}},
+	}
+	for i, test := range tests {
+		t.Run(pad.Left(strconv.Itoa(i), 2, '0')+" "+test.name, test.test)
+	}
+}
+func Test_Snapshot_ReadLxc(t *testing.T) {
+	t.Parallel()
+	const (
+		guest    = pveSDK.GuestID(805)
+		name     = pveSDK.GuestName("Test-Snapshot-ReadLxc")
+		node     = pveSDK.NodeName(test.FirstNode)
+		snapName = pveSDK.SnapshotName("snap1")
+		storage  = pveSDK.StorageName(test.GuestStorage)
+	)
+	snapshot := pveSDK.SnapshotInfo{
+		Name:        snapName,
+		Description: "Test snapshot" + body.Symbols,
+		VmState:     new(false)}
+	cl, err := pveSDK.NewClient(test.ApiURL, nil, "", &tls.Config{InsecureSkipVerify: true}, "", 1000, false)
+	require.NoError(t, err)
+	ctx := context.Background()
+	require.NoError(t, cl.Login(ctx, test.UserID, test.Password, ""))
+	c := cl.New()
+	set, expected := lxc.MinimumConfig(guest, node, storage, new(false), name)
+	var currentTime time.Time
+	currentTimePtr := &currentTime
+	tests := []struct {
+		name string
+		test func(t *testing.T)
+	}{
+		{name: `Ensure guest does not exist`,
+			test: func(t *testing.T) {
+				existed, err := c.Guest.Delete(ctx, *pveSDK.NewVmRef(guest))
+				require.NoError(t, err)
+				require.False(t, existed)
+			}},
+		{name: `Create guest`,
+			test: func(t *testing.T) {
+				createLxc(t, ctx, cl, set)
+			}},
+		{name: `Create snapshot`,
+			test: func(t *testing.T) {
+				*currentTimePtr = time.Now()
+				require.NoError(t, c.Snapshot.CreateLxc(ctx, *pveSDK.NewVmRef(guest), snapshot.Name, snapshot.Description))
+			}},
+		{name: `Read snapshot`,
+			test: func(t *testing.T) {
+				raw, err := c.Snapshot.ReadLxc(ctx, *pveSDK.NewVmRef(guest), snapshot.Name)
+				require.NoError(t, err)
+				require.NotNil(t, raw)
+				config := raw.Get(pveSDK.VmRef{}, pveSDK.PowerStateRunning)
+				config.State = nil
+				expected.Description = &snapshot.Description
+				require.EqualExportedValues(t, &expected, config)
 			}},
 		{name: `Delete guest`,
 			test: func(t *testing.T) {

--- a/test/api/Snapshot/update_snapshot_test.go
+++ b/test/api/Snapshot/update_snapshot_test.go
@@ -10,19 +10,24 @@ import (
 	"github.com/Telmate/proxmox-api-go/internal/pad"
 	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"
 	"github.com/Telmate/proxmox-api-go/test"
+	"github.com/Telmate/proxmox-api-go/test/api/qemu"
 	"github.com/stretchr/testify/require"
 )
 
 func Test_Snapshot_Update(t *testing.T) {
 	t.Parallel()
-	const snapName = pveSDK.SnapshotName("snap1")
-	const guest = pveSDK.GuestID(803)
-	const node = pveSDK.NodeName(test.FirstNode)
+	const (
+		guest    = pveSDK.GuestID(803)
+		name     = pveSDK.GuestName("Test-Snapshot-Update")
+		node     = pveSDK.NodeName(test.FirstNode)
+		snapName = pveSDK.SnapshotName("snap1")
+	)
 	cl, err := pveSDK.NewClient(test.ApiURL, nil, "", &tls.Config{InsecureSkipVerify: true}, "", 1000, false)
 	require.NoError(t, err)
 	ctx := context.Background()
 	require.NoError(t, cl.Login(ctx, test.UserID, test.Password, ""))
 	c := cl.New()
+	set, _ := qemu.MinimumConfig(guest, node, name)
 	tests := []struct {
 		name string
 		test func(t *testing.T)
@@ -35,7 +40,7 @@ func Test_Snapshot_Update(t *testing.T) {
 			}},
 		{name: `Create guest`,
 			test: func(t *testing.T) {
-				guestCreate(t, ctx, c, guest, node, "Test-Snapshot-Update")
+				createQemu(t, ctx, c, set)
 			}},
 		{name: `Create snapshot`,
 			test: func(t *testing.T) {

--- a/test/api/lxc/config.go
+++ b/test/api/lxc/config.go
@@ -1,4 +1,4 @@
-package api
+package lxc
 
 import (
 	pveSDK "github.com/Telmate/proxmox-api-go/proxmox"

--- a/test/api/lxc/create_lxc_test.go
+++ b/test/api/lxc/create_lxc_test.go
@@ -1,4 +1,4 @@
-package api
+package lxc
 
 import (
 	"context"

--- a/test/api/lxc/helper.go
+++ b/test/api/lxc/helper.go
@@ -1,4 +1,4 @@
-package api
+package lxc
 
 import (
 	"context"

--- a/test/api/qemu/clone_qemu_test.go
+++ b/test/api/qemu/clone_qemu_test.go
@@ -1,4 +1,4 @@
-package api
+package qemu
 
 import (
 	"context"

--- a/test/api/qemu/config.go
+++ b/test/api/qemu/config.go
@@ -1,4 +1,4 @@
-package api
+package qemu
 
 import (
 	"strings"

--- a/test/api/qemu/create_qemu_test.go
+++ b/test/api/qemu/create_qemu_test.go
@@ -1,4 +1,4 @@
-package api
+package qemu
 
 import (
 	"context"

--- a/test/api/qemu/helper.go
+++ b/test/api/qemu/helper.go
@@ -1,4 +1,4 @@
-package api
+package qemu
 
 import (
 	"context"

--- a/test/api/qemu/update_qemu_test.go
+++ b/test/api/qemu/update_qemu_test.go
@@ -1,4 +1,4 @@
-package api
+package qemu
 
 import (
 	"context"


### PR DESCRIPTION
The description of Lxc has a trailing `\n`, this will now be removed.

During Qemu related operations we know the node and id, these properties are added to the returned raw object for later use.