### PR TITLE
feat: parse ApiToken

### DIFF
--- a/cli/cobra.go
+++ b/cli/cobra.go
@@ -86,9 +86,9 @@ func Client(ctx context.Context, apiUrl, userID, password, otp string, http_head
 	c, err = proxmox.NewClient(apiUrl, nil, http_headers, tlsConf, proxyUrl, timeout, false)
 	LogFatalError(err)
 	if userRequiresAPIToken(userID) {
-		var token proxmox.ApiTokenID
-		LogFatalError(token.Parse(userID))
-		c.SetAPIToken(token, proxmox.ApiTokenSecret(password))
+		var tokenID proxmox.ApiTokenID
+		LogFatalError(tokenID.Parse(userID))
+		c.SetAPIToken(proxmox.ApiToken{ID: tokenID, Secret: proxmox.ApiTokenSecret(password)})
 		// As test, get the version of the server
 		_, err = c.GetVersion(Context())
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -59,9 +59,9 @@ func initializeProxmoxClient(ctx context.Context, config AppConfig, insecure boo
 	}
 
 	if userRequiresAPIToken(config.User) {
-		var token proxmox.ApiTokenID
-		failError(token.Parse(config.User))
-		client.SetAPIToken(token, proxmox.ApiTokenSecret(config.Password))
+		var tokenID proxmox.ApiTokenID
+		failError(tokenID.Parse(config.User))
+		client.SetAPIToken(proxmox.ApiToken{ID: tokenID, Secret: proxmox.ApiTokenSecret(config.Password)})
 		_, err := client.GetVersion(ctx)
 		if err != nil {
 			return nil, err

--- a/proxmox/client.go
+++ b/proxmox/client.go
@@ -206,9 +206,7 @@ func (c *Client) new() ClientNewTest {
 // - `token` is just the UUID you get when initially creating the token
 //
 // See https://pve.proxmox.com/wiki/User_Management#pveum_tokens
-func (c *Client) SetAPIToken(token ApiTokenID, secret ApiTokenSecret) {
-	c.session.setAPIToken(token, secret)
-}
+func (c *Client) SetAPIToken(token ApiToken) { c.session.setAPIToken(token) }
 
 // SetTicket let's set directly ticket and csrfPreventionToken obtained in
 // a different way, for example using OIDC identity provider

--- a/proxmox/config__apiToken.go
+++ b/proxmox/config__apiToken.go
@@ -121,6 +121,27 @@ func (c *apiTokenClient) UpdateNoCheck(ctx context.Context, user UserID, token A
 	return token.update(ctx, c.api, user)
 }
 
+const ApiToken_Errors_Invalid string = "api token must be in the format user@realm!tokenname=aaaaaaaaa-bbb-cccc-dddd-ef0123456789"
+
+type ApiToken struct {
+	Secret ApiTokenSecret
+	ID     ApiTokenID
+}
+
+func (token *ApiToken) Parse(s string) error {
+	index := strings.IndexByte(s, '=')
+	if index == -1 || len(s) == index+1 {
+		return errors.New(ApiToken_Errors_Invalid)
+	}
+	if err := token.ID.Parse(s[:index]); err != nil {
+		return errors.New(ApiToken_Errors_Invalid)
+	}
+	token.Secret = ApiTokenSecret(s[index+1:])
+	return nil
+}
+
+func (token ApiToken) String() string { return token.ID.String() + "=" + token.Secret.String() }
+
 type ApiTokenConfig struct {
 	Name                ApiTokenName `json:"id"`
 	Comment             *string      `json:"comment,omitempty"` // Never nil when returned

--- a/proxmox/config__apiToken_test.go
+++ b/proxmox/config__apiToken_test.go
@@ -337,6 +337,65 @@ func Test_apiTokenClient_Update(t *testing.T) {
 	}
 }
 
+func Test_ApiToken_Parse(t *testing.T) {
+	t.Parallel()
+	err := errors.New("api token must be in the format user@realm!tokenname=aaaaaaaaa-bbb-cccc-dddd-ef0123456789")
+	tests := []struct {
+		name   string
+		input  string
+		output ApiToken
+		err    error
+	}{
+		{name: `Invalid empty`,
+			input: "",
+			err:   err},
+		{name: `Invalid missing @`,
+			input: "userrealm!tokenname=aaaaaaaaa-bbb-cccc-dddd-ef0123456789",
+			err:   err},
+		{name: `Invalid no realm`,
+			input: "user@!tokenname=aaaaaaaaa-bbb-cccc-dddd-ef0123456789",
+			err:   err},
+		{name: `Invalid missing !`,
+			input: "user@realmtokenname=aaaaaaaaa-bbb-cccc-dddd-ef0123456789",
+			err:   err},
+		{name: `Invalid missing =`,
+			input: "user@realm!tokennameaaaaaaaaa-bbb-cccc-dddd-ef0123456789",
+			err:   err},
+		{name: `Invalid no secret`,
+			input: "user@realm!tokenname",
+			err:   err},
+		{name: `Invalid no secret but =`,
+			input: "user@realm!tokenname=",
+			err:   err},
+		{name: `Valid`,
+			input: "user@realm!tokenname=aaaaaaaaa-bbb-cccc-dddd-ef0123456789",
+			output: ApiToken{
+				ID: ApiTokenID{
+					User:      UserID{Name: "user", Realm: "realm"},
+					TokenName: "tokenname"},
+				Secret: "aaaaaaaaa-bbb-cccc-dddd-ef0123456789"}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(*testing.T) {
+			var result ApiToken
+			err := result.Parse(test.input)
+			require.Equal(t, test.err, err)
+			require.Equal(t, test.output, result)
+		})
+	}
+}
+
+func Test_ApiToken_String(t *testing.T) {
+	t.Parallel()
+	require.Equal(t, "user@realm!tokenname=aaaaaaaaa-bbb-cccc-dddd-ef0123456789", ApiToken{
+		ID: ApiTokenID{
+			User: UserID{
+				Name:  "user",
+				Realm: "realm"},
+			TokenName: "tokenname"},
+		Secret: "aaaaaaaaa-bbb-cccc-dddd-ef0123456789"}.String())
+}
+
 func Test_ApiTokenConfig_mapToAPI(t *testing.T) {
 	t.Parallel()
 	type test struct {

--- a/proxmox/session.go
+++ b/proxmox/session.go
@@ -143,9 +143,7 @@ func responseJSON(resp *http.Response) (jbody map[string]interface{}, err error)
 	return jbody, err
 }
 
-func (s *Session) setAPIToken(token ApiTokenID, secret ApiTokenSecret) {
-	s.AuthToken = token.String() + "=" + secret.String()
-}
+func (s *Session) setAPIToken(token ApiToken) { s.AuthToken = token.String() }
 
 func (s *Session) setTicket(ticket, csrfPreventionToken string) {
 	s.AuthTicket = ticket

--- a/test/api/ApiToken/create_token_test.go
+++ b/test/api/ApiToken/create_token_test.go
@@ -57,7 +57,7 @@ func Test_Token_Create(t *testing.T) {
 				cl, err := pveSDK.NewClient(test.ApiURL, nil, "", &tls.Config{InsecureSkipVerify: true}, "", 1000, false)
 				require.NoError(t, err)
 				require.NotNil(t, cl)
-				cl.SetAPIToken(tokenID, *secret)
+				cl.SetAPIToken(pveSDK.ApiToken{ID: tokenID, Secret: *secret})
 				version, err := cl.Version(ctx)
 				require.NoError(t, err)
 				require.NotEmpty(t, version.String())

--- a/test/api/Authentication/apikey_authentication_test.go
+++ b/test/api/Authentication/apikey_authentication_test.go
@@ -48,7 +48,7 @@ func Test_Authenticate_ApiKey(t *testing.T) {
 				cl, err := pveSDK.NewClient(test.ApiURL, nil, "", &tls.Config{InsecureSkipVerify: true}, "", 1000, false)
 				require.NoError(t, err)
 				require.NotNil(t, cl)
-				cl.SetAPIToken(tokenID, *secret)
+				cl.SetAPIToken(pveSDK.ApiToken{ID: tokenID, Secret: *secret})
 				version, err := cl.Version(ctx)
 				require.NoError(t, err)
 				require.NotEmpty(t, version.String())


### PR DESCRIPTION
Introduces a new `ApiToken` type to parse an API token in one go. This way the consumer doesn't have to spilt `user@realm!tokenname=aaaaaaaaa-bbb-cccc-dddd-ef0123456789` into it's parts.