### PR TITLE
Invert allowRestart condition for reboot handling

### DIFF
--- a/proxmox/config__qemu.go
+++ b/proxmox/config__qemu.go
@@ -813,7 +813,7 @@ func (config ConfigQemu) updateNoCheck(
 	}
 
 	if rebootRequired {
-		if allowRestart {
+		if !allowRestart {
 			return true, errors.New(ConfigQemu_Error_UnableToUpdateWithoutReboot)
 		}
 		if err = vmr.reboot_Unsafe(ctx, c); err != nil {


### PR DESCRIPTION
If I understand this correctly, the condition should be inverted.

Otherwise, whenever a reboot is required and allowRestart is enabled, the function will always return an error instead of performing the restart.